### PR TITLE
utilk8s: support default context overrides

### DIFF
--- a/internal/backup/cmd/cluster-config/cluster_config.go
+++ b/internal/backup/cmd/cluster-config/cluster_config.go
@@ -153,7 +153,12 @@ func setupK8sClients(cmd *cobra.Command) (*rest.Config, *kubernetes.Clientset, *
 		return nil, nil, nil, fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}

--- a/internal/backup/cmd/etcd/etcd.go
+++ b/internal/backup/cmd/etcd/etcd.go
@@ -89,7 +89,12 @@ func etcd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}

--- a/internal/backup/cmd/flags.go
+++ b/internal/backup/cmd/flags.go
@@ -17,4 +17,6 @@ func addPersistentFlags(flagSet *pflag.FlagSet) {
 		defaultKubeconfigPath,
 		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
 	)
+
+	flagSet.String("context", "", "The name of the kubeconfig context to use")
 }

--- a/internal/platform/cmd/collect-debug-info/collect-debug-info.go
+++ b/internal/platform/cmd/collect-debug-info/collect-debug-info.go
@@ -18,12 +18,14 @@ package collect_debug_info
 
 import (
 	"fmt"
-	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/collect-debug-info/debugTar"
-	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+	"os"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"k8s.io/kubectl/pkg/util/templates"
-	"os"
+
+	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/collect-debug-info/debugTar"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 var collectDebugInfoCmdLong = templates.LongDesc(`
@@ -55,7 +57,12 @@ func collectDebugInfo(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}

--- a/internal/platform/cmd/edit/editconfig/editconfig.go
+++ b/internal/platform/cmd/edit/editconfig/editconfig.go
@@ -28,7 +28,12 @@ func BaseEditConfigCMD(cmd *cobra.Command, name, secret, dataKey string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	_, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	_, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}

--- a/internal/platform/cmd/module/list/list.go
+++ b/internal/platform/cmd/module/list/list.go
@@ -18,12 +18,14 @@ package list
 
 import (
 	"fmt"
+
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/module/operatemodule"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 
-	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/edit/flags"
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/edit/flags"
 )
 
 var listLong = templates.LongDesc(`
@@ -44,13 +46,18 @@ func NewCommand() *cobra.Command {
 	return listCmd
 }
 
-func listModule(cmd *cobra.Command, args []string) error {
+func listModule(cmd *cobra.Command, _ []string) error {
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
@@ -59,5 +66,6 @@ func listModule(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Error list modules: %w", err)
 	}
-	return err
+
+	return nil
 }

--- a/internal/platform/cmd/module/snapshots/snapshots.go
+++ b/internal/platform/cmd/module/snapshots/snapshots.go
@@ -18,6 +18,7 @@ package snapshots
 
 import (
 	"fmt"
+
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/module/operatemodule"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 
@@ -43,20 +44,29 @@ func NewCommand() *cobra.Command {
 	return snapshotsCmd
 }
 
-func snapshotsModule(cmd *cobra.Command, moduleName []string) error {
+func snapshotsModule(cmd *cobra.Command, args []string) error {
+	moduleName := args[0]
+
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
-	pathFromOption := fmt.Sprintf("%s/snapshots.yaml", moduleName[0])
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	pathFromOption := fmt.Sprintf("%s/snapshots.yaml", moduleName)
 	err = operatemodule.OptionsModule(config, kubeCl, pathFromOption)
 	if err != nil {
 		return fmt.Errorf("Error snapshot module: %w", err)
 	}
-	return err
+
+	return nil
 }

--- a/internal/platform/cmd/module/values/values.go
+++ b/internal/platform/cmd/module/values/values.go
@@ -18,10 +18,12 @@ package values
 
 import (
 	"fmt"
-	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/module/operatemodule"
-	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/module/operatemodule"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 var valuesLong = templates.LongDesc(`
@@ -42,21 +44,29 @@ func NewCommand() *cobra.Command {
 	return valuesCmd
 }
 
-func valuesModule(cmd *cobra.Command, moduleName []string) error {
+func valuesModule(cmd *cobra.Command, args []string) error {
+	moduleName := args[0]
+
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	pathFromOption := fmt.Sprintf("%s/values.yaml", moduleName[0])
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	pathFromOption := fmt.Sprintf("%s/values.yaml", moduleName)
 	err = operatemodule.OptionsModule(config, kubeCl, pathFromOption)
 	if err != nil {
 		return fmt.Errorf("Error print values: %w", err)
 	}
-	return err
+
+	return nil
 }

--- a/internal/platform/cmd/queue/list/list.go
+++ b/internal/platform/cmd/queue/list/list.go
@@ -18,11 +18,13 @@ package list
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/queue/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/queue/operatequeue"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
-	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
 )
 
 var listLong = templates.LongDesc(`
@@ -45,13 +47,18 @@ func NewCommand() *cobra.Command {
 	return listCmd
 }
 
-func listModule(cmd *cobra.Command, args []string) error {
+func listModule(cmd *cobra.Command, _ []string) error {
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
@@ -75,5 +82,6 @@ func listModule(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Error list queues: %w", err)
 	}
-	return err
+
+	return nil
 }

--- a/internal/platform/cmd/queue/mainqueue/mainqueue.go
+++ b/internal/platform/cmd/queue/mainqueue/mainqueue.go
@@ -18,12 +18,14 @@ package mainqueue
 
 import (
 	"fmt"
+
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/spf13/cobra"
 
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/queue/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/platform/cmd/queue/operatequeue"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
-	"github.com/spf13/cobra"
 )
 
 var mainQueueLong = templates.LongDesc(`
@@ -45,13 +47,18 @@ func NewCommand() *cobra.Command {
 	return listCmd
 }
 
-func mainQueue(cmd *cobra.Command, args []string) error {
+func mainQueue(cmd *cobra.Command, _ []string) error {
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath)
+	contextName, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
+	}
+
+	config, kubeCl, err := utilk8s.SetupK8sClientSet(kubeconfigPath, contextName)
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
@@ -67,5 +74,6 @@ func mainQueue(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Error list main queue: %w", err)
 	}
-	return err
+
+	return nil
 }

--- a/internal/platform/flags/flags.go
+++ b/internal/platform/flags/flags.go
@@ -33,4 +33,6 @@ func AddPersistentFlags(cmd *cobra.Command) {
 		defaultKubeconfigPath,
 		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
 	)
+
+	cmd.PersistentFlags().String("context", "", "The name of the kubeconfig context to use")
 }

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -8,10 +8,20 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const DefaultKubeContext = ""
+
 // SetupK8sClientSet reads kubeconfig file at kubeconfigPath and constructs a kubernetes clientset from it.
-func SetupK8sClientSet(kubeconfigPath string) (*rest.Config, *kubernetes.Clientset, error) {
+// If contextName is not empty, context under that name is used instead of default.
+func SetupK8sClientSet(kubeconfigPath, contextName string) (*rest.Config, *kubernetes.Clientset, error) {
+	var configOverrides *clientcmd.ConfigOverrides = nil
+	if contextName != DefaultKubeContext {
+		configOverrides = &clientcmd.ConfigOverrides{
+			CurrentContext: contextName,
+		}
+	}
+
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}, nil).ClientConfig()
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath}, configOverrides).ClientConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("Reading kubeconfig file: %w", err)
 	}


### PR DESCRIPTION
Added `--context` flag alongside `--kubeconfig` similar to `kubectl` to allow users to select specific kubernetes context from kubeconfig instead of default.

Closes https://github.com/deckhouse/deckhouse-cli/issues/110