### PR TITLE
Backup of cluster configuration

### DIFF
--- a/internal/backup/cmd/backup.go
+++ b/internal/backup/cmd/backup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	"github.com/deckhouse/deckhouse-cli/internal/backup/cmd/cluster-config"
 	"github.com/deckhouse/deckhouse-cli/internal/backup/cmd/etcd"
 )
 
@@ -35,8 +36,11 @@ func NewCommand() *cobra.Command {
 		Long:  backupLong,
 	}
 
+	addPersistentFlags(backupCmd.PersistentFlags())
+
 	backupCmd.AddCommand(
 		etcd.NewCommand(),
+		cluster_config.NewCommand(),
 	)
 
 	return backupCmd

--- a/internal/backup/cmd/cluster-config/cluster_config.go
+++ b/internal/backup/cmd/cluster-config/cluster_config.go
@@ -1,0 +1,163 @@
+package cluster_config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"runtime"
+
+	"github.com/samber/lo"
+	"github.com/samber/lo/parallel"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/configmaps"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/crds"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/roles"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/secrets"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/storageclasses"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/tarball"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/whitelist"
+	"github.com/deckhouse/deckhouse-cli/internal/backup/utilk8s"
+)
+
+var clusterConfigLong = templates.LongDesc(`
+Take a snapshot of cluster configuration.
+		
+This command creates a snapshot various kubernetes resources.
+
+© Flant JSC 2024`)
+
+func NewCommand() *cobra.Command {
+	etcdCmd := &cobra.Command{
+		Use:           "cluster-config <backup-tarball-path>",
+		Short:         "Take a snapshot of cluster configuration",
+		Long:          clusterConfigLong,
+		ValidArgs:     []string{"backup-tarball-path"},
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          backupConfigs,
+	}
+
+	return etcdCmd
+}
+
+type BackupStage struct {
+	payload BackupFunc
+	filter  tarball.BackupResourcesFilter
+}
+
+type BackupFunc func(
+	restConfig *rest.Config,
+	kubeCl kubernetes.Interface,
+	dynamicCl dynamic.Interface,
+	namespaces []string,
+) ([]k8sruntime.Object, error)
+
+func backupConfigs(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("This command requires exactly 1 argument")
+	}
+
+	restConfig, kubeCl, dynamicCl, err := setupK8sClients(cmd)
+	if err != nil {
+		return err
+	}
+	namespaces, err := getNamespacesFromCluster(kubeCl)
+	if err != nil {
+		return err
+	}
+
+	tarFile, err := os.CreateTemp(".", ".*.d8tmp")
+	if err != nil {
+		return fmt.Errorf("Failed to create temp file: %v", err)
+	}
+	defer func() {
+		os.Remove(tarFile.Name())
+	}()
+	backup := tarball.NewBackup(tarFile)
+
+	backupStages := []*BackupStage{
+		{payload: secrets.BackupSecrets, filter: &whitelist.BakedInFilter{}},
+		{payload: configmaps.BackupConfigMaps, filter: &whitelist.BakedInFilter{}},
+		{payload: crds.BackupCustomResources},
+		{payload: roles.BackupClusterRoles},
+		{payload: roles.BackupClusterRoleBindings},
+		{payload: storageclasses.BackupStorageClasses},
+	}
+
+	errs := parallel.Map(backupStages, func(stage *BackupStage, _ int) error {
+		stagePayloadFuncName := runtime.FuncForPC(reflect.ValueOf(stage.payload).Pointer()).Name()
+
+		objects, err := stage.payload(restConfig, kubeCl, dynamicCl, namespaces)
+		if err != nil {
+			return fmt.Errorf("%s failed: %v", stagePayloadFuncName, err)
+		}
+
+		for _, object := range objects {
+			if stage.filter != nil && !stage.filter.Matches(object) {
+				continue
+			}
+
+			if err = backup.PutObject(object); err != nil {
+				return fmt.Errorf("%s failed: %v", stagePayloadFuncName, err)
+			}
+		}
+
+		return nil
+	})
+	if errors.Join(errs...) != nil {
+		log.Printf("WARN: Some backup procedures failed, only successfully backed-up resources will be available:\n%v", err)
+	}
+
+	if err = backup.Close(); err != nil {
+		return fmt.Errorf("close tarball failed: %w", err)
+	}
+	if err = tarFile.Sync(); err != nil {
+		return fmt.Errorf("tarball flush failed: %w", err)
+	}
+	if err = tarFile.Close(); err != nil {
+		return fmt.Errorf("tarball close failed: %w", err)
+	}
+
+	if err = os.Rename(tarFile.Name(), args[0]); err != nil {
+		return fmt.Errorf("write tarball failed: %w", err)
+	}
+
+	return nil
+}
+
+func getNamespacesFromCluster(kubeCl *kubernetes.Clientset) ([]string, error) {
+	namespaceList, err := kubeCl.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list namespaces: %w", err)
+	}
+	namespaces := lo.Map(namespaceList.Items, func(ns corev1.Namespace, _ int) string {
+		return ns.Name
+	})
+	return namespaces, nil
+}
+
+func setupK8sClients(cmd *cobra.Command) (*rest.Config, *kubernetes.Clientset, *dynamic.DynamicClient, error) {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	dynamicCl := dynamic.New(kubeCl.RESTClient())
+	return restConfig, kubeCl, dynamicCl, nil
+}

