### PR TITLE
mirror: Fix vulnerability database mirroring over HTTP

### DIFF
--- a/internal/mirror/cmd/modules/modules.go
+++ b/internal/mirror/cmd/modules/modules.go
@@ -18,7 +18,6 @@ package modules
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/modules/pull"
@@ -52,6 +51,5 @@ func NewCommand() *cobra.Command {
 		push.NewCommand(),
 	)
 
-	logs.AddFlags(mirrorModulesCmd.PersistentFlags())
 	return mirrorModulesCmd
 }

--- a/internal/mirror/cmd/modules/pull/pull.go
+++ b/internal/mirror/cmd/modules/pull/pull.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 	"sigs.k8s.io/yaml"
 
@@ -63,8 +62,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(mirrorModulesCmd.Flags())
-	logs.AddFlags(mirrorModulesCmd.Flags())
-	logs.AddFlags(mirrorModulesCmd.PersistentFlags())
 	return mirrorModulesCmd
 }
 

--- a/internal/mirror/cmd/modules/push/push.go
+++ b/internal/mirror/cmd/modules/push/push.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/contexts"
@@ -64,7 +63,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(mirrorModulesCmd.PersistentFlags())
-	logs.AddFlags(mirrorModulesCmd.PersistentFlags())
 	return mirrorModulesCmd
 }
 

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/gostsums"
@@ -85,7 +84,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(pullCmd.Flags())
-	logs.AddFlags(pullCmd.Flags())
 	return pullCmd
 }
 

--- a/internal/mirror/cmd/push/push.go
+++ b/internal/mirror/cmd/push/push.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
@@ -65,7 +64,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(pushCmd.Flags())
-	logs.AddFlags(pushCmd.Flags())
 	return pushCmd
 }
 

--- a/internal/mirror/cmd/vulndb/pull/pull.go
+++ b/internal/mirror/cmd/vulndb/pull/pull.go
@@ -88,6 +88,8 @@ func pull(_ *cobra.Command, _ []string) error {
 			Logger:                logger,
 			RegistryAuth:          getSourceRegistryAuthProvider(),
 			DeckhouseRegistryRepo: SourceRegistryRepo,
+			Insecure:              Insecure,
+			SkipTLSVerification:   TLSSkipVerify,
 		},
 	}
 

--- a/internal/mirror/cmd/vulndb/pull/pull.go
+++ b/internal/mirror/cmd/vulndb/pull/pull.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/contexts"
@@ -60,7 +59,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(pullCmd.Flags())
-	logs.AddFlags(pullCmd.Flags())
 	return pullCmd
 }
 

--- a/internal/mirror/cmd/vulndb/push/push.go
+++ b/internal/mirror/cmd/vulndb/push/push.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/contexts"
@@ -55,7 +54,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(pushCmd.Flags())
-	logs.AddFlags(pushCmd.Flags())
 	return pushCmd
 }
 

--- a/internal/mirror/cmd/vulndb/push/push.go
+++ b/internal/mirror/cmd/vulndb/push/push.go
@@ -86,6 +86,8 @@ func push(_ *cobra.Command, _ []string) error {
 			RegistryHost:          RegistryHost,
 			RegistryPath:          RegistryPath,
 			DeckhouseRegistryRepo: RegistryRepo,
+			Insecure:              Insecure,
+			SkipTLSVerification:   TLSSkipVerify,
 		},
 	}
 

--- a/internal/mirror/cmd/vulndb/vulndb.go
+++ b/internal/mirror/cmd/vulndb/vulndb.go
@@ -18,7 +18,6 @@ package vulndb
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/vulndb/pull"
@@ -47,6 +46,5 @@ func NewCommand() *cobra.Command {
 		push.NewCommand(),
 	)
 
-	logs.AddFlags(trivyDBCmd.PersistentFlags())
 	return trivyDBCmd
 }


### PR DESCRIPTION
Fixed `--insecure` and `--tls-skip-verify` flags ignored during vunerability database mirroring. Also cleaned up mirror flags in general by removing some kubectl flags that were added by mistake.