### PR TITLE
mirror: Ignore empty release-channels layout

### DIFF
--- a/pkg/libmirror/bundle/validation.go
+++ b/pkg/libmirror/bundle/validation.go
@@ -27,7 +27,6 @@ func MandatoryLayoutsForPlatform(platformPkgDir string) map[string]string {
 	return map[string]string{
 		"root layout":             platformPkgDir,
 		"installers layout":       filepath.Join(platformPkgDir, "install"),
-		"release channels layout": filepath.Join(platformPkgDir, "release-channel"),
 	}
 }
 


### PR DESCRIPTION
Skip existence validation for platform release channels as they may not be in the platform package