### PR TITLE
Fix SE edition mirroring

### DIFF
--- a/internal/mirror/cmd/push/push.go
+++ b/internal/mirror/cmd/push/push.go
@@ -183,6 +183,11 @@ func PushDeckhouseToRegistry(mirrorCtx *contexts.PushContext) error {
 			return fmt.Errorf("read index manifest: %w", err)
 		}
 
+		if len(indexManifest.Manifests) == 0 {
+			log.InfoLn("Skipped repo", originalRepo, "as it contains no images")
+			continue
+		}
+
 		repo := strings.Replace(originalRepo, mirrorCtx.DeckhouseRegistryRepo, mirrorCtx.RegistryHost+mirrorCtx.RegistryPath, 1)
 		pushCount := 1
 		for _, manifest := range indexManifest.Manifests {

--- a/internal/mirror/layouts/pull.go
+++ b/internal/mirror/layouts/pull.go
@@ -125,6 +125,7 @@ func PullTrivyVulnerabilityDatabasesImages(
 			dbImageLayout,
 			map[string]struct{}{ref.String(): {}},
 			WithTagToDigestMapper(NopTagToDigestMappingFunc),
+			WithAllowMissingTags(true), // SE edition does not contain images for trivy
 		); err != nil {
 			return fmt.Errorf("pull vulnerability database: %w", err)
 		}


### PR DESCRIPTION
Fixed Standard edition mirroring by not requiring Trivy database images to exist in registry as SE has no builtin vulnerability scanner