### PR TITLE
[system] Add aliases "p" and "platform" to "d8 system" commands

### DIFF
--- a/internal/system/cmd/system.go
+++ b/internal/system/cmd/system.go
@@ -35,9 +35,11 @@ Operate system options in DKP.
 
 func NewCommand() *cobra.Command {
 	systemCmd := &cobra.Command{
-		Use:     "system",
-		Short:   "Operate system options.",
-		Aliases: []string{"s"},
+		Use:   "system",
+		Short: "Operate system options.",
+		// TODO(mvasl) p and platform are old names of this commands and are left as aliases for backwards compatibility
+		//  with our docs until we update them to use s or system.
+		Aliases: []string{"s", "p", "platform"},
 		Long:    systemLong,
 		PreRunE: flags.ValidateParameters,
 	}


### PR DESCRIPTION
Our docs mention `d8 platform` a lot of times and should be updated to `d8 system` in the future. Until then, alias `d8 p/platform` commands to `d8 system` for backwards compatibility with existing docs.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/31bc2d0b-3790-4d07-9c33-0b2b0be71740" />
