### PR TITLE
[tools] gostsum

### DIFF
--- a/internal/tools/farconverter/cmd/far-convert.go
+++ b/internal/tools/farconverter/cmd/far-convert.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package farconverter
+package cmd
 
 import (
 	"fmt"
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/tools/farconverter"
 )
 
 var convertLong = templates.LongDesc(`
@@ -50,7 +52,7 @@ func NewCommand() *cobra.Command {
 
 			return nil
 		},
-		RunE: Convert,
+		RunE: farconverter.Convert,
 	}
 
 	return convertCmd

--- a/internal/tools/gostsum/cmd/flags.go
+++ b/internal/tools/gostsum/cmd/flags.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+)
+
+func addFlags(flags *pflag.FlagSet) {
+	flags.IntP(
+		"hash-length",
+		"l",
+		256,
+		"Bit-length variant of the algorithm to use. Only 256 (default) and 512 bit lengths are supported.",
+	)
+}

--- a/internal/tools/gostsum/cmd/gostsum.go
+++ b/internal/tools/gostsum/cmd/gostsum.go
@@ -14,33 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tools
+package cmd
 
 import (
-	farconverter "github.com/deckhouse/deckhouse-cli/internal/tools/farconverter/cmd"
-	gostsum "github.com/deckhouse/deckhouse-cli/internal/tools/gostsum/cmd"
-
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/tools/gostsum"
 )
 
-var toolsLong = templates.LongDesc(`
-Various useful tools for operating in The Deckhouse Ecosystem.
+var gostsumLong = templates.LongDesc(`
+Calculate Streebog checksum of the data according to the RFC 6986 (GOST R 34.11-2012) specifications.
+
+Data for checksumming is provided as a list of filepaths in the command-line arguments.
+If no filepaths are provided, data is assumed to be available from stdin.
 
 © Flant JSC 2025`)
 
 func NewCommand() *cobra.Command {
-	toolsCmd := &cobra.Command{
-		Use:     "tools",
-		Short:   "Various useful tools for operating in The Deckhouse Ecosystem.",
-		Aliases: []string{"t"},
-		Long:    toolsLong,
+	convertCmd := &cobra.Command{
+		Use:   "gostsum",
+		Short: "Calculate Streebog checksum of the data according to the RFC 6986 (GOST R 34.11-2012) specifications",
+		Long:  gostsumLong,
+		RunE:  gostsum.Gostsum,
 	}
 
-	toolsCmd.AddCommand(
-		farconverter.NewCommand(),
-		gostsum.NewCommand(),
-	)
+	addFlags(convertCmd.Flags())
 
-	return toolsCmd
+	return convertCmd
 }

--- a/internal/tools/gostsum/gostsum.go
+++ b/internal/tools/gostsum/gostsum.go
@@ -1,0 +1,69 @@
+package gostsum
+
+import (
+	"bufio"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	streebog256 "go.cypherpunks.ru/gogost/v5/gost34112012256"
+	streebog512 "go.cypherpunks.ru/gogost/v5/gost34112012512"
+)
+
+func Gostsum(cmd *cobra.Command, args []string) error {
+	length, err := cmd.Flags().GetInt("hash-length")
+	if err != nil {
+		panic(err)
+	}
+
+	var hasher hash.Hash
+	switch length {
+	case 256:
+		hasher = streebog256.New()
+	case 512:
+		hasher = streebog512.New()
+	default:
+		return fmt.Errorf("invalid hash length: %d", length)
+	}
+
+	// No input files, read from stdin
+	if len(args) == 0 {
+		checksum, err := digest(os.Stdin, hasher)
+		if err != nil {
+			return err
+		}
+		if _, err = fmt.Println(checksum); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Have a set of file paths to hash provided as args
+	var reader io.Reader
+	var checksum string
+	for _, filepath := range args {
+		reader, err = os.Open(filepath)
+		if err != nil {
+			return fmt.Errorf("%s: %w", filepath, err)
+		}
+		checksum, err = digest(bufio.NewReader(reader), hasher)
+		if err != nil {
+			return err
+		}
+		if _, err = fmt.Println(filepath+":", checksum); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func digest(blobStream io.Reader, hasher hash.Hash) (string, error) {
+	if _, err := io.Copy(hasher, blobStream); err != nil {
+		return "", fmt.Errorf("digest blob: %w", err)
+	}
+
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}

--- a/internal/tools/gostsum/gostsum_test.go
+++ b/internal/tools/gostsum/gostsum_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gostsum
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	streebog256 "go.cypherpunks.ru/gogost/v5/gost34112012256"
+	streebog512 "go.cypherpunks.ru/gogost/v5/gost34112012512"
+)
+
+func Test_gostsums_HashCompatibility256(t *testing.T) {
+	input := "012345678901234567890123456789012345678901234567890123456789012"
+	gostsumHash := "9d151eefd8590b89daa6ba6cb74af9275dd051026bb149a452fd84e5e57b5500"
+
+	gogostHash, err := digest(strings.NewReader(input), streebog256.New())
+	require.NoError(t, err)
+	require.Equal(t, gostsumHash, gogostHash)
+}
+
+func Test_gostsums_HashCompatibility512(t *testing.T) {
+	input := "012345678901234567890123456789012345678901234567890123456789012"
+	gostsumHash := "1b54d01a4af5b9d5cc3d86d68d285462b19abc2475222f35c085122be4ba1ffa00ad30f8767b3a82384c6574f024c311e2a481332b08ef7f41797891c1646f48"
+
+	gogostHash, err := digest(strings.NewReader(input), streebog512.New())
+	require.NoError(t, err)
+	require.Equal(t, gostsumHash, gogostHash)
+}


### PR DESCRIPTION
Added a gostsums-like tool to calculate streebog 256 and 512-bit variants under `d8 tools gostsum`

```
~ # d8 tools
Various useful tools for operating in The Deckhouse Ecosystem.

 © Flant JSC 2025

Usage:
  d8 tools [command]

Aliases:
  tools, t

Available Commands:
  far-convert Converts files with Falco rules to FalcoAuditRules CRD format
  gostsum     Calculate Streebog checksum of the data according to the RFC 6986 (GOST R 34.11-2012) specifications

Flags:
  -h, --help   help for tools

Use "d8 tools [command] --help" for more information about a command.
```

---

```
~ # d8 tools gostsum
Calculate Streebog checksum of the data according to the RFC 6986 (GOST R 34.11-2012) specifications.

Data for checksumming is provided as a list of filepaths in the command-line arguments.
If no filepaths are provided, data is assumed to be available from stdin.

 © Flant JSC 2025

Usage:
  d8 tools gostsum [flags]

Flags:
  -l, --hash-length int   Bit-length variant of the algorithm to use. Only 256 (default) and 512 bit lengths are supported. (default 256)
  -h, --help              help for gostsum
```