### PR TITLE
Cancel context for mirror push command

### DIFF
--- a/internal/mirror/cmd/modules/pull/pull.go
+++ b/internal/mirror/cmd/modules/pull/pull.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pull
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -160,6 +161,7 @@ func pullExternalModulesToLocalFS(
 
 		pullCtx := &contexts.PullContext{
 			BaseContext: contexts.BaseContext{
+				Ctx:                 context.TODO(),
 				Logger:              logger,
 				Insecure:            insecure,
 				SkipTLSVerification: skipVerifyTLS,

--- a/internal/mirror/cmd/modules/push/push.go
+++ b/internal/mirror/cmd/modules/push/push.go
@@ -17,6 +17,7 @@ limitations under the License.
 package push
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -139,6 +140,7 @@ func pushModulesToRegistry(
 		}
 
 		if err = layouts.PushLayoutToRepo(
+			context.TODO(),
 			moduleLayout,
 			moduleRegistryPath,
 			authProvider,
@@ -152,6 +154,7 @@ func pushModulesToRegistry(
 
 		logger.InfoF("Pushing releases for module %s", moduleName)
 		if err = layouts.PushLayoutToRepo(
+			context.TODO(),
 			moduleReleasesLayout,
 			moduleReleasesRegistryPath,
 			authProvider,

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -18,6 +18,7 @@ package pull
 
 import (
 	"bufio"
+	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -122,6 +123,7 @@ func buildPullContext() *contexts.PullContext {
 
 	mirrorCtx := &contexts.PullContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                logger,
 			Insecure:              Insecure,
 			SkipTLSVerification:   TLSSkipVerify,

--- a/internal/mirror/cmd/push/push.go
+++ b/internal/mirror/cmd/push/push.go
@@ -17,6 +17,7 @@ limitations under the License.
 package push
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -146,6 +147,7 @@ func buildPushContext() *contexts.PushContext {
 
 	mirrorCtx := &contexts.PushContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                 context.TODO(),
 			Logger:              logger,
 			Insecure:            Insecure,
 			SkipTLSVerification: TLSSkipVerify,

--- a/internal/mirror/cmd/vulndb/pull/pull.go
+++ b/internal/mirror/cmd/vulndb/pull/pull.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pull
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -85,6 +86,7 @@ func pull(_ *cobra.Command, _ []string) error {
 
 	pullContext := &contexts.PullContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                logger,
 			RegistryAuth:          getSourceRegistryAuthProvider(),
 			DeckhouseRegistryRepo: SourceRegistryRepo,

--- a/internal/mirror/cmd/vulndb/push/push.go
+++ b/internal/mirror/cmd/vulndb/push/push.go
@@ -17,6 +17,7 @@ limitations under the License.
 package push
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"path"
@@ -81,6 +82,7 @@ func push(_ *cobra.Command, _ []string) error {
 
 	pushContext := &contexts.PushContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                logger,
 			RegistryAuth:          getRegistryAuthProvider(),
 			RegistryHost:          RegistryHost,
@@ -107,6 +109,7 @@ func push(_ *cobra.Command, _ []string) error {
 		}
 
 		err = layouts.PushLayoutToRepo(
+			pushContext.Ctx,
 			ociLayout,
 			repo,
 			pushContext.RegistryAuth,

--- a/pkg/libmirror/bundle/bundle_test.go
+++ b/pkg/libmirror/bundle/bundle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bundle
 
 import (
+	"context"
 	"crypto/rand"
 	"io"
 	"io/fs"
@@ -50,6 +51,7 @@ func TestBundlePackingAndUnpacking(t *testing.T) {
 
 	err = Pack(&contexts.PullContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                context.TODO(),
 			BundlePath:         tarBundlePath,
 			UnpackedImagesPath: packFromDir,
 		},
@@ -58,6 +60,7 @@ func TestBundlePackingAndUnpacking(t *testing.T) {
 	require.FileExists(t, tarBundlePath)
 
 	err = Unpack(&contexts.BaseContext{
+		Ctx:                context.TODO(),
 		BundlePath:         tarBundlePath,
 		UnpackedImagesPath: unpackToDir,
 	})
@@ -87,6 +90,7 @@ func TestChunkedBundlePackingAndUnpacking(t *testing.T) {
 
 	err = Pack(&contexts.PullContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                context.TODO(),
 			BundlePath:         bundlePath,
 			UnpackedImagesPath: packFromDir,
 		},
@@ -105,6 +109,7 @@ func TestChunkedBundlePackingAndUnpacking(t *testing.T) {
 	}
 
 	err = Unpack(&contexts.BaseContext{
+		Ctx:                context.TODO(),
 		BundlePath:         bundlePath,
 		UnpackedImagesPath: unpackToDir,
 	})

--- a/pkg/libmirror/contexts/base.go
+++ b/pkg/libmirror/contexts/base.go
@@ -17,6 +17,8 @@ limitations under the License.
 package contexts
 
 import (
+	"context"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 )
 
@@ -35,6 +37,8 @@ type Logger interface {
 
 // BaseContext hold data related to pending registry mirroring operation.
 type BaseContext struct {
+	Ctx context.Context
+
 	// --registry-login + --registry-password (can be nil in this case) or --license depending on the operation requested
 	RegistryAuth authn.Authenticator
 	RegistryHost string // --registry (FQDN with port, if one is provided)

--- a/pkg/libmirror/images/digests_test.go
+++ b/pkg/libmirror/images/digests_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package images
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -43,7 +44,7 @@ func TestExtractImageDigestsFromDeckhouseInstaller(t *testing.T) {
 
 	installersLayout := createOCILayoutWithInstallerImage(t, "localhost:5001/deckhouse", installerTag, expectedImages)
 	images, err := ExtractImageDigestsFromDeckhouseInstaller(
-		&contexts.PullContext{BaseContext: contexts.BaseContext{DeckhouseRegistryRepo: "localhost:5001/deckhouse"}},
+		&contexts.PullContext{BaseContext: contexts.BaseContext{Ctx: context.TODO(), DeckhouseRegistryRepo: "localhost:5001/deckhouse"}},
 		installerTag,
 		installersLayout,
 	)

--- a/pkg/libmirror/layouts/pull.go
+++ b/pkg/libmirror/layouts/pull.go
@@ -17,6 +17,7 @@ limitations under the License.
 package layouts
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
@@ -182,9 +183,10 @@ func PullImageSet(
 		}
 
 		err = retry.RunTask(
+			pullCtx.Ctx,
 			pullCtx.Logger,
 			fmt.Sprintf("[%d / %d] Pulling %s ", pullCount, totalCount, imageReferenceString),
-			task.WithConstantRetries(5, 10*time.Second, func() error {
+			task.WithConstantRetries(5, 10*time.Second, func(ctx context.Context) error {
 				img, err := remote.Image(ref, remoteOpts...)
 				if err != nil {
 					if errorutil.IsImageNotFoundError(err) && pullOpts.allowMissingTags {

--- a/pkg/libmirror/layouts/pull_test.go
+++ b/pkg/libmirror/layouts/pull_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package layouts
 
 import (
+	"context"
 	"log/slog"
 	"net/http/httptest"
 	"strings"
@@ -71,6 +72,7 @@ func TestPullTrivyVulnerabilityDatabaseImageSuccessSkipTLS(t *testing.T) {
 
 	err := PullTrivyVulnerabilityDatabasesImages(
 		&contexts.PullContext{BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                testLogger,
 			RegistryAuth:          authn.Anonymous,
 			DeckhouseRegistryRepo: deckhouseRepo,
@@ -126,6 +128,7 @@ func TestPullTrivyVulnerabilityDatabaseImageSuccessInsecure(t *testing.T) {
 
 	err := PullTrivyVulnerabilityDatabasesImages(
 		&contexts.PullContext{BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                testLogger,
 			RegistryAuth:          authn.Anonymous,
 			DeckhouseRegistryRepo: deckhouseRepo,

--- a/pkg/libmirror/layouts/push_test.go
+++ b/pkg/libmirror/layouts/push_test.go
@@ -1,6 +1,7 @@
 package layouts
 
 import (
+	"context"
 	"log/slog"
 	"math/rand/v2"
 	"testing"
@@ -20,6 +21,7 @@ import (
 )
 
 func TestPushLayoutToRepoWithParallelism(t *testing.T) {
+	ctx := context.TODO()
 	s := require.New(t)
 
 	const totalImages, layersPerImage = 10, 3
@@ -42,6 +44,7 @@ func TestPushLayoutToRepoWithParallelism(t *testing.T) {
 	}
 
 	err := PushLayoutToRepo(
+		ctx,
 		imagesLayout,
 		host+repoPath, // Images repo
 		authn.Anonymous,
@@ -70,6 +73,7 @@ func TestPushLayoutToRepoWithParallelism(t *testing.T) {
 }
 
 func TestPushLayoutToRepoWithoutParallelism(t *testing.T) {
+	ctx := context.TODO()
 	s := require.New(t)
 
 	const totalImages, layersPerImage = 10, 3
@@ -92,6 +96,7 @@ func TestPushLayoutToRepoWithoutParallelism(t *testing.T) {
 	}
 
 	err := PushLayoutToRepo(
+		ctx,
 		imagesLayout,
 		host+repoPath, // Images repo
 		authn.Anonymous,
@@ -120,11 +125,13 @@ func TestPushLayoutToRepoWithoutParallelism(t *testing.T) {
 }
 
 func TestPushEmptyLayoutToRepo(t *testing.T) {
+	ctx := context.TODO()
 	s := require.New(t)
 	host, repoPath, blobHandler := mirrorTestUtils.SetupEmptyRegistryRepo(false)
 
 	emptyLayout := createEmptyOCILayout(t)
 	err := PushLayoutToRepo(
+		ctx,
 		emptyLayout,
 		host+repoPath,
 		authn.Anonymous,

--- a/pkg/libmirror/operations/push.go
+++ b/pkg/libmirror/operations/push.go
@@ -29,6 +29,7 @@ func PushDeckhouseToRegistry(mirrorCtx *contexts.PushContext) error {
 	for repo, ociLayout := range ociLayouts {
 		logger.InfoLn("Mirroring", repo)
 		err = layouts.PushLayoutToRepo(
+			mirrorCtx.Ctx,
 			ociLayout, repo,
 			mirrorCtx.RegistryAuth,
 			mirrorCtx.Logger,
@@ -70,6 +71,7 @@ func pushModulesTags(mirrorCtx *contexts.BaseContext, modulesList []string) erro
 	logger := mirrorCtx.Logger
 
 	refOpts, remoteOpts := auth.MakeRemoteRegistryRequestOptionsFromMirrorContext(mirrorCtx)
+	remoteOpts = append(remoteOpts, remote.WithContext(mirrorCtx.Ctx))
 	modulesRepo := path.Join(mirrorCtx.RegistryHost, mirrorCtx.RegistryPath, "modules")
 	pushCount := 1
 	for _, moduleName := range modulesList {

--- a/pkg/libmirror/util/parallel/slice.go
+++ b/pkg/libmirror/util/parallel/slice.go
@@ -1,0 +1,25 @@
+package parallel
+
+import (
+	"golang.org/x/sync/errgroup"
+)
+
+// ForEachWithErrors iterates over elements of collection and invokes iteratee for each element in parallel.
+// If any error occurs in one of the goroutines, it returns the first encountered error.
+func ForEachWithErrors[T any](collection []T, iteratee func(item T, index int) error) error {
+	var g errgroup.Group
+
+	for i, item := range collection {
+		_item := item
+		_i := i
+
+		g.Go(func() error {
+			return iteratee(_item, _i)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/libmirror/util/parallel/slice_test.go
+++ b/pkg/libmirror/util/parallel/slice_test.go
@@ -1,0 +1,54 @@
+package parallel
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Sample error to test with
+var sampleError = errors.New("sample error")
+
+// Test cases for ForEachWithErrors function
+func TestForEachWithErrors(t *testing.T) {
+	t.Run("All Success", func(t *testing.T) {
+		collection := []int{1, 2, 3, 4}
+		err := ForEachWithErrors(collection, func(item int, index int) error {
+			// All items succeed
+			return nil
+		})
+		assert.NoError(t, err, "Expected no error, but got one")
+	})
+
+	t.Run("Single Error", func(t *testing.T) {
+		collection := []int{1, 2, 3, 4}
+		err := ForEachWithErrors(collection, func(item int, index int) error {
+			if item == 2 {
+				return sampleError // Introduce an error on item 2
+			}
+			return nil
+		})
+		assert.Error(t, err, "Expected an error, but got nil")
+		assert.Equal(t, sampleError, err, "Expected the returned error to be sampleError")
+	})
+
+	t.Run("Multiple Errors", func(t *testing.T) {
+		collection := []int{1, 2, 3, 4}
+		err := ForEachWithErrors(collection, func(item int, index int) error {
+			if item%2 == 0 {
+				return sampleError // Error on even items
+			}
+			return nil
+		})
+		assert.Error(t, err, "Expected an error, but got nil")
+	})
+
+	t.Run("Empty Collection", func(t *testing.T) {
+		collection := []int{}
+		err := ForEachWithErrors(collection, func(item int, index int) error {
+			return nil // Should not be called
+		})
+		assert.NoError(t, err, "Expected no error for empty collection, but got one")
+	})
+}

--- a/pkg/libmirror/util/retry/task/constant_interval.go
+++ b/pkg/libmirror/util/retry/task/constant_interval.go
@@ -1,14 +1,17 @@
 package task
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type ConstantRetryIntervalTask struct {
 	maxRetries   uint
 	waitInterval time.Duration
-	payload      func() error
+	payload      func(ctx context.Context) error
 }
 
-func WithConstantRetries(maxRetries uint, waitInterval time.Duration, payload func() error) *ConstantRetryIntervalTask {
+func WithConstantRetries(maxRetries uint, waitInterval time.Duration, payload func(ctx context.Context) error) *ConstantRetryIntervalTask {
 	task := &ConstantRetryIntervalTask{
 		maxRetries:   maxRetries,
 		waitInterval: waitInterval,
@@ -25,8 +28,8 @@ func WithConstantRetries(maxRetries uint, waitInterval time.Duration, payload fu
 	return task
 }
 
-func (s *ConstantRetryIntervalTask) Do(_ uint) error {
-	return s.payload()
+func (s *ConstantRetryIntervalTask) Do(ctx context.Context, _ uint) error {
+	return s.payload(ctx)
 }
 
 func (s *ConstantRetryIntervalTask) Interval(_ uint) time.Duration {

--- a/testing/e2e/mirror/mirror_e2e_test.go
+++ b/testing/e2e/mirror/mirror_e2e_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mirror
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -64,6 +65,7 @@ func TestMirrorE2E(t *testing.T) {
 	testLogger := log.NewSLogger(slog.LevelDebug)
 	pullCtx := &contexts.PullContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                testLogger,
 			Insecure:              true,
 			BundlePath:            filepath.Join(tmpDir, "d8.tar"),
@@ -73,6 +75,7 @@ func TestMirrorE2E(t *testing.T) {
 	}
 	pushCtx := &contexts.PushContext{
 		BaseContext: contexts.BaseContext{
+			Ctx:                   context.TODO(),
 			Logger:                testLogger,
 			Insecure:              true,
 			DeckhouseRegistryRepo: sourceHost + sourceRepoPath,


### PR DESCRIPTION
## Description:

We are using the push function in dhctl. This function requires the ability to be canceled via context.

Fixes:
- Added error return from the push function for uploading a single image. Removed the use of os.Exit.
- Implemented error groups for running the push command used for uploading a single image.
- Changed the behavior of the retry function. Added context propagation to the function executed via retry.
- Added context passing.