### PR TITLE
[d8] Add d8 backup loki option

### DIFF
--- a/internal/backup/cmd/backup.go
+++ b/internal/backup/cmd/backup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backup
 
 import (
+	"github.com/deckhouse/deckhouse-cli/internal/backup/cmd/loki"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -41,6 +42,7 @@ func NewCommand() *cobra.Command {
 	backupCmd.AddCommand(
 		etcd.NewCommand(),
 		cluster_config.NewCommand(),
+		loki.NewCommand(),
 	)
 
 	return backupCmd

--- a/internal/backup/cmd/loki/flags.go
+++ b/internal/backup/cmd/loki/flags.go
@@ -46,8 +46,8 @@ func addFlags(flagSet *pflag.FlagSet) {
 	flagSet.IntVar(
 		&chunkDaysFlag,
 		"days",
-		30,
-		"Limit maximum number of days in range to output per queue from Loki. (Default 30 max limit days range per queue.)",
+		5,
+		"Limit maximum number of days in range to output per queue from Loki. (Default 5 maximum number of days in range per queue.)",
 	)
 }
 

--- a/internal/backup/cmd/loki/flags.go
+++ b/internal/backup/cmd/loki/flags.go
@@ -40,14 +40,14 @@ func addFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(
 		&limitFlag,
 		"limit",
-		"",
-		"Limit max string to output per queue from Loki. (Default 100000 max limit strings per queue.)",
+		"5000",
+		"Limit the number of lines to output per queue from Loki. (Default 5000 max limit strings per queue.)",
 	)
 	flagSet.IntVar(
 		&chunkDaysFlag,
 		"days",
 		30,
-		"Limit max days range to output per queue from Loki. (Default 30 max limit days range per queue.)",
+		"Limit maximum number of days in range to output per queue from Loki. (Default 30 max limit days range per queue.)",
 	)
 }
 

--- a/internal/backup/cmd/loki/flags.go
+++ b/internal/backup/cmd/loki/flags.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loki
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func addFlags(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&endTimestamp,
+		"end",
+		"",
+		"Set end timestamp range to dump logs from Loki. (Default get max end timestamp from Loki, ex. \"2025-01-14 15:04:05\".)",
+	)
+	flagSet.StringVar(
+		&startTimestamp,
+		"start",
+		"",
+		"Set start timestamp range to dump logs from Loki. (Default get max start timestamp from Loki, ex. \"2025-01-12 15:04:05\".)",
+	)
+	flagSet.StringVar(
+		&limitFlag,
+		"limit",
+		"",
+		"Limit max string to output per queue from Loki. (Default 100000 max limit strings per queue.)",
+	)
+}
+
+func validateFlags(cmd *cobra.Command) error {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	stats, err := os.Stat(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("Invalid --kubeconfig: %w", err)
+	}
+	if !stats.Mode().IsRegular() {
+		return fmt.Errorf("Invalid --kubeconfig: %s is not a regular file", kubeconfigPath)
+	}
+
+	return nil
+}

--- a/internal/backup/cmd/loki/flags.go
+++ b/internal/backup/cmd/loki/flags.go
@@ -43,6 +43,12 @@ func addFlags(flagSet *pflag.FlagSet) {
 		"",
 		"Limit max string to output per queue from Loki. (Default 100000 max limit strings per queue.)",
 	)
+	flagSet.IntVar(
+		&chunkDaysFlag,
+		"days",
+		30,
+		"Limit max days range to output per queue from Loki. (Default 30 max limit days range per queue.)",
+	)
 }
 
 func validateFlags(cmd *cobra.Command) error {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -158,7 +158,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 
 	chunkEnd = endDumpTimestamp
 	for chunkEnd > chunkStart {
-		limit := "100000"
+		limit := "5000"
 		if limitFlag != "" {
 			limit = limitFlag
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -281,7 +281,9 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 
 		if t == fmt.Sprintf("%s/series", lokiURL) {
 			var series SeriesApi
-			fmt.Println("Raw JSON response:", stdout.String())
+			if !json.Valid(stdout.Bytes()) {
+				return nil, nil, fmt.Errorf("Error response from loki api: %s", stdout.String())
+			}
 			err = json.Unmarshal(stdout.Bytes(), &series)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Failed unmarshal SeriesApi: %s", err)
@@ -290,6 +292,9 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		} else if t == fmt.Sprintf("%s/query_range", lokiURL) {
 			var queryRange QueryRange
 			fmt.Println("Raw JSON response:", stdout.String())
+			if !json.Valid(stdout.Bytes()) {
+				return nil, nil, fmt.Errorf("Error response from loki api: %s", stdout.String())
+			}
 			err = json.Unmarshal(stdout.Bytes(), &queryRange)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Failed unmarshal LokiResponse: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -140,7 +140,6 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 			break
 		}
 		for _, r := range streamListDumpJson.Data {
-			//fmt.Printf("stream is: %s", streamListDumpJson.Data)
 			err := fetchLogs(chunkStart, chunkEnd, endDumpTimestamp, token, r, config, kubeCl)
 			if err != nil {
 				return fmt.Errorf("Error get logs from Loki: %s", err)
@@ -153,9 +152,6 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map[string]string, config *rest.Config, kubeCl kubernetes.Interface) error {
 	var filters []string
 	for key, value := range r {
-
-		//fmt.Printf("\nstream is %s=%s", key, value)
-
 		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
 	}
 	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))
@@ -166,10 +162,6 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		if limitFlag != "" {
 			limit = limitFlag
 		}
-
-		//chunkStartUtc := time.Unix(0, chunkStart).UTC()
-		//chunkEndUtc := time.Unix(0, chunkEnd).UTC()
-		//fmt.Printf("\nchunkStart is %v, chunkEnd is %v", chunkStartUtc, chunkEndUtc)
 
 		curlParamDumpLog := CurlRequest{
 			BaseURL: "query_range",
@@ -207,10 +199,6 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
-		//firstTimestampUtc := time.Unix(0, firstTimestamp).UTC()
-
-		//fmt.Printf("\nend timestamp is %v", firstTimestampUtc)
-
 		chunkEnd = firstTimestamp
 
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -287,7 +287,8 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 			AuthToken: token,
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
-		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
+		//endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
+		endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
 		if err != nil {
 			return 0, fmt.Errorf("error get latest timestamp JSON from loki: %w", err)
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -385,7 +385,7 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		if err == nil && SeriesApiDump == nil {
 			return QueryRangeDump, nil, nil
 		}
-		fmt.Printf("\n%v\n", err)
+		fmt.Printf("%v\n", err)
 		time.Sleep(45 * time.Second)
 	}
 	if err != nil {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -159,6 +159,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
 	}
 	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))
+
 	chunkEnd = endDumpTimestamp
 	for chunkEnd > chunkStart {
 		limit := "100000"
@@ -191,7 +192,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			break
 		}
 
-		var logs []string
+		//var logs []string
 		for _, d := range DumpLogCurlJson.Data.Result {
 			for _, entry := range d.Values {
 				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
@@ -199,9 +200,10 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 					return fmt.Errorf("Error converting timestamp: %s", err)
 				}
 				timestampUtc := time.Unix(0, timestampInt64).UTC()
-				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
+				//logs = append(logs, fmt.Sprintf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
 				//logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampInt64, entry[1]))
-				fmt.Printf("%s", logs)
+				//fmt.Printf("%s", logs)
+				fmt.Printf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1])
 			}
 		}
 		//firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -388,9 +388,9 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		fmt.Printf("%v\n", err)
 		time.Sleep(1 * time.Second)
 	}
