### PR TITLE
mirror: update trivy mimetypes error text for trivy-checks

### DIFF
--- a/pkg/libmirror/util/errorutil/errors.go
+++ b/pkg/libmirror/util/errorutil/errors.go
@@ -24,12 +24,12 @@ const CustomTrivyMediaTypesWarning = `` +
 	"TL;DR: You should retry push after allowing some additional types of OCI artifacts in your config.yaml as follows:\n" +
 	`FEATURE_GENERAL_OCI_SUPPORT: true
 ALLOWED_OCI_ARTIFACT_TYPES:
-  "application/vnd.aquasec.trivy.config.v1+json":
-    - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
   "application/octet-stream":
     - "application/deckhouse.io.bdu.layer.v1.tar+gzip"
-  "application/vnd.oci.empty.v1+json":
-    - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"`
+    - "application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"
+  "application/vnd.aquasec.trivy.config.v1+json":
+    - "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+    - "application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"`
 
 func IsImageNotFoundError(err error) bool {
 	if err == nil {
@@ -55,5 +55,6 @@ func IsTrivyMediaTypeNotAllowedError(err error) bool {
 	}
 
 	errMsg := err.Error()
-	return strings.Contains(errMsg, "MANIFEST_INVALID") && strings.Contains(errMsg, "vnd.aquasec.trivy")
+	return strings.Contains(errMsg, "MANIFEST_INVALID") &&
+		(strings.Contains(errMsg, "vnd.aquasec.trivy") || strings.Contains(errMsg, "application/octet-stream"))
 }


### PR DESCRIPTION
Authored by @unreturned in https://github.com/deckhouse/deckhouse-cli/pull/55

Handle error for trivy-bdu
```
Nov 14 21:27:42.714 INFO  ║ Mirroring kovalkov-quay.ru-central1.internal/user/dkp/security/trivy-bdu
Nov 14 21:27:42.715 INFO  ║ [1 / 1] Pushing image kovalkov-quay.ru-central1.internal/user/dkp/security/trivy-bdu:1
Nov 14 21:28:44.409 WARN  ║ Push image: "": task failed to many times, last error: Write kovalkov-quay.ru-central1.internal/user/dkp/security/trivy-bdu:1 to registry: PUT https://kovalkov-quay.ru-central1.internal/v2/user/dkp/security/trivy-bdu/manifests/1: MANIFEST_INVALID: manifest invalid; map[message:failed to parse manifest: manifest data does not match schema: 'application/octet-stream' is not one of ['application/vnd.oci.image.config.v1+json', 'application/vnd.sylabs.sif.config.v1+json', 'application/vnd.cncf.helm.config.v1+json']
```
and rework recommendations for Quay - more information at https://github.com/deckhouse/deckhouse/pull/10672