--- a/internal/backup/cmd/etcd/flags.go
+++ b/internal/backup/cmd/etcd/flags.go
@@ -20,21 +20,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func addFlags(flagSet *pflag.FlagSet) {
-	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		defaultKubeconfigPath = p
-	}
-
-	flagSet.StringVarP(
-		&kubeconfigPath,
-		"kubeconfig", "k",
-		defaultKubeconfigPath,
-		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
-	)
 	flagSet.StringVarP(
 		&requestedEtcdPodName,
 		"etcd-pod", "p",
@@ -49,7 +39,12 @@ func addFlags(flagSet *pflag.FlagSet) {
 	)
 }
 
-func validateFlags() error {
+func validateFlags(cmd *cobra.Command) error {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
 	stats, err := os.Stat(kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("Invalid --kubeconfig: %w", err)

--- a/internal/backup/cmd/flags.go
+++ b/internal/backup/cmd/flags.go
@@ -1,0 +1,20 @@
+package backup
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+func addPersistentFlags(flagSet *pflag.FlagSet) {
+	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
+	if p := os.Getenv("KUBECONFIG"); p != "" {
+		defaultKubeconfigPath = p
+	}
+
+	flagSet.StringP(
+		"kubeconfig", "k",
+		defaultKubeconfigPath,
+		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
+	)
+}

--- a/internal/backup/configs/configmaps/backup.go
+++ b/internal/backup/configs/configmaps/backup.go
@@ -1,0 +1,47 @@
+package configmaps
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/samber/lo/parallel"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func BackupConfigMaps(
+	_ *rest.Config,
+	kubeCl kubernetes.Interface,
+	_ dynamic.Interface,
+	namespaces []string,
+) ([]runtime.Object, error) {
+	namespaces = lo.Filter(namespaces, func(item string, _ int) bool {
+		return strings.HasPrefix(item, "d8-") || strings.HasPrefix(item, "kube-")
+	})
+
+	configmaps := parallel.Map(namespaces, func(namespace string, _ int) []runtime.Object {
+		list, err := kubeCl.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			log.Fatalf("Failed to list configmaps from : %v", err)
+		}
+
+		return lo.Map(list.Items, func(item corev1.ConfigMap, _ int) runtime.Object {
+			// Some shit-for-brains kubernetes/client-go developer decided that it is fun to remove GVK from responses for no reason.
+			// Have to add it back so that meta.Accessor can do its job
+			// https://github.com/kubernetes/client-go/issues/1328
+			item.TypeMeta = metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			}
+			return &item
+		})
+	})
+
+	return lo.Flatten(configmaps), nil
+}