-	if err != nil {
-		return nil, nil, fmt.Errorf("Error get JSON response from Loki: %s", err)
-	}
+	//if err != nil {
+	//	return nil, nil, fmt.Errorf("Error get JSON response from Loki: %s", err)
+	//}
 
-	return nil, nil, err
+	return nil, nil, fmt.Errorf("error get JSON response from Loki: %s", err)
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -140,7 +140,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 			break
 		}
 		for _, r := range streamListDumpJson.Data {
-			fmt.Printf("stream is: %s", streamListDumpJson.Data)
+			//fmt.Printf("stream is: %s", streamListDumpJson.Data)
 			err := fetchLogs(chunkStart, chunkEnd, endDumpTimestamp, token, r, config, kubeCl)
 			if err != nil {
 				return fmt.Errorf("Error get logs from Loki: %s", err)
@@ -153,6 +153,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map[string]string, config *rest.Config, kubeCl kubernetes.Interface) error {
 	var filters []string
 	for key, value := range r {
+		fmt.Printf("stream is %s=%s", key, value)
 		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
 	}
 	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -195,7 +195,8 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		}
 		//get latest timestamp from latest index array from Loki api response to use pagination and get all log strings from stream
 		//lastLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
-		lastLog := DumpLogCurlJson.Data.Result[0].Values[0][0]
+		//lastLog := DumpLogCurlJson.Data.Result[0].Values[0][0]
+		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		lastTimestamp, err := strconv.ParseInt(lastLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -388,6 +388,9 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		fmt.Printf("\n%v\n", err)
 		time.Sleep(45 * time.Second)
 	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error get JSON response from Loki: %s", err)
+	}
 
 	return nil, nil, err
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -388,9 +388,10 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		fmt.Printf("%v\n", err)
 		time.Sleep(1 * time.Second)
 	}
-	//if err != nil {
-	//	return nil, nil, fmt.Errorf("Error get JSON response from Loki: %s", err)
-	//}
 
-	return nil, nil, fmt.Errorf("error get JSON response from Loki: %s", err)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error get JSON response from Loki: %v", err)
+	}
+
+	return nil, nil, fmt.Errorf("error get JSON response from Loki: %v", err)
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -191,8 +191,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 				if err != nil {
 					return fmt.Errorf("Error converting timestamp: %s", err)
 				}
-				timestampUtc := time.Unix(0, timestampInt64).UTC()
-				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
+				//timestampUtc := time.Unix(0, timestampInt64).UTC()
+				//logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
+				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampInt64, entry[1]))
 				fmt.Printf("%s", logs)
 			}
 		}
@@ -201,7 +202,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
+		fmt.Printf("end timestamp is %v", firstTimestamp)
 		chunkEnd = firstTimestamp
