### PR TITLE
fix: add bin directory to install path

### DIFF
--- a/d8-install.sh
+++ b/d8-install.sh
@@ -98,13 +98,13 @@ installBinary() {
   set +e
   local output
   local rc
-  output=$(install "$D8_TMP/$OS-$ARCH/d8" "$INSTALL_DIR" 2>&1)
+  output=$(install "$D8_TMP/$OS-$ARCH/bin/d8" "$INSTALL_DIR" 2>&1)
   rc=$?
   if [ "$rc" -ne 0 ]; then
     if grep -q "Permission denied" <<< "$output"; then
       echo "Got Permission denied error. Trying with sudo (you may need to enter sudo password)"
       set -e
-      sudo install "$D8_TMP/$OS-$ARCH/d8" "$INSTALL_DIR"
+      sudo install "$D8_TMP/$OS-$ARCH/bin/d8" "$INSTALL_DIR"
     else
       echo "Unexpected error during install: $output"
       set -e


### PR DESCRIPTION
Right now, running `d8-install.sh` fails with the error `Unexpected error during install: install: cannot stat '/tmp/d8-installer-XXXXX/linux-amd64/d8': No such file or directory`. 
Since #68, the build is stored in /bin/ directory, and this change is reflected in Taskfile, but not in `d8-install.sh`.
