### PR TITLE
[d8] Add --release mirror from dev registry

### DIFF
--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
@@ -85,6 +86,11 @@ func parseAndValidateVersionFlags() error {
 	if specificReleaseString != "" {
 		SpecificRelease, err = semver.NewVersion(specificReleaseString)
 		if err != nil {
+			if strings.HasPrefix(specificReleaseString, "pr") {
+				prTag := fmt.Sprintf("0.0.0-%s", specificReleaseString)
+				SpecificRelease, err = semver.NewVersion(prTag)
+				return nil
+			}
 			return fmt.Errorf("Parse required deckhouse version: %w", err)
 		}
 	}

--- a/pkg/libmirror/layouts/layouts.go
+++ b/pkg/libmirror/layouts/layouts.go
@@ -194,7 +194,9 @@ type ociLayout struct {
 func FillLayoutsWithBasicDeckhouseImages(
 	mirrorCtx *contexts.PullContext,
 	layouts *ImageLayouts,
+	//deckhouseVersions []semver.Version,
 	deckhouseVersions []semver.Version,
+
 ) {
 	layouts.DeckhouseImages = map[string]struct{}{}
 	layouts.InstallImages = map[string]struct{}{}
@@ -207,11 +209,21 @@ func FillLayoutsWithBasicDeckhouseImages(
 		mirrorCtx.DeckhouseRegistryRepo + "/security/trivy-checks:0":  {},
 	}
 
-	for _, version := range deckhouseVersions {
-		layouts.DeckhouseImages[fmt.Sprintf("%s:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
-		layouts.InstallImages[fmt.Sprintf("%s/install:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
-		layouts.InstallStandaloneImages[fmt.Sprintf("%s/install-standalone:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
-		layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+	if mirrorCtx.SpecificVersion.Prerelease() != "" {
+		for _, version := range deckhouseVersions {
+			layouts.DeckhouseImages[fmt.Sprintf("%s:%s", mirrorCtx.DeckhouseRegistryRepo, version.Prerelease())] = struct{}{}
+			layouts.InstallImages[fmt.Sprintf("%s/install:%s", mirrorCtx.DeckhouseRegistryRepo, version.Prerelease())] = struct{}{}
+			layouts.InstallStandaloneImages[fmt.Sprintf("%s/install-standalone:%s", mirrorCtx.DeckhouseRegistryRepo, version.Prerelease())] = struct{}{}
+			layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:%s", mirrorCtx.DeckhouseRegistryRepo, version.Prerelease())] = struct{}{}
+		}
+
+	} else {
+		for _, version := range deckhouseVersions {
+			layouts.DeckhouseImages[fmt.Sprintf("%s:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+			layouts.InstallImages[fmt.Sprintf("%s/install:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+			layouts.InstallStandaloneImages[fmt.Sprintf("%s/install-standalone:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+			layouts.ReleaseChannelImages[fmt.Sprintf("%s/release-channel:v%s", mirrorCtx.DeckhouseRegistryRepo, version.String())] = struct{}{}
+		}
 	}
 
 	// If we are to pull only the specific requested version, we should not pull any release channels at all.


### PR DESCRIPTION
This pr allow mirror dev registry by pass --release option.
e.g
```
d8 mirror pull --source='dev-registry.deckhouse.io/sys/deckhouse-oss' --release='pr11838' --license='#comment' ./d8-dev.tar
INFO  ╔ Looking for required Deckhouse releases
INFO  ║ Skipped releases lookup as release pr11838 is specifically requested with --release
INFO  ╚ Looking for required Deckhouse releases succeeded in 110.404µs
INFO  ╔ Pull images
INFO  ║ Fetching Deckhouse external modules list
INFO  ║ Creating OCI Image Layouts
INFO  ║ Created OCI Image Layouts
INFO  ║ Beginning to pull installers
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/install:pr11838
INFO  ║ All required installers are pulled!
INFO  ║ Beginning to pull standalone installers
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/install-standalone:pr11838
INFO  ║ ✅ All required standalone installers are pulled!
INFO  ║ Searching for Deckhouse built-in modules digests
INFO  ║ Found 348 images
INFO  ║ Beginning to pull Deckhouse release channels information
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/release-channel:pr11838
WARN  ║ ⚠️ Not found in registry, skipping pull
INFO  ║ Deckhouse release channels are pulled!
INFO  ║ Beginning to pull Deckhouse, this may take a while
INFO  ║ [1 / 348] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss@sha256:4a0c59c43303fdbe1a1ca270e09d8fd7ff7acaa26c1b7c2e07104944ea85b4d1
...
INFO  ║ All required Deckhouse images are pulled!
INFO  ║ Pulling Trivy vulnerability databases
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/security/trivy-db:2
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/security/trivy-bdu:1
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/security/trivy-java-db:1
INFO  ║ [1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/security/trivy-checks:0
INFO  ║ Trivy vulnerability databases pulled
INFO  ║ Searching for Deckhouse external modules images
INFO  ║ Beginning to pull Deckhouse modules
INFO  ║ [1 / 5] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/modules/console/release:early-access
WARN  ║ ⚠️ Not found in registry, skipping pull
...
INFO  ║ Deckhouse modules pulled!
INFO  ║ Processing image indexes
INFO  ╚ Pull images succeeded in 59m13.594315701s
INFO  ╔ Pack images
INFO  ╚ Pack images succeeded in 50.4475456s
```