--- a/internal/backup/configs/crds/custom_resources.go
+++ b/internal/backup/configs/crds/custom_resources.go
@@ -1,0 +1,75 @@
+package crds
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/samber/lo"
+	"github.com/samber/lo/parallel"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const configResourcesLabelSelector = "backup.deckhouse.io/cluster-config=true"
+
+func BackupCustomResources(
+	restConfig *rest.Config,
+	_ kubernetes.Interface,
+	dynamicCl dynamic.Interface,
+	namespaces []string,
+) ([]runtime.Object, error) {
+	apiExtensionClient, err := apiext.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create api extension clientset: %w", err)
+	}
+
+	crdList, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: configResourcesLabelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list CustomResourceDefinitions: %w", err)
+	}
+
+	resourcesToBackup := lo.Compact(
+		lo.Map(crdList.Items, func(crd v1.CustomResourceDefinition, _ int) schema.GroupVersionResource {
+			if crd.Spec.Scope != v1.NamespaceScoped {
+				return schema.GroupVersionResource{}
+			}
+
+			version, validVersionFound := lo.Find(crd.Spec.Versions, func(item v1.CustomResourceDefinitionVersion) bool {
+				return item.Storage && item.Served
+			})
+			if !validVersionFound {
+				return schema.GroupVersionResource{} // Empty GVR's will be filtered out
+			}
+
+			return schema.GroupVersionResource{
+				Group:    crd.Spec.Group,
+				Version:  version.Name,
+				Resource: crd.Spec.Names.Plural,
+			}
+		}))
+
+	resources := lo.Map(resourcesToBackup, func(resource schema.GroupVersionResource, _ int) []runtime.Object {
+		return lo.Flatten(parallel.Map(namespaces, func(namespace string, _ int) []runtime.Object {
+			list, err := dynamicCl.Resource(resource).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				log.Fatalf("Failed to list %s: %v", resource, err)
+			}
+
+			return lo.Map(list.Items, func(object unstructured.Unstructured, _ int) runtime.Object {
+				return &object
+			})
+		}))
+	})
+
+	return lo.Flatten(resources), nil
+}

--- a/internal/backup/configs/roles/cluster_roles.go
+++ b/internal/backup/configs/roles/cluster_roles.go
@@ -1,0 +1,66 @@
+package roles
+
+import (
+	"context"
+	"log"
+
+	"github.com/samber/lo"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const notDeckhouseHeritage = "heritage!=deckhouse"
+
+func BackupClusterRoles(
+	_ *rest.Config,
+	kubeCl kubernetes.Interface,
+	_ dynamic.Interface,
+	_ []string,
+) ([]runtime.Object, error) {
+	list, err := kubeCl.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: notDeckhouseHeritage,
+	})
+	if err != nil {
+		log.Fatalf("Failed to list ClusterRoles from: %v", err)
+	}
+
+	return lo.Map(list.Items, func(item rbacv1.ClusterRole, _ int) runtime.Object {
+		// Some shit-for-brains kubernetes/client-go developer decided that it is fun to remove GVK from responses for no reason.
+		// Have to add it back so that meta.Accessor can do its job
+		// https://github.com/kubernetes/client-go/issues/1328
+		item.TypeMeta = metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		}
+		return &item
+	}), nil
+}
+
+func BackupClusterRoleBindings(
+	_ *rest.Config,
+	kubeCl kubernetes.Interface,
+	_ dynamic.Interface,
+	_ []string,
+) ([]runtime.Object, error) {
+	list, err := kubeCl.RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: notDeckhouseHeritage,
+	})
+	if err != nil {
+		log.Fatalf("Failed to list ClusterRoleBindings from: %v", err)
+	}
+
+	return lo.Map(list.Items, func(item rbacv1.ClusterRoleBinding, _ int) runtime.Object {
+		// Some shit-for-brains kubernetes/client-go developer decided that it is fun to remove GVK from responses for no reason.
+		// Have to add it back so that meta.Accessor can do its job
+		// https://github.com/kubernetes/client-go/issues/1328
+		item.TypeMeta = metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+		}
+		return &item
+	}), nil
+}

--- a/internal/backup/configs/secrets/backup.go
+++ b/internal/backup/configs/secrets/backup.go
@@ -1,0 +1,47 @@
+package secrets
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/samber/lo/parallel"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func BackupSecrets(
+	_ *rest.Config,
+	kubeCl kubernetes.Interface,
+	_ dynamic.Interface,
+	namespaces []string,
+) ([]runtime.Object, error) {
+	namespaces = lo.Filter(namespaces, func(item string, _ int) bool {
+		return strings.HasPrefix(item, "d8-") || strings.HasPrefix(item, "kube-")
+	})
+
+	secrets := parallel.Map(namespaces, func(namespace string, index int) []runtime.Object {
+		list, err := kubeCl.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			log.Fatalf("Failed to list secrets from : %v", err)
+		}
+
+		return lo.Map(list.Items, func(secret corev1.Secret, _ int) runtime.Object {
+			// Some shit-for-brains kubernetes/client-go developer decided that it is fun to remove GVK from responses for no reason.
+			// Have to add it back so that meta.Accessor can do its job
+			// https://github.com/kubernetes/client-go/issues/1328
+			secret.TypeMeta = metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			}
+			return &secret
+		})
+	})
+
+	return lo.Flatten(secrets), nil
+}

