### PR TITLE
[platform] Avoid panic argument if module name was not provided

### DIFF
--- a/internal/platform/cmd/module/disable/disable.go
+++ b/internal/platform/cmd/module/disable/disable.go
@@ -47,6 +47,9 @@ func NewCommand() *cobra.Command {
 }
 
 func disableModule(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("module name is required")
+	}
 	moduleName := args[0]
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")

--- a/internal/platform/cmd/module/disable/disable.go
+++ b/internal/platform/cmd/module/disable/disable.go
@@ -47,8 +47,8 @@ func NewCommand() *cobra.Command {
 }
 
 func disableModule(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("module name is required")
+	if len(args) != 1 {
+		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
 	moduleName := args[0]
 

--- a/internal/platform/cmd/module/enable/enable.go
+++ b/internal/platform/cmd/module/enable/enable.go
@@ -47,6 +47,9 @@ func NewCommand() *cobra.Command {
 }
 
 func enableModule(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("module name is required")
+	}
 	moduleName := args[0]
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")

--- a/internal/platform/cmd/module/enable/enable.go
+++ b/internal/platform/cmd/module/enable/enable.go
@@ -47,8 +47,8 @@ func NewCommand() *cobra.Command {
 }
 
 func enableModule(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("module name is required")
+	if len(args) != 1 {
+		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
 	moduleName := args[0]
 

--- a/internal/platform/cmd/module/values/values.go
+++ b/internal/platform/cmd/module/values/values.go
@@ -45,8 +45,8 @@ func NewCommand() *cobra.Command {
 }
 
 func valuesModule(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("module name is required")
+	if len(args) != 1 {
+		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
 	moduleName := args[0]
 

--- a/internal/platform/cmd/module/values/values.go
+++ b/internal/platform/cmd/module/values/values.go
@@ -45,6 +45,9 @@ func NewCommand() *cobra.Command {
 }
 
 func valuesModule(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("module name is required")
+	}
 	moduleName := args[0]
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")


### PR DESCRIPTION
this pr allow to avoid panic if module was not provided in options:

> module enable
> module disable
> module values

ex.
```
d8 p module enable
Error: this command requires exactly 1 argument: module name
```