### PR TITLE
refactor(virtualization): lifecycle wait flag behavior

### DIFF
--- a/internal/virtualization/cmd/lifecycle/lifecycle.go
+++ b/internal/virtualization/cmd/lifecycle/lifecycle.go
@@ -184,7 +184,7 @@ func AddCommandlineArgs(flagset *pflag.FlagSet, opts *Options) {
 	flagset.BoolVarP(&opts.WaitComplete, waitFlag, waitFlagShort, opts.WaitComplete,
 		fmt.Sprintf("--%s, -%s: Set this flag to wait for the operation to complete.", waitFlag, waitFlagShort))
 	flagset.BoolVarP(&opts.CreateOnly, createOnlyFlag, createOnlyFlagShort, opts.CreateOnly,
-		fmt.Sprintf("--%s, -%s: Set this flag for create operation only.", waitFlag, waitFlagShort))
+		fmt.Sprintf("--%s, -%s: Set this flag for create operation only.", createOnlyFlag, createOnlyFlagShort))
 	flagset.DurationVarP(&opts.Timeout, timeoutFlag, timeoutFlagShort, opts.Timeout,
 		fmt.Sprintf("--%s, -%s: Set this flag to change the timeout.", timeoutFlag, timeoutFlagShort))
 }

--- a/internal/virtualization/cmd/lifecycle/vmop/vmop.go
+++ b/internal/virtualization/cmd/lifecycle/vmop/vmop.go
@@ -130,9 +130,9 @@ func (v VirtualMachineOperation) createAndWait(ctx context.Context, vmop *v1alph
 
 	if waitCompleted {
 		return v.waitUntil(ctx, vmop.GetName(), vmop.GetNamespace(), v1alpha2.VMOPPhaseCompleted)
-	} else {
-		return v.waitUntil(ctx, vmop.GetName(), vmop.GetNamespace(), v1alpha2.VMOPPhaseInProgress)
 	}
+
+	return v.waitUntil(ctx, vmop.GetName(), vmop.GetNamespace(), v1alpha2.VMOPPhaseInProgress)
 }
 
 func (v VirtualMachineOperation) create(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation) (*v1alpha2.VirtualMachineOperation, error) {

--- a/internal/virtualization/cmd/lifecycle/vmop/vmop.go
+++ b/internal/virtualization/cmd/lifecycle/vmop/vmop.go
@@ -150,6 +150,8 @@ func (v VirtualMachineOperation) generateMsg(vmop *v1alpha2.VirtualMachineOperat
 	case v1alpha2.VMOPPhaseFailed:
 		cond, _ := getCondition(vmopcondition.TypeCompleted.String(), vmop.Status.Conditions)
 		sb.WriteString(fmt.Sprintf("failed. type=%q reason=%q, message=%q.", cond.Type, cond.Reason, cond.Message))
+	case "":
+		sb.WriteString("created.")
 	default:
 		sb.WriteString(fmt.Sprintf(" phase=%q.", phase))
 	}

--- a/internal/virtualization/cmd/lifecycle/vmop/vmop.go
+++ b/internal/virtualization/cmd/lifecycle/vmop/vmop.go
@@ -33,31 +33,31 @@ type VirtualMachineOperation struct {
 	client kubeclient.Client
 }
 
-func (v VirtualMachineOperation) Stop(ctx context.Context, vmName, vmNamespace string, wait, force bool) (msg string, err error) {
+func (v VirtualMachineOperation) Stop(ctx context.Context, vmName, vmNamespace string, createOnly, waitCompleted, force bool) (msg string, err error) {
 	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeStop, force)
-	return v.do(ctx, vmop, wait)
+	return v.do(ctx, vmop, createOnly, waitCompleted)
 }
 
-func (v VirtualMachineOperation) Start(ctx context.Context, vmName, vmNamespace string, wait bool) (msg string, err error) {
+func (v VirtualMachineOperation) Start(ctx context.Context, vmName, vmNamespace string, createOnly, waitCompleted bool) (msg string, err error) {
 	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeStart, false)
-	return v.do(ctx, vmop, wait)
+	return v.do(ctx, vmop, createOnly, waitCompleted)
 }
 
-func (v VirtualMachineOperation) Restart(ctx context.Context, vmName, vmNamespace string, wait, force bool) (msg string, err error) {
+func (v VirtualMachineOperation) Restart(ctx context.Context, vmName, vmNamespace string, createOnly, waitCompleted, force bool) (msg string, err error) {
 	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeRestart, force)
-	return v.do(ctx, vmop, wait)
+	return v.do(ctx, vmop, createOnly, waitCompleted)
 }
 
-func (v VirtualMachineOperation) Evict(ctx context.Context, vmName, vmNamespace string, wait bool) (msg string, err error) {
+func (v VirtualMachineOperation) Evict(ctx context.Context, vmName, vmNamespace string, createOnly, waitCompleted bool) (msg string, err error) {
 	vmop := v.newVMOP(vmName, vmNamespace, v1alpha2.VMOPTypeEvict, false)
-	return v.do(ctx, vmop, wait)
+	return v.do(ctx, vmop, createOnly, waitCompleted)
 }
 
-func (v VirtualMachineOperation) do(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation, wait bool) (msg string, err error) {
-	if wait {
-		vmop, err = v.createAndWait(ctx, vmop)
-	} else {
+func (v VirtualMachineOperation) do(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation, createOnly, waitCompleted bool) (msg string, err error) {
+	if createOnly {
 		vmop, err = v.create(ctx, vmop)
+	} else {
+		vmop, err = v.createAndWait(ctx, vmop, waitCompleted)
 	}
 	msg = v.generateMsg(vmop)
 	return msg, err
@@ -74,7 +74,7 @@ func (v VirtualMachineOperation) generateMsg(vmop *v1alpha2.VirtualMachineOperat
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("VirtualMachine %q ", vmKey.String()))
 
-	if v.isFinished(vmop) {
+	if v.isPhaseOrFailed(vmop, v1alpha2.VMOPPhaseCompleted) {
 		if !v.isCompleted(vmop) {
 			sb.WriteString("was not ")
 		}
@@ -111,7 +111,7 @@ func (v VirtualMachineOperation) generateMsg(vmop *v1alpha2.VirtualMachineOperat
 		sb.WriteString("completed.")
 	case v1alpha2.VMOPPhaseFailed:
 		cond, _ := getCondition(vmopcondition.TypeCompleted.String(), vmop.Status.Conditions)
-		sb.WriteString(fmt.Sprintf("failed. reason=%q, message=%q.", cond.Reason, cond.Message))
+		sb.WriteString(fmt.Sprintf("failed. type=%q reason=%q, message=%q.", cond.Type, cond.Reason, cond.Message))
 	default:
 		sb.WriteString(fmt.Sprintf(" phase=%q.", phase))
 	}
@@ -119,22 +119,27 @@ func (v VirtualMachineOperation) generateMsg(vmop *v1alpha2.VirtualMachineOperat
 	return sb.String()
 }
 
-func (v VirtualMachineOperation) createAndWait(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation) (*v1alpha2.VirtualMachineOperation, error) {
+func (v VirtualMachineOperation) createAndWait(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation, waitCompleted bool) (*v1alpha2.VirtualMachineOperation, error) {
 	vmop, err := v.create(ctx, vmop)
 	if err != nil {
 		return nil, err
 	}
-	if v.isFinished(vmop) {
+	if v.isPhaseOrFailed(vmop, v1alpha2.VMOPPhaseCompleted) {
 		return vmop, nil
 	}
-	return v.wait(ctx, vmop.GetName(), vmop.GetNamespace())
+
+	if waitCompleted {
+		return v.waitUntil(ctx, vmop.GetName(), vmop.GetNamespace(), v1alpha2.VMOPPhaseCompleted)
+	} else {
+		return v.waitUntil(ctx, vmop.GetName(), vmop.GetNamespace(), v1alpha2.VMOPPhaseInProgress)
+	}
 }
 
 func (v VirtualMachineOperation) create(ctx context.Context, vmop *v1alpha2.VirtualMachineOperation) (*v1alpha2.VirtualMachineOperation, error) {
 	return v.client.VirtualMachineOperations(vmop.GetNamespace()).Create(ctx, vmop, metav1.CreateOptions{})
 }
 
-func (v VirtualMachineOperation) wait(ctx context.Context, name, namespace string) (*v1alpha2.VirtualMachineOperation, error) {
+func (v VirtualMachineOperation) waitUntil(ctx context.Context, name, namespace string, phase v1alpha2.VMOPPhase) (*v1alpha2.VirtualMachineOperation, error) {
 	var vmop *v1alpha2.VirtualMachineOperation
 	selector, err := fields.ParseSelector(fmt.Sprintf("metadata.name=%s", name))
 	if err != nil {
@@ -150,12 +155,12 @@ func (v VirtualMachineOperation) wait(ctx context.Context, name, namespace strin
 		if !ok {
 			continue
 		}
-		if v.isFinished(op) {
+		if v.isPhaseOrFailed(op, phase) {
 			vmop = op
 			break
 		}
 	}
-	if !v.isFinished(vmop) {
+	if !v.isPhaseOrFailed(vmop, phase) {
 		return nil, context.DeadlineExceeded
 	}
 	return vmop, nil
@@ -168,11 +173,11 @@ func (v VirtualMachineOperation) isCompleted(vmop *v1alpha2.VirtualMachineOperat
 	return vmop.Status.Phase == v1alpha2.VMOPPhaseCompleted
 }
 
-func (v VirtualMachineOperation) isFinished(vmop *v1alpha2.VirtualMachineOperation) bool {
+func (v VirtualMachineOperation) isPhaseOrFailed(vmop *v1alpha2.VirtualMachineOperation, phase v1alpha2.VMOPPhase) bool {
 	if vmop == nil {
 		return false
 	}
-	return vmop.Status.Phase == v1alpha2.VMOPPhaseCompleted || vmop.Status.Phase == v1alpha2.VMOPPhaseFailed
+	return vmop.Status.Phase == phase || vmop.Status.Phase == v1alpha2.VMOPPhaseFailed
 }
 
 func (v VirtualMachineOperation) newVMOP(vmName, vmNamespace string, t v1alpha2.VMOPType, force bool) *v1alpha2.VirtualMachineOperation {


### PR DESCRIPTION
- [x] Running without -w flag is only creating vmop and instant exit, it is not convenient and informative for user, the message is always phase=“”.
I would like -w to wait for the whole operation to finish, i.e. stop/start/restart.
And if a command is started without a flag, it should wait for the Failed or InProgress phase and exit with that.
For some special cases when you need to create a vmop and exit immediately, you can make a special flag, for example, --create-only.
- [x] For failed operation need to correct the reason and message - maybe condition was renamed and you forgot to correct it here.