--- a/internal/backup/configs/storageclasses/storage_classes.go
+++ b/internal/backup/configs/storageclasses/storage_classes.go
@@ -1,0 +1,39 @@
+package storageclasses
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	v1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func BackupStorageClasses(
+	_ *rest.Config,
+	kubeCl kubernetes.Interface,
+	_ dynamic.Interface,
+	_ []string,
+) ([]runtime.Object, error) {
+	list, err := kubeCl.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "heritage=deckhouse",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list StorageClasses: %w", err)
+	}
+
+	return lo.Map(list.Items, func(item v1.StorageClass, _ int) runtime.Object {
+		// Some shit-for-brains kubernetes/client-go developer decided that it is fun to remove GVK from responses for no reason.
+		// Have to add it back so that meta.Accessor can do its job
+		// https://github.com/kubernetes/client-go/issues/1328
+		item.TypeMeta = metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: v1.SchemeGroupVersion.String(),
+		}
+		return &item
+	}), nil
+}

--- a/internal/backup/configs/tarball/backup.go
+++ b/internal/backup/configs/tarball/backup.go
@@ -1,0 +1,73 @@
+package tarball
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"path"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+)
+
+type Backup struct {
+	mu     sync.Mutex
+	writer *tar.Writer
+}
+
+type BackupResourcesFilter interface {
+	Matches(object runtime.Object) bool
+}
+
+func NewBackup(sink io.Writer) *Backup {
+	return &Backup{
+		writer: tar.NewWriter(sink),
+	}
+}
+
+func (b *Backup) PutObject(object runtime.Object) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	metadataAccessor, err := meta.Accessor(object)
+	if err != nil {
+		return fmt.Errorf("%w: %s does not contain metadata to filter with", err, object.GetObjectKind().GroupVersionKind().String())
+	}
+
+	metadataAccessor.SetManagedFields(nil)
+
+	kind := object.GetObjectKind().GroupVersionKind().Kind
+	name, namespace := metadataAccessor.GetName(), metadataAccessor.GetNamespace()
+	if namespace == "" {
+		namespace = "Cluster-Wide Resources"
+	}
+
+	rawObject, err := yaml.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("marshal %s %s/%s: %w", kind, namespace, name, err)
+	}
+
+	err = b.writer.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     path.Join(namespace, kind, name+".yml"),
+		Size:     int64(len(rawObject)),
+		Mode:     0600,
+		ModTime:  time.Now(),
+	})
+	if err != nil {
+		return fmt.Errorf("write tar header for %s %s/%s: %w", kind, namespace, name, err)
+	}
+
+	if _, err = b.writer.Write(rawObject); err != nil {
+		return fmt.Errorf("write tar content for %s %s/%s: %w", kind, namespace, name, err)
+	}
+
+	return nil
+}
+
+func (b *Backup) Close() error {
+	return b.writer.Close()
+}

--- a/internal/backup/configs/whitelist/whitelist.go
+++ b/internal/backup/configs/whitelist/whitelist.go
@@ -1,0 +1,71 @@
+package whitelist
+
+import (
+	_ "embed"
+	"log"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse-cli/internal/backup/configs/tarball"
+)
+
+// map[Namespace]map[APIVersion]map[Kind] = []Objects names
+type whitelistManifest map[string]map[string]map[string][]string
+
+//go:embed whitelist.yml
+var rawBuiltInWhitelist []byte
+
+var _ tarball.BackupResourcesFilter = &BakedInFilter{}
+
+type BakedInFilter struct {
+	whitelist whitelistManifest
+	initOnce  sync.Once
+}
+
+func (f *BakedInFilter) Matches(obj runtime.Object) bool {
+	metadataAccessor, err := meta.Accessor(obj)
+	if err != nil {
+		log.Printf("%s does not contain metadata to filter with", obj.GetObjectKind().GroupVersionKind().String())
+		return false
+	}
+	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	name, namespace := metadataAccessor.GetName(), metadataAccessor.GetNamespace()
+
+	f.initOnce.Do(func() {
+		if err := yaml.Unmarshal(rawBuiltInWhitelist, &f.whitelist); err != nil {
+			panic(err)
+		}
+	})
+
+	if !lo.HasKey(f.whitelist, namespace) ||
+		!lo.HasKey(f.whitelist[namespace], apiVersion) ||
+		!lo.HasKey(f.whitelist[namespace][apiVersion], kind) {
+		return false
+	}
+
+	_, foundInWhitelist := lo.Find(f.whitelist[namespace][apiVersion][kind], func(item string) bool {
+		if strings.HasPrefix(item, "$regexp:") {
+			_, pattern, _ := strings.Cut(item, ":")
+			return matchNameWithRegex(name, pattern)
+		}
+
+		return item == name
+	})
+
+	return foundInWhitelist
+}
+
+func matchNameWithRegex(objectName, pattern string) bool {
+	matched, err := regexp.MatchString(pattern, objectName)
+	if err != nil {
+		log.Panicln("Invalid regexp:", pattern, err)
+	}
+
+	return matched
+}