+
 	}
 	return nil
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -382,7 +382,7 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			return QueryRangeDump, nil, nil
 		}
 		fmt.Printf("error get JSON response from Loki: %v\n", err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(45 * time.Second)
 	}
 	return nil, nil, fmt.Errorf("error get JSON response from Loki")
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loki
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/deckhouse/deckhouse-cli/internal/platform/flags"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	//"github.com/deckhouse/deckhouse-cli/internal/platform/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var lokiLong = templates.LongDesc(`
+Dump Loki logs.
+		
+This command dump all logs from Loki api or in given range timestamps in DKP.
+
+© Flant JSC 2025`)
+
+func NewCommand() *cobra.Command {
+	lokiCmd := &cobra.Command{
+		Use:           "loki",
+		Short:         "Dump logs from Loki api.",
+		Long:          lokiLong,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PreRunE:       flags.ValidateParameters,
+		RunE:          backupLoki,
+	}
+	addFlags(lokiCmd.Flags())
+	return lokiCmd
+}
+
+const (
+	lokiURL            = "https://loki.d8-monitoring.svc.cluster.local:3100/loki/api/v1"
+	labelSelector      = "leader=true"
+	namespaceDeckhouse = "d8-system"
+	containerName      = "deckhouse"
+	namespaceLoki      = "d8-monitoring"
+	secretNameLoki     = "loki-api-token"
+	templateDate       = "2006-01-02 15:04:05"
+
+	chunkSize = int64(30 * 24 * 60 * 60 * 1e9) //30 days in nanosec timestamp
+)
+
+var (
+	endTimestamp   string
+	startTimestamp string
+	limitFlag      string
+)
+
+type QueryRange struct {
+	Data struct {
+		Result []struct {
+			Values [][]string `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+type SeriesApi struct {
+	Data []map[string]string `json:"data"`
+}
+
+type CurlRequest struct {
+	BaseURL   string
+	Params    map[string]string
+	AuthToken string
+}
+
+func backupLoki(cmd *cobra.Command, _ []string) error {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	token, err := getTokenLokiSa(kubeCl)
+	if err != nil {
+		return fmt.Errorf("Error get token from secret for Loki api: %s", err)
+	}
+
+	endDumpTimestamp, err := getEndTimestamp(config, kubeCl, token)
+	if err != nil {
+		return fmt.Errorf("Error get end timestamp for Loki: %s", err)
+	}
+	for chunkEnd := endDumpTimestamp; chunkEnd > 0; chunkEnd -= chunkSize {
+		chunkStart := chunkEnd - chunkSize
+		if startTimestamp != "" {
+			chunkStart, err = getStartTimestamp()
+		}
+		curlParamStreamList := CurlRequest{
+			BaseURL: "series",
+			Params: map[string]string{
+				"end":   strconv.FormatInt(chunkEnd, 10),
+				"start": strconv.FormatInt(chunkStart, 10),
+			},
+			AuthToken: token,
+		}
+		streamListDumpCurl := curlParamStreamList.GenerateCurlCommand()
+		_, streamListDumpJson, err := getLogTimestamp(config, kubeCl, streamListDumpCurl)
+		if err != nil {
+			return fmt.Errorf("Error get stream list JSON from Loki: %s", err)
+		}
+		if len(streamListDumpJson.Data) == 0 {
+			fmt.Printf("No more streams.\nStop...")
+			break
+		}
+		for _, r := range streamListDumpJson.Data {
+			err := fetchLogs(chunkStart, chunkEnd, endDumpTimestamp, token, r, config, kubeCl)
+			if err != nil {
+				return fmt.Errorf("Error get logs from Loki: %s", err)
+			}
+		}
+	}
+	return err
+}
+
+func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map[string]string, config *rest.Config, kubeCl kubernetes.Interface) error {
+	var filters []string
+	for key, value := range r {
+		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
+	}
+	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))
+	chunkEnd = endDumpTimestamp
+	for chunkEnd > chunkStart {
+		limit := "100000"
+		if limitFlag != "" {
+			limit = limitFlag
+		}
+		curlParamDumpLog := CurlRequest{
+			BaseURL: "query_range",
+			Params: map[string]string{
+				"end":       strconv.FormatInt(chunkEnd, 10),
+				"start":     strconv.FormatInt(chunkStart, 10),
+				"query":     q,
+				"limit":     limit,
+				"direction": "BACKWARD",
+			},
+			AuthToken: token,
+		}
+		DumpLogCurl := curlParamDumpLog.GenerateCurlCommand()
+		DumpLogCurlJson, _, err := getLogTimestamp(config, kubeCl, DumpLogCurl)
+		if err != nil {
+			//errChan <- fmt.Errorf("Error get JSON from Loki: %s", err)
+			return fmt.Errorf("Error get JSON from Loki: %s", err)
+		}
+		if len(DumpLogCurlJson.Data.Result) == 0 {
+			break
+		}
+
+		var logs []string
+		for _, r := range DumpLogCurlJson.Data.Result {
+			for _, entry := range r.Values {
+				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("Error converting timestamp:", err)
+				}
+				timestampUtc := time.Unix(0, timestampInt64).UTC()
+				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
+				fmt.Printf("%s", logs)
+			}
+		}
+		firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
+		firstTimestamp, err := strconv.ParseInt(firstLog, 10, 64)
+		if err != nil {
+			return fmt.Errorf("Error converting timestamp:", err)
+		}
+		chunkEnd = firstTimestamp
+	}
+	return nil
+}
+
+func (c *CurlRequest) GenerateCurlCommand() []string {
+	curlParts := append([]string{"curl", "--insecure", "-v"})
+	curlParts = append(curlParts, fmt.Sprintf("%s/%s", lokiURL, c.BaseURL))
+	for key, value := range c.Params {
+		if value != "" {
+			curlParts = append(curlParts, []string{"--data-urlencode", fmt.Sprintf("%s=%s", key, value)}...)
+		}
+	}
+	if c.AuthToken != "" {
+		curlParts = append(curlParts, []string{"-H", fmt.Sprintf("Authorization: Bearer %s", c.AuthToken)}...)
+	}
+	return curlParts
+}
+
+func GetDeckhousePod(kubeCl kubernetes.Interface, namespace string, labelSelector string) (string, error) {
+	pods, err := kubeCl.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return "", fmt.Errorf("Error listing pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("No pods found with the label: %s", labelSelector)
+	}
+
+	pod := pods.Items[0]
+	podName := pod.Name
+	return podName, nil
+}
+
+func ExecInPod(config *rest.Config, kubeCl kubernetes.Interface, command []string, podName string, namespace string, containerName string) (remotecommand.Executor, error) {
+	scheme := runtime.NewScheme()
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	if err := v1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("Failed to create parameter codec: %w", err)
+	}
+
+	req := kubeCl.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Command:   command,
+			Container: containerName,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, parameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return nil, fmt.Errorf("Creating SPDY executor for Pod %s: %v", podName, err)
+	}
+	return executor, nil
+}
+
+func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullCommand []string) (*QueryRange, *SeriesApi, error) {
+	for _, t := range fullCommand {
+		var stdout, stderr bytes.Buffer
+		podName, err := GetDeckhousePod(kubeCl, namespaceDeckhouse, labelSelector)
+		executor, err := ExecInPod(config, kubeCl, fullCommand, podName, namespaceDeckhouse, containerName)
+		if err = executor.StreamWithContext(
+			context.Background(),
+			remotecommand.StreamOptions{
+				Stdout: &stdout,
+				Stderr: &stderr,
+			}); err != nil {
+			fmt.Fprintf(os.Stderr, strings.Join(fullCommand, " "))
+			return nil, nil, err
+		}
+
+		if t == fmt.Sprintf("%s/series", lokiURL) {
+			var series SeriesApi
+			err = json.Unmarshal(stdout.Bytes(), &series)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed unmarshal SeriesApi %s", err)
+			}
+			return nil, &series, nil
+		} else if t == fmt.Sprintf("%s/query_range", lokiURL) {
+			var queryRange QueryRange
+			err = json.Unmarshal(stdout.Bytes(), &queryRange)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed unmarshal LokiResponse%s", err)
+			}
+			return &queryRange, nil, nil
+		}
+		stdout.Reset()
+	}
+
+	return nil, nil, nil
+}
+
+func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token string) (int64, error) {
+	if endTimestamp == "" {
+		endTimestampCurlParam := CurlRequest{
+			BaseURL: "query_range",
+			Params: map[string]string{
+				"query":     `{pod=~".+"}`,
+				"limit":     "1",
+				"direction": "BACKWARD",
+			},
+			AuthToken: token,
+		}
+		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
+		endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
+		if err != nil {
+			return 0, fmt.Errorf("Error get latest timestamp JSON from Loki: %s", err)
+		}
+		endTimestamp, err := strconv.ParseInt(endTimestampJson.Data.Result[0].Values[0][0], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("Error converting timestamp:", err)
+		}
+		return endTimestamp, nil
+	}
+
+	end, err := time.Parse(templateDate, endTimestamp)
+	if err != nil {
+		return 0, fmt.Errorf("Error parsing date: %s, please provide correct date.", err)
+	}
+	endTimestampNanoSec := end.UnixNano()
+
+	return endTimestampNanoSec, nil
+}
+
+func getStartTimestamp() (int64, error) {
+	start, err := time.Parse(templateDate, startTimestamp)
+	if err != nil {
+		return 0, fmt.Errorf("Error parsing date: %s, please provide correct date.", err)
+	}
+	startTimestampNanoSec := start.UnixNano()
+
+	return startTimestampNanoSec, nil
+}
+
+func getTokenLokiSa(kubeCl kubernetes.Interface) (string, error) {
+	secret, err := kubeCl.CoreV1().Secrets(namespaceLoki).Get(context.TODO(), secretNameLoki, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("Failed to get Secret: %v", err)
+	}
+
+	tokenBase64, exists := secret.Data["token"]
+	if !exists {
+		return "", fmt.Errorf("Token not found in Secret: %v", err)
+	}
+	return string(tokenBase64), err
+}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -330,8 +330,8 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 			AuthToken: token,
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
-		endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
-		//endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
+		//endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
+		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
 		if err != nil {
 			return 0, fmt.Errorf("error get latest timestamp JSON from Loki: %s", err)
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -80,7 +80,6 @@ var (
 	Logger         = log.NewSLogger(slog.LevelError)
 	QueryRangeDump *QueryRange
 	SeriesApiDump  *SeriesApi
-	//limit          = "5000"
 )
 
 type QueryRange struct {
@@ -116,6 +115,8 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error get token from secret for loki api: %w", err)
 	}
+
+	fmt.Println("Getting logs from Loki api...")
 
 	endDumpTimestamp, err := getEndTimestamp(config, kubeCl, token)
 	if err != nil {
@@ -166,10 +167,6 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 
 	chunkEnd = endDumpTimestamp
 	for chunkEnd > chunkStart {
-		//if limitFlag != "" {
-		//	limit = limitFlag
-		//}
-
 		curlParamDumpLog := CurlRequest{
 			BaseURL: "query_range",
 			Params: map[string]string{
@@ -288,7 +285,6 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
 		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
-		//endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
 		if err != nil {
 			return 0, fmt.Errorf("error get latest timestamp JSON from loki: %w", err)
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -77,8 +77,6 @@ var (
 	limitFlag      string
 	chunkDaysFlag  int
 	Logger         = log.NewSLogger(slog.LevelError)
-	QueryRangeDump *QueryRange
-	SeriesApiDump  *SeriesApi
 )
 
 type QueryRange struct {
@@ -327,7 +325,13 @@ func getTokenLokiSa(kubeCl kubernetes.Interface) (string, error) {
 }
 
 func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullCommand []string) (*QueryRange, *SeriesApi, error) {
-	var err error
+
+	var (
+		err            error
+		QueryRangeDump *QueryRange
+		SeriesApiDump  *SeriesApi
+	)
+
 	err = retry.RunTask(Logger,
 		"error get json response from Loki",
 		task.WithConstantRetries(5, 10*time.Second, func(ctx context.Context) error {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -287,8 +287,8 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 			AuthToken: token,
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
-		//endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
-		endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
+		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
+		//endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
 		if err != nil {
 			return 0, fmt.Errorf("error get latest timestamp JSON from loki: %w", err)
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -153,7 +153,9 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map[string]string, config *rest.Config, kubeCl kubernetes.Interface) error {
 	var filters []string
 	for key, value := range r {
-		fmt.Printf("stream is %s=%s", key, value)
+
+		fmt.Printf("\nstream is %s=%s", key, value)
+
 		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
 	}
 	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))
@@ -164,7 +166,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			limit = limitFlag
 		}
 
-		fmt.Printf("chunkStart is %v, chunkEnd is %v", chunkStart, chunkEnd)
+		chunkStartUtc := time.Unix(0, chunkStart).UTC()
+		chunkEndUtc := time.Unix(0, chunkEnd).UTC()
+		fmt.Printf("\nchunkStart is %v, chunkEnd is %v", chunkStartUtc, chunkEndUtc)
 
 		curlParamDumpLog := CurlRequest{
 			BaseURL: "query_range",
@@ -200,13 +204,16 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 				fmt.Printf("%s", logs)
 			}
 		}
+		//firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		firstTimestamp, err := strconv.ParseInt(firstLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
 		firstTimestampUtc := time.Unix(0, firstTimestamp).UTC()
-		fmt.Printf("end timestamp is %v", firstTimestampUtc)
+
+		fmt.Printf("\nend timestamp is %v", firstTimestampUtc)
+
 		chunkEnd = firstTimestamp
 
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -281,6 +281,7 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 
 		if t == fmt.Sprintf("%s/series", lokiURL) {
 			var series SeriesApi
+			fmt.Println("Raw JSON response:", stdout.String())
 			err = json.Unmarshal(stdout.Bytes(), &series)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Failed unmarshal SeriesApi: %s", err)
@@ -288,6 +289,7 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			return nil, &series, nil
 		} else if t == fmt.Sprintf("%s/query_range", lokiURL) {
 			var queryRange QueryRange
+			fmt.Println("Raw JSON response:", stdout.String())
 			err = json.Unmarshal(stdout.Bytes(), &queryRange)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Failed unmarshal LokiResponse: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -191,9 +191,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 				if err != nil {
 					return fmt.Errorf("Error converting timestamp: %s", err)
 				}
-				//timestampUtc := time.Unix(0, timestampInt64).UTC()
-				//logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
-				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampInt64, entry[1]))
+				timestampUtc := time.Unix(0, timestampInt64).UTC()
+				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
+				//logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampInt64, entry[1]))
 				fmt.Printf("%s", logs)
 			}
 		}
@@ -202,7 +202,8 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
-		fmt.Printf("end timestamp is %v", firstTimestamp)
+		firstTimestampUtc := time.Unix(0, firstTimestamp).UTC()
+		fmt.Printf("end timestamp is %v", firstTimestampUtc)
 		chunkEnd = firstTimestamp
 
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -339,7 +339,7 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 		if err != nil {
 			return 0, fmt.Errorf("Error converting timestamp: %s", err)
 		}
-		return endTimestamp, nil
+		return endTimestamp, err
 	}
 
 	end, err := time.Parse(templateDate, endTimestamp)
@@ -348,7 +348,7 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 	}
 	endTimestampNanoSec := end.UnixNano()
 
-	return endTimestampNanoSec, nil
+	return endTimestampNanoSec, err
 }
 
 func getStartTimestamp() (int64, error) {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -154,7 +154,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 	var filters []string
 	for key, value := range r {
 
-		fmt.Printf("\nstream is %s=%s", key, value)
+		//fmt.Printf("\nstream is %s=%s", key, value)
 
 		filters = append(filters, fmt.Sprintf(`%s="%s"`, key, value))
 	}
@@ -167,9 +167,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			limit = limitFlag
 		}
 
-		chunkStartUtc := time.Unix(0, chunkStart).UTC()
-		chunkEndUtc := time.Unix(0, chunkEnd).UTC()
-		fmt.Printf("\nchunkStart is %v, chunkEnd is %v", chunkStartUtc, chunkEndUtc)
+		//chunkStartUtc := time.Unix(0, chunkStart).UTC()
+		//chunkEndUtc := time.Unix(0, chunkEnd).UTC()
+		//fmt.Printf("\nchunkStart is %v, chunkEnd is %v", chunkStartUtc, chunkEndUtc)
 
 		curlParamDumpLog := CurlRequest{
 			BaseURL: "query_range",
@@ -192,7 +192,6 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			break
 		}
 
-		//var logs []string
 		for _, d := range DumpLogCurlJson.Data.Result {
 			for _, entry := range d.Values {
 				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
@@ -200,21 +199,17 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 					return fmt.Errorf("Error converting timestamp: %s", err)
 				}
 				timestampUtc := time.Unix(0, timestampInt64).UTC()
-				//logs = append(logs, fmt.Sprintf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
-				//logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampInt64, entry[1]))
-				//fmt.Printf("%s", logs)
 				fmt.Printf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1])
 			}
 		}
-		//firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		firstTimestamp, err := strconv.ParseInt(firstLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
-		firstTimestampUtc := time.Unix(0, firstTimestamp).UTC()
+		//firstTimestampUtc := time.Unix(0, firstTimestamp).UTC()
 
-		fmt.Printf("\nend timestamp is %v", firstTimestampUtc)
+		//fmt.Printf("\nend timestamp is %v", firstTimestampUtc)
 
 		chunkEnd = firstTimestamp
 

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -163,6 +163,9 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		if limitFlag != "" {
 			limit = limitFlag
 		}
+
+		fmt.Printf("chunkStart is %v, chunkEnd is %v", chunkStart, chunkEnd)
+
 		curlParamDumpLog := CurlRequest{
 			BaseURL: "query_range",
 			Params: map[string]string{
@@ -185,8 +188,8 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		}
 
 		var logs []string
-		for _, r := range DumpLogCurlJson.Data.Result {
-			for _, entry := range r.Values {
+		for _, d := range DumpLogCurlJson.Data.Result {
+			for _, entry := range d.Values {
 				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
 				if err != nil {
 					return fmt.Errorf("Error converting timestamp: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -375,8 +375,6 @@ func getTokenLokiSa(kubeCl kubernetes.Interface) (string, error) {
 }
 
 func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullCommand []string) (*QueryRange, *SeriesApi, error) {
-	var err error
-
 	for attempts := 1; attempts <= 5; attempts++ {
 		QueryRangeDump, SeriesApiDump, err := getLogTimestamp(config, kubeCl, fullCommand)
 		if err == nil && QueryRangeDump == nil {
@@ -385,9 +383,9 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		if err == nil && SeriesApiDump == nil {
 			return QueryRangeDump, nil, nil
 		}
-		fmt.Printf("%v\n", err)
+		fmt.Printf("error get JSON response from Loki: %v\n", err)
 		time.Sleep(1 * time.Second)
 	}
 
-	return nil, nil, fmt.Errorf("error get JSON response from Loki: %w", err)
+	return nil, nil, fmt.Errorf("error get JSON response from Loki")
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -154,7 +154,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 			}
 		}
 	}
-	return err
+	return nil
 }
 
 func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map[string]string, config *rest.Config, kubeCl kubernetes.Interface) error {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -77,7 +77,7 @@ var (
 	startTimestamp string
 	limitFlag      string
 	chunkDaysFlag  int
-	Logger         = log.NewSLogger(slog.LevelInfo)
+	Logger         = log.NewSLogger(slog.LevelError)
 	QueryRangeDump *QueryRange
 	SeriesApiDump  *SeriesApi
 	//limit          = "5000"
@@ -333,7 +333,7 @@ func getTokenLokiSa(kubeCl kubernetes.Interface) (string, error) {
 func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullCommand []string) (*QueryRange, *SeriesApi, error) {
 	var err error
 	err = retry.RunTask(Logger,
-		"Get json response from Loki",
+		"error get json response from Loki",
 		task.WithConstantRetries(5, 10*time.Second, func(ctx context.Context) error {
 			QueryRangeDump, SeriesApiDump, err = getLogTimestamp(config, kubeCl, fullCommand)
 			if err != nil {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -193,9 +193,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 				fmt.Printf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1])
 			}
 		}
-		//get latest timestamp value from stream Loki api response to use pagination and get all log strings
-		//lastLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
-		//lastLog := DumpLogCurlJson.Data.Result[0].Values[0][0]
+		//get latest timestamp value from stream Loki api response to use pagination and get all log strings.
 		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[0].Values)-1][0]
 		lastTimestamp, err := strconv.ParseInt(lastLog, 10, 64)
 		if err != nil {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -386,6 +386,5 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		fmt.Printf("error get JSON response from Loki: %v\n", err)
 		time.Sleep(1 * time.Second)
 	}
-
 	return nil, nil, fmt.Errorf("error get JSON response from Loki")
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -196,7 +196,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		//get latest timestamp value from stream Loki api response to use pagination and get all log strings
 		//lastLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		//lastLog := DumpLogCurlJson.Data.Result[0].Values[0][0]
-		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
+		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[0].Values)-1][0]
 		lastTimestamp, err := strconv.ParseInt(lastLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -140,6 +140,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 			break
 		}
 		for _, r := range streamListDumpJson.Data {
+			fmt.Printf("stream is: %s", streamListDumpJson.Data)
 			err := fetchLogs(chunkStart, chunkEnd, endDumpTimestamp, token, r, config, kubeCl)
 			if err != nil {
 				return fmt.Errorf("Error get logs from Loki: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/operatepod"
 	"github.com/deckhouse/deckhouse-cli/internal/platform/flags"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/retry"
@@ -227,11 +226,11 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 	for _, apiUrlLoki := range fullCommand {
 		var stdout, stderr bytes.Buffer
 
-		podName, err := operatepod.GetDeckhousePod(kubeCl)
+		podName, err := utilk8s.GetDeckhousePod(kubeCl)
 		if err != nil {
 			return nil, nil, err
 		}
-		executor, err := operatepod.ExecInPod(config, kubeCl, fullCommand, podName, namespaceDeckhouse, containerName)
+		executor, err := utilk8s.ExecInPod(config, kubeCl, fullCommand, podName, namespaceDeckhouse, containerName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -291,7 +291,6 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			return nil, &series, nil
 		} else if t == fmt.Sprintf("%s/query_range", lokiURL) {
 			var queryRange QueryRange
-			fmt.Println("Raw JSON response:", stdout.String())
 			if !json.Valid(stdout.Bytes()) {
 				return nil, nil, fmt.Errorf("Error response from loki api: %s", stdout.String())
 			}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -187,7 +187,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			for _, entry := range r.Values {
 				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
 				if err != nil {
-					return fmt.Errorf("Error converting timestamp:", err)
+					return fmt.Errorf("Error converting timestamp: %s", err)
 				}
 				timestampUtc := time.Unix(0, timestampInt64).UTC()
 				logs = append(logs, fmt.Sprintf("\nTimestamp: [%v], Log: %s\n", timestampUtc, entry[1]))
@@ -197,7 +197,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 		firstLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		firstTimestamp, err := strconv.ParseInt(firstLog, 10, 64)
 		if err != nil {
-			return fmt.Errorf("Error converting timestamp:", err)
+			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
 		chunkEnd = firstTimestamp
 	}
@@ -283,14 +283,14 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			var series SeriesApi
 			err = json.Unmarshal(stdout.Bytes(), &series)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed unmarshal SeriesApi %s", err)
+				return nil, nil, fmt.Errorf("Failed unmarshal SeriesApi: %s", err)
 			}
 			return nil, &series, nil
 		} else if t == fmt.Sprintf("%s/query_range", lokiURL) {
 			var queryRange QueryRange
 			err = json.Unmarshal(stdout.Bytes(), &queryRange)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed unmarshal LokiResponse%s", err)
+				return nil, nil, fmt.Errorf("Failed unmarshal LokiResponse: %s", err)
 			}
 			return &queryRange, nil, nil
 		}
@@ -318,7 +318,7 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 		}
 		endTimestamp, err := strconv.ParseInt(endTimestampJson.Data.Result[0].Values[0][0], 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("Error converting timestamp:", err)
+			return 0, fmt.Errorf("Error converting timestamp: %s", err)
 		}
 		return endTimestamp, nil
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -389,5 +389,5 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		time.Sleep(1 * time.Second)
 	}
 
-	return nil, nil, fmt.Errorf("error get JSON response from Loki: %s", err)
+	return nil, nil, fmt.Errorf("error get JSON response from Loki: %w", err)
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -341,11 +341,5 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 	if err != nil {
 		return nil, nil, fmt.Errorf("error get JSON from loki: %w", err)
 	}
-	if SeriesApiDump != nil {
-		return nil, SeriesApiDump, nil
-	}
-	if QueryRangeDump != nil {
-		return QueryRangeDump, nil, nil
-	}
-	return nil, nil, nil
+	return QueryRangeDump, SeriesApiDump, nil
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -328,7 +328,6 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 			AuthToken: token,
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
-		//endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
 		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
 		if err != nil {
 			return 0, fmt.Errorf("error get latest timestamp JSON from Loki: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -385,7 +385,7 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		if err == nil && SeriesApiDump == nil {
 			return QueryRangeDump, nil, nil
 		}
-		fmt.Printf("\nAttempt %d failed: %v\n", attempts, err)
+		fmt.Printf("\n%v\n", err)
 		time.Sleep(45 * time.Second)
 	}
 

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -385,7 +385,8 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		if err == nil && SeriesApiDump == nil {
 			return QueryRangeDump, nil, nil
 		}
-		fmt.Printf("Attempt %d failed: %v\n", attempts, err)
+		fmt.Printf("\nAttempt %d failed: %v\n", attempts, err)
+		time.Sleep(45 * time.Second)
 	}
 
 	return nil, nil, err

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -330,14 +330,14 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 			AuthToken: token,
 		}
 		endTimestampCurl := endTimestampCurlParam.GenerateCurlCommand()
-		//endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
-		endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
+		endTimestampJson, _, err := getLogTimestamp(config, kubeCl, endTimestampCurl)
+		//endTimestampJson, _, err := getLogWithRetry(config, kubeCl, endTimestampCurl)
 		if err != nil {
-			return 0, fmt.Errorf("Error get latest timestamp JSON from Loki: %s", err)
+			return 0, fmt.Errorf("error get latest timestamp JSON from Loki: %s", err)
 		}
 		endTimestamp, err := strconv.ParseInt(endTimestampJson.Data.Result[0].Values[0][0], 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("Error converting timestamp: %s", err)
+			return 0, fmt.Errorf("error converting timestamp: %s", err)
 		}
 		return endTimestamp, err
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -386,7 +386,7 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			return QueryRangeDump, nil, nil
 		}
 		fmt.Printf("%v\n", err)
-		time.Sleep(45 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error get JSON response from Loki: %s", err)

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -177,17 +177,16 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			},
 			AuthToken: token,
 		}
-		DumpLogCurl := curlParamDumpLog.GenerateCurlCommand()
-		//DumpLogCurlJson, _, err := getLogTimestamp(config, kubeCl, DumpLogCurl)
-		DumpLogCurlJson, _, err := getLogWithRetry(config, kubeCl, DumpLogCurl)
+		dumpLogCurl := curlParamDumpLog.GenerateCurlCommand()
+		dumpLogCurlJson, _, err := getLogWithRetry(config, kubeCl, dumpLogCurl)
 		if err != nil {
 			return fmt.Errorf("Error get JSON from Loki: %s", err)
 		}
-		if len(DumpLogCurlJson.Data.Result) == 0 {
+		if len(dumpLogCurlJson.Data.Result) == 0 {
 			break
 		}
 
-		for _, d := range DumpLogCurlJson.Data.Result {
+		for _, d := range dumpLogCurlJson.Data.Result {
 			for _, entry := range d.Values {
 				timestampInt64, err := strconv.ParseInt(entry[0], 10, 64)
 				if err != nil {
@@ -198,13 +197,12 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 			}
 		}
 		//get last timestamp value from stream Loki api response to use pagination and get all logs.
-		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[0].Values)-1][0]
+		lastLog := dumpLogCurlJson.Data.Result[0].Values[len(dumpLogCurlJson.Data.Result[0].Values)-1][0]
 		lastTimestamp, err := strconv.ParseInt(lastLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("Error converting timestamp: %s", err)
 		}
 		chunkEnd = lastTimestamp
-
 	}
 	return nil
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -69,14 +69,13 @@ const (
 	namespaceLoki      = "d8-monitoring"
 	secretNameLoki     = "loki-api-token"
 	templateDate       = "2006-01-02 15:04:05"
-
-	chunkSize = int64(30 * 24 * 60 * 60 * 1e9) //30 days in nanosec timestamp
 )
 
 var (
 	endTimestamp   string
 	startTimestamp string
 	limitFlag      string
+	chunkDaysFlag  int
 )
 
 type QueryRange struct {
@@ -117,6 +116,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error get end timestamp for Loki: %s", err)
 	}
+	chunkSize := int64(chunkDaysFlag * 24 * 60 * 60 * 1e9)
 	for chunkEnd := endDumpTimestamp; chunkEnd > 0; chunkEnd -= chunkSize {
 		chunkStart := chunkEnd - chunkSize
 		if startTimestamp != "" {

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -389,5 +389,5 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		time.Sleep(1 * time.Second)
 	}
 
-	return nil, nil, fmt.Errorf("error get JSON response from Loki: %v", err)
+	return nil, nil, fmt.Errorf("error get JSON response from Loki: %s", err)
 }

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -193,7 +193,7 @@ func fetchLogs(chunkStart, chunkEnd, endDumpTimestamp int64, token string, r map
 				fmt.Printf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1])
 			}
 		}
-		//get latest timestamp from latest index array from Loki api response to use pagination and get all log strings from stream
+		//get latest timestamp value from stream Loki api response to use pagination and get all log strings
 		//lastLog := DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]
 		//lastLog := DumpLogCurlJson.Data.Result[0].Values[0][0]
 		lastLog := DumpLogCurlJson.Data.Result[0].Values[len(DumpLogCurlJson.Data.Result[len(DumpLogCurlJson.Data.Result)-1].Values)-1][0]

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -389,9 +389,5 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		time.Sleep(1 * time.Second)
 	}
 
-	if err != nil {
-		return nil, nil, fmt.Errorf("error get JSON response from Loki: %v", err)
-	}
-
 	return nil, nil, fmt.Errorf("error get JSON response from Loki: %v", err)
 }

--- a/internal/utilk8s/operatepod.go
+++ b/internal/utilk8s/operatepod.go
@@ -20,7 +20,6 @@ func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
 	}
 
 	if len(pods.Items) == 0 {
-		fmt.Println("No pods deckhouse available in the namespace d8-system")
 		return "", fmt.Errorf("no pods deckhouse available in namespace d8-system to get response from loki api")
 	}
 	pod := pods.Items[0]

--- a/internal/utilk8s/operatepod.go
+++ b/internal/utilk8s/operatepod.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"os"
 )
 
 func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
@@ -22,7 +21,8 @@ func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
 
 	if len(pods.Items) == 0 {
 		fmt.Println("No pods deckhouse available in the namespace d8-system")
-		os.Exit(1)
+		return "", fmt.Errorf("no pods deckhouse available in namespace d8-system to get response from loki api")
+		//os.Exit(1)
 	}
 	pod := pods.Items[0]
 	podName := pod.Name

--- a/internal/utilk8s/operatepod.go
+++ b/internal/utilk8s/operatepod.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"os"
 )
 
 func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
@@ -19,6 +20,10 @@ func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
 		return "", fmt.Errorf("error listing pods: %w", err)
 	}
 
+	if len(pods.Items) == 0 {
+		fmt.Println("No pods deckhouse available in the namespace d8-system")
+		os.Exit(1)
+	}
 	pod := pods.Items[0]
 	podName := pod.Name
 	return podName, nil

--- a/internal/utilk8s/operatepod.go
+++ b/internal/utilk8s/operatepod.go
@@ -22,7 +22,6 @@ func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
 	if len(pods.Items) == 0 {
 		fmt.Println("No pods deckhouse available in the namespace d8-system")
 		return "", fmt.Errorf("no pods deckhouse available in namespace d8-system to get response from loki api")
-		//os.Exit(1)
 	}
 	pod := pods.Items[0]
 	podName := pod.Name


### PR DESCRIPTION
This pr add d8 backup loki option to dump all logs from Loki api endpoint or in given range timestamps.
e.g.
```
d8 backup loki --help
Dump Loki logs.

 This command dump all logs from Loki api or in given range timestamps in DKP.

 © Flant JSC 2025

Usage:
  d8 backup loki [flags]

Flags:
      --end string     Set end timestamp range to dump logs from Loki. (Default get max end timestamp from Loki, ex. "2025-01-14 15:04:05".)
  -h, --help           help for loki
      --limit string   Limit max string to output per queue from Loki. (Default 5000 max limit strings per queue.)
      --start string   Set start timestamp range to dump logs from Loki. (Default get max start timestamp from Loki, ex. "2025-01-12 15:04:05".)

Global Flags:
  -k, --kubeconfig string   KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise) (default "/root/.kube/config")

```