### PR TITLE
feat: Avoid Cgo build for linux/arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,6 @@ jobs:
         with:
           fetch-depth: 0 # To use `git describe --tags`
 
-      - name: Install dependency for linix-amd64 dist
-        run: sudo apt-get install -y apt-utils libbtrfs-dev file
-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -58,9 +55,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # To use `git describe --tags`
-
-      - name: Install dependency for linix-amd64 dist
-        run: sudo apt-get install -y apt-utils libbtrfs-dev file
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -87,7 +87,7 @@ tasks:
   _test:go:
     internal: true
     cmds:
-      - go test -tags="{{ .cgoTags }}" ./...
+      - CGO_ENABLED=0 go test -tags="{{ .goTags }}" ./...
 
   build:
     desc: Build d8 binary for personal usage
@@ -100,10 +100,19 @@ tasks:
   build:dev:linux:amd64:
     desc: Build d8 dev binary for linux/amd64
     cmds:
-      - task: _build:cgo:dev
+      - task: _build:go:dev
         vars:
           targetOS: "linux"
           targetArch: "amd64"
+          outputDir: "{{ .outputDir }}"
+
+  build:dev:linux:arm64:
+    desc: Build d8 dev binary for linux/arm64
+    cmds:
+      - task: _build:go:dev
+        vars:
+          targetOS: "linux"
+          targetArch: "arm64"
           outputDir: "{{ .outputDir }}"
 
   build:dev:darwin:amd64:
@@ -137,6 +146,7 @@ tasks:
     desc: Build all d8 release binaries in parallel
     deps:
       - build:dist:linux:amd64
+      - build:dist:linux:arm64
       - build:dist:darwin:amd64
       - build:dist:darwin:arm64
       - build:dist:windows:amd64
@@ -144,10 +154,19 @@ tasks:
   build:dist:linux:amd64:
     desc: Build d8 release binary for linux/amd64
     cmds:
-      - task: _build:cgo:dist
+      - task: _build:go:dist
         vars:
           targetOS: "linux"
           targetArch: "amd64"
+          outputDir: "{{ .outputDir }}"
+
+  build:dist:linux:arm64:
+    desc: Build d8 release binary for linux/arm64
+    cmds:
+      - task: _build:go:dist
+        vars:
+          targetOS: "linux"
+          targetArch: "arm64"
           outputDir: "{{ .outputDir }}"
 
   build:dist:darwin:amd64:
@@ -187,6 +206,7 @@ tasks:
     desc: Package all release assets in parallel
     deps:
       - package:dist:linux:amd64
+      - package:dist:linux:arm64
       - package:dist:darwin:amd64
       - package:dist:darwin:arm64
       - package:dist:windows:amd64


### PR DESCRIPTION
Made all build Cgo-less, added a build for `linux/arm64` target