--- a/internal/backup/configs/whitelist/whitelist.yml
+++ b/internal/backup/configs/whitelist/whitelist.yml
@@ -1,0 +1,29 @@
+d8-system:
+  v1:
+    Secret:
+    - d8-cluster-terraform-state
+    - $regexp:^d8-node-terraform-state-(.*)$ # Regexp
+    - deckhouse-registry
+    ConfigMap:
+    - d8-deckhouse-version-info
+kube-system:
+  v1:
+    ConfigMap:
+    - d8-cluster-is-bootstraped
+    - d8-cluster-uuid
+    - extension-apiserver-authentication
+    Secret:
+    - d8-cloud-provider-discovery-data
+    - d8-cluster-configuration
+    - d8-cni-configuration
+    - d8-control-plane-manager-config
+    - d8-node-manager-cloud-provider
+    - d8-pki
+    - d8-provider-cluster-configuration
+    - d8-static-cluster-configuration
+    - d8-secret-encryption-key
+d8-cert-manager:
+  v1:
+    Secret:
+    - cert-manager-letsencrypt-private-key
+    - selfsigned-ca-key-pair

--- a/internal/backup/configs/whitelist/whitelist_test.go
+++ b/internal/backup/configs/whitelist/whitelist_test.go
@@ -1,0 +1,104 @@
+package whitelist
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMatches(t *testing.T) {
+	type args struct {
+		obj runtime.Object
+	}
+	tests := []struct {
+		name string
+		want bool
+		args args
+	}{
+		{
+			name: "plain unstructured resource in whitelist",
+			want: true,
+			args: args{
+				obj: &unstructured.Unstructured{Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name":      "deckhouse-registry",
+						"namespace": "d8-system",
+					},
+				}},
+			},
+		},
+		{
+			name: "Secret in whitelist",
+			want: true,
+			args: args{
+				obj: &corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deckhouse-registry",
+						Namespace: "d8-system",
+					},
+				},
+			},
+		},
+		{
+			name: "plain unstructured resource not in whitelist",
+			want: false,
+			args: args{
+				obj: &unstructured.Unstructured{Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name":      "kube-root-ca.crt",
+						"namespace": "kube-system",
+					},
+				}},
+			},
+		},
+		{
+			name: "Secret not in whitelist",
+			want: false,
+			args: args{
+				obj: &corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-root-ca.crt",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name: "matching regexp of resource in whitelist",
+			want: true,
+			args: args{
+				obj: &unstructured.Unstructured{Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata": map[string]interface{}{
+						"name":      "d8-node-terraform-state-dev-master-0",
+						"namespace": "d8-system",
+					},
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := BakedInFilter{}
+			if got := f.Matches(tt.args.obj); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backup/utilk8s/clientset.go
+++ b/internal/backup/utilk8s/clientset.go
@@ -1,0 +1,25 @@
+package utilk8s
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// SetupK8sClientSet reads kubeconfig file at kubeconfigPath and constructs a kubernetes clientset from it.
+func SetupK8sClientSet(kubeconfigPath string) (*rest.Config, *kubernetes.Clientset, error) {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}, nil).ClientConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Reading kubeconfig file: %w", err)
+	}
+
+	kubeCl, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Constructing Kubernetes clientset: %w", err)
+	}
+
+	return config, kubeCl, nil
+}


### PR DESCRIPTION
Added a `backup cluster-config` subcommand that saves a set of predefined resources and all custom resources which CRD's are labeled as `backup.deckhouse.io/cluster-config: "true"`.