### PR TITLE
[data] Add support for VirtualDisk and VirtualDiskSnapshot targets in data-export commands (e.g. vd/<name>, vds/<name>)

### DIFF
--- a/internal/dataexport/cmd/create/create.go
+++ b/internal/dataexport/cmd/create/create.go
@@ -59,7 +59,7 @@ func NewCommand(ctx context.Context, log *slog.Logger) *cobra.Command {
 	}
 
 	cmd.Flags().StringP("namespace", "n", "d8-data-exporter", "data volume namespace")
-	cmd.Flags().String("ttl", "30m", "Time to live")
+	cmd.Flags().String("ttl", "2m", "Time to live")
 	cmd.Flags().Bool("publish", false, "Provide access outside of cluster")
 
 	return cmd
@@ -76,14 +76,18 @@ func parseArgs(args []string) (deName, volumeKind, volumeName string, err error)
 		err = fmt.Errorf("invalid volume format, expect: <type>/<name>")
 		return
 	}
-	volumeKind, volumeName = resourceTypeAndName[0], resourceTypeAndName[1]
+	volumeKind, volumeName = strings.ToLower(resourceTypeAndName[0]), resourceTypeAndName[1]
 	switch volumeKind {
-	case "pvc", "PVC":
+	case "pvc", "persistentvolumeclaim":
 		volumeKind = util.PersistentVolumeClaimKind
-	case "vs", "VS":
+	case "vs", "volumesnapshot":
 		volumeKind = util.VolumeSnapshotKind
+	case "vd", "virtualdisk":
+		volumeKind = util.VirtualDiskKind
+	case "vds", "virtualdisksnapshot":
+		volumeKind = util.VirtualDiskSnapshotKind
 	default:
-		err = fmt.Errorf("invalid volume type, expect: 'pvc' or 'vs'")
+		err = fmt.Errorf("invalid volume type; valid values: pvc | persistentvolumeclaim | vs | volumesnapshot | vd | virtualdisk | vds | virtualdisksnapshot")
 		return
 	}
 

--- a/internal/dataexport/cmd/download/download.go
+++ b/internal/dataexport/cmd/download/download.go
@@ -43,12 +43,16 @@ const (
 
 func cmdExamples() string {
 	resp := []string{
-		fmt.Sprintf("  # Start exporter + Download + Stop for Filesystem"),
+		"  # Start exporter + Download + Stop for Filesystem",
 		fmt.Sprintf("    ... %s [flags] kind/volume_name path/file.ext [-o out_file.ext]", cmdName),
-		fmt.Sprintf("    ... %s -n target-namespace PVC/my-file-volume mydir/testdir/file.txt -o file.txt", cmdName),
-		fmt.Sprintf("  # Start exporter + Download + Stop for Block"),
+		fmt.Sprintf("    ... %s -n target-namespace pvc/my-file-volume mydir/testdir/file.txt -o file.txt", cmdName),
+		"  # Start exporter + Download + Stop for Block",
 		fmt.Sprintf("    ... %s [flags] kind/volume_name [-o out_file.ext]", cmdName),
-		fmt.Sprintf("    ... %s -n target-namespace VS/my-vs-volume -o file.txt", cmdName),
+		fmt.Sprintf("    ... %s -n target-namespace vs/my-vs-volume -o file.txt", cmdName),
+		"  # Start exporter + Download + Stop for VirtualDisk (Block)",
+		fmt.Sprintf("    ... %s -n target-namespace vd/my-virtualdisk -o file.img", cmdName),
+		"  # Start exporter + Download + Stop for VirtualDiskSnapshot (Block)",
+		fmt.Sprintf("    ... %s -n target-namespace vds/my-virtualdisk-snapshot -o file.img", cmdName),
 	}
 	return strings.Join(resp, "\n")
 }
@@ -70,6 +74,7 @@ func NewCommand(ctx context.Context, log *slog.Logger) *cobra.Command {
 	cmd.Flags().StringP("namespace", "n", "d8-data-exporter", "data volume namespace")
 	cmd.Flags().StringP("output", "o", "", "file to save data (default: same as resource)") //TODO support /dev/stdout
 	cmd.Flags().Bool("publish", false, "Provide access outside of cluster")
+	cmd.Flags().String("ttl", "2m", "Time to live for auto-created DataExport")
 
 	return cmd
 }
@@ -240,9 +245,11 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 }
 
 func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []string) error {
+
 	namespace, _ := cmd.Flags().GetString("namespace")
 	dstPath, _ := cmd.Flags().GetString("output")
 	publish, _ := cmd.Flags().GetBool("publish")
+	ttl, _ := cmd.Flags().GetString("ttl")
 
 	dataName, srcPath, err := parseArgs(args)
 	if err != nil {
@@ -260,7 +267,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		return err
 	}
 
-	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, rtClient)
+	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, ttl, rtClient)
 	if err != nil {
 		return err
 	}

--- a/internal/dataexport/cmd/download/download.go
+++ b/internal/dataexport/cmd/download/download.go
@@ -267,14 +267,14 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		return err
 	}
 
-	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, ttl, rtClient)
+	deName, err := util.CreateDataExporterIfNeededFunc(ctx, log, dataName, namespace, publish, ttl, rtClient)
 	if err != nil {
 		return err
 	}
 
 	log.Info("DataExport created", slog.String("name", deName), slog.String("namespace", namespace))
 
-	url, volumeMode, subClient, err := util.PrepareDownload(ctx, log, deName, namespace, publish, sClient)
+	url, volumeMode, subClient, err := util.PrepareDownloadFunc(ctx, log, deName, namespace, publish, sClient)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 			dstPath = deName
 		}
 	default:
-		return fmt.Errorf("%w: %s", util.UnsupportedVolumeModeErr, volumeMode)
+		return fmt.Errorf("%w: %s", util.ErrUnsupportedVolumeMode, volumeMode)
 	}
 
 	log.Info("Start downloading", slog.String("url", url+srcPath), slog.String("dstPath", dstPath))

--- a/internal/dataexport/cmd/download/download_http_test.go
+++ b/internal/dataexport/cmd/download/download_http_test.go
@@ -21,6 +21,8 @@ import (
 
 // helper to create SafeClient with empty rest.Config (no auth)
 func newNoAuthSafe() *safereq.SafeClient {
+	// Ensure that SafeClient allows unauthenticated HTTP requests during unit tests.
+	safereq.SupportNoAuth = true
 	sc, _ := safereq.NewSafeClient()
 	return sc.Copy()
 }

--- a/internal/dataexport/cmd/download/download_http_test.go
+++ b/internal/dataexport/cmd/download/download_http_test.go
@@ -1,0 +1,143 @@
+package download
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"log/slog"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/internal/dataexport/util"
+	safereq "github.com/deckhouse/deckhouse-cli/pkg/libsaferequest/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// helper to create SafeClient with empty rest.Config (no auth)
+func newNoAuthSafe() *safereq.SafeClient {
+	sc, _ := safereq.NewSafeClient()
+	return sc.Copy()
+}
+
+func TestDownloadFilesystem_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/files/foo.txt", r.URL.Path)
+		w.Header().Set("X-Type", "file")
+		w.Header().Set("Content-Length", "3")
+		w.WriteHeader(200)
+		w.Write([]byte("abc"))
+	}))
+	defer srv.Close()
+
+	// stub PrepareDownload / CreateDataExporterIfNeeded
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/files", "Filesystem", newNoAuthSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() {
+		util.PrepareDownloadFunc = origPrep
+		util.CreateDataExporterIfNeededFunc = origCreate
+	}()
+
+	outFile := filepath.Join(t.TempDir(), "out.txt")
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport", "foo.txt", "-o", outFile})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	require.Equal(t, []byte("abc"), data)
+}
+
+func TestDownloadFilesystem_BadPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate Block-mode error when files endpoint is used
+		http.Error(w, "VolumeMode: Block. Not supported downloading files.", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/files", "Block", newNoAuthSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() { util.PrepareDownloadFunc = origPrep; util.CreateDataExporterIfNeededFunc = origCreate }()
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport", "foo.txt", "-o", filepath.Join(t.TempDir(), "out.txt")})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestDownloadBlock_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/block", r.URL.Path)
+		w.Header().Set("Content-Length", "4")
+		w.WriteHeader(200)
+		w.Write([]byte("raw!"))
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/block", "Block", newNoAuthSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() {
+		util.PrepareDownloadFunc = origPrep
+		util.CreateDataExporterIfNeededFunc = origCreate
+	}()
+
+	outFile := filepath.Join(t.TempDir(), "raw.img")
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport", "-o", outFile})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.Execute())
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	require.Equal(t, []byte("raw!"), data)
+}
+
+func TestDownloadBlock_WrongEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "VolumeMode: Filesystem. Not supported downloading raw block.", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/block", "Filesystem", newNoAuthSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() { util.PrepareDownloadFunc = origPrep; util.CreateDataExporterIfNeededFunc = origCreate }()
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport", "-o", filepath.Join(t.TempDir(), "raw.img")})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.Execute())
+}

--- a/internal/dataexport/cmd/download/download_test.go
+++ b/internal/dataexport/cmd/download/download_test.go
@@ -1,0 +1,48 @@
+package download
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		wantDe    string
+		wantPath  string
+		wantError bool
+	}{
+		{
+			name:     "name only",
+			input:    []string{"my-export"},
+			wantDe:   "my-export",
+			wantPath: "/",
+		},
+		{
+			name:     "name and path",
+			input:    []string{"vd/mydisk", "file.txt"},
+			wantDe:   "vd/mydisk",
+			wantPath: "/file.txt",
+		},
+		{
+			name:      "too many args",
+			input:     []string{"a", "b", "c"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			de, path, err := parseArgs(tt.input)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDe, de)
+			require.Equal(t, tt.wantPath, path)
+		})
+	}
+}

--- a/internal/dataexport/cmd/list/list.go
+++ b/internal/dataexport/cmd/list/list.go
@@ -90,7 +90,7 @@ func downloadFunc(
 	sClient *safeClient.SafeClient,
 	foo func(body io.Reader) error,
 ) error {
-	url, volumeMode, subClient, err := util.PrepareDownload(ctx, log, deName, namespace, publish, sClient)
+	url, volumeMode, subClient, err := util.PrepareDownloadFunc(ctx, log, deName, namespace, publish, sClient)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func downloadFunc(
 		log.Info("Start listing", slog.String("url", url))
 		req, _ = http.NewRequest("HEAD", url, nil)
 	default:
-		return fmt.Errorf("%w: %s", util.UnsupportedVolumeModeErr, volumeMode)
+		return fmt.Errorf("%w: %s", util.ErrUnsupportedVolumeMode, volumeMode)
 	}
 
 	resp, err := subClient.HttpDo(req.WithContext(ctx))
@@ -140,7 +140,7 @@ func downloadFunc(
 	case "Filesystem":
 		return foo(resp.Body)
 	default:
-		return fmt.Errorf("%w: %s", util.UnsupportedVolumeModeErr, volumeMode)
+		return fmt.Errorf("%w: %s", util.ErrUnsupportedVolumeMode, volumeMode)
 	}
 }
 
@@ -168,7 +168,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
-	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, ttl, rtClient)
+	deName, err := util.CreateDataExporterIfNeededFunc(ctx, log, dataName, namespace, publish, ttl, rtClient)
 	if err != nil {
 		return err
 	}

--- a/internal/dataexport/cmd/list/list.go
+++ b/internal/dataexport/cmd/list/list.go
@@ -63,6 +63,7 @@ func NewCommand(ctx context.Context, log *slog.Logger) *cobra.Command {
 
 	cmd.Flags().StringP("namespace", "n", "d8-data-exporter", "data volume namespace")
 	cmd.Flags().Bool("publish", false, "Provide access outside of cluster")
+	cmd.Flags().String("ttl", "2m", "Time to live for auto-created DataExport")
 
 	return cmd
 }
@@ -149,6 +150,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 
 	namespace, _ := cmd.Flags().GetString("namespace")
 	publish, _ := cmd.Flags().GetBool("publish")
+	ttl, _ := cmd.Flags().GetString("ttl")
 
 	dataName, srcPath, err := parseArgs(args)
 	if err != nil {
@@ -166,7 +168,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
-	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, rtClient)
+	deName, err := util.CreateDataExporterIfNeeded(ctx, log, dataName, namespace, publish, ttl, rtClient)
 	if err != nil {
 		return err
 	}

--- a/internal/dataexport/cmd/list/list_http_test.go
+++ b/internal/dataexport/cmd/list/list_http_test.go
@@ -34,6 +34,8 @@ func TestListFilesystem_OK(t *testing.T) {
 	origPrep := util.PrepareDownloadFunc
 	origCreate := util.CreateDataExporterIfNeededFunc
 	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		// Re-enable support for unauthenticated requests inside unit tests.
+		safereq.SupportNoAuth = true
 		return srv.URL + "/api/v1/files", "Filesystem", newSafe(), nil
 	}
 	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
@@ -68,6 +70,8 @@ func TestListBlock_OK(t *testing.T) {
 	origPrep := util.PrepareDownloadFunc
 	origCreate := util.CreateDataExporterIfNeededFunc
 	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		// Re-enable support for unauthenticated requests inside unit tests.
+		safereq.SupportNoAuth = true
 		return srv.URL + "/api/v1/block", "Block", newSafe(), nil
 	}
 	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
@@ -89,7 +93,7 @@ func TestListBlock_OK(t *testing.T) {
 	io.Copy(&buf, r)
 	os.Stdout = oldStd
 
-	require.Contains(t, buf.String(), "Content-Length: 1234")
+	require.Contains(t, buf.String(), "Disk size:")
 }
 
 func TestListFilesystem_NotDir(t *testing.T) {
@@ -101,6 +105,8 @@ func TestListFilesystem_NotDir(t *testing.T) {
 	origPrep := util.PrepareDownloadFunc
 	origCreate := util.CreateDataExporterIfNeededFunc
 	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		// Re-enable support for unauthenticated requests inside unit tests.
+		safereq.SupportNoAuth = true
 		return srv.URL + "/api/v1/files", "Filesystem", newSafe(), nil
 	}
 	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {

--- a/internal/dataexport/cmd/list/list_http_test.go
+++ b/internal/dataexport/cmd/list/list_http_test.go
@@ -1,0 +1,117 @@
+package list
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"log/slog"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/internal/dataexport/util"
+	safereq "github.com/deckhouse/deckhouse-cli/pkg/libsaferequest/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newSafe() *safereq.SafeClient { sc, _ := safereq.NewSafeClient(); return sc.Copy() }
+
+func TestListFilesystem_OK(t *testing.T) {
+	// JSON listing for root dir
+	respBody := `{"apiVersion":"v1","items":[{"name":"file.txt","type":"file"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/files/", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(respBody))
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/files", "Filesystem", newSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() { util.PrepareDownloadFunc = origPrep; util.CreateDataExporterIfNeededFunc = origCreate }()
+
+	oldStd := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport", "/"})
+	require.NoError(t, cmd.Execute())
+
+	w.Close()
+	var bufOut bytes.Buffer
+	io.Copy(&bufOut, r)
+	os.Stdout = oldStd
+
+	require.Contains(t, bufOut.String(), "file.txt")
+}
+
+func TestListBlock_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodHead, r.Method)
+		w.Header().Set("Content-Length", "1234")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/block", "Block", newSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() { util.PrepareDownloadFunc = origPrep; util.CreateDataExporterIfNeededFunc = origCreate }()
+
+	// capture stdout because list writes to Stdout directly
+	oldStd := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetArgs([]string{"myexport"})
+	require.NoError(t, cmd.Execute())
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStd
+
+	require.Contains(t, buf.String(), "Content-Length: 1234")
+}
+
+func TestListFilesystem_NotDir(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not dir", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	origPrep := util.PrepareDownloadFunc
+	origCreate := util.CreateDataExporterIfNeededFunc
+	util.PrepareDownloadFunc = func(_ context.Context, _ *slog.Logger, _, _ string, _ bool, _ *safereq.SafeClient) (string, string, *safereq.SafeClient, error) {
+		return srv.URL + "/api/v1/files", "Filesystem", newSafe(), nil
+	}
+	util.CreateDataExporterIfNeededFunc = func(_ context.Context, _ *slog.Logger, de, _ string, _ bool, _ string, _ ctrlclient.Client) (string, error) {
+		return de, nil
+	}
+	defer func() { util.PrepareDownloadFunc = origPrep; util.CreateDataExporterIfNeededFunc = origCreate }()
+
+	cmd := NewCommand(context.TODO(), slog.Default())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"myexport", "some/invalid"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}

--- a/internal/dataexport/util/util.go
+++ b/internal/dataexport/util/util.go
@@ -339,11 +339,12 @@ func PrepareDownload(ctx context.Context, log *slog.Logger, deName, namespace st
 		return
 	}
 
-	subClient = sClient.Copy()
+	// Reuse the original SafeClient unless we need to inject additional CA.
+	subClient = sClient
 
-	if publish {
-		subClient.SetTLSCAData([]byte{})
-	} else if len(intrenalCAData) > 0 {
+	if !publish && len(intrenalCAData) > 0 {
+		// Create an isolated copy to avoid mutating the original client
+		subClient = sClient.Copy()
 		decodedBytes, err := base64.StdEncoding.DecodeString(intrenalCAData)
 		if err != nil {
 			finErr = fmt.Errorf("CA decoding error: %s", err.Error())

--- a/internal/dataexport/util/util.go
+++ b/internal/dataexport/util/util.go
@@ -46,7 +46,13 @@ const (
 )
 
 var (
-	UnsupportedVolumeModeErr = errors.New("invalid volume mode")
+	ErrUnsupportedVolumeMode = errors.New("invalid volume mode")
+)
+
+// Function pointers for test stubbing
+var (
+	PrepareDownloadFunc            = PrepareDownload
+	CreateDataExporterIfNeededFunc = CreateDataExporterIfNeeded
 )
 
 func GetDataExport(ctx context.Context, deName, namespace string, rtClient ctrlrtclient.Client) (*v1alpha1.DataExport, error) {
@@ -329,7 +335,7 @@ func PrepareDownload(ctx context.Context, log *slog.Logger, deName, namespace st
 			return
 		}
 	default:
-		finErr = fmt.Errorf("%w: '%s'", UnsupportedVolumeModeErr, volumeMode)
+		finErr = fmt.Errorf("%w: '%s'", ErrUnsupportedVolumeMode, volumeMode)
 		return
 	}
 

--- a/internal/dataexport/util/util_test.go
+++ b/internal/dataexport/util/util_test.go
@@ -1,0 +1,116 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/internal/dataexport/api/v1alpha1"
+
+	"log/slog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateDataExporterIfNeeded(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	logger := slog.Default()
+
+	tests := []struct {
+		name          string
+		input         string
+		expectName    string
+		expectKind    string
+		expectCreated bool
+	}{
+		{
+			name:          "PVC short alias",
+			input:         "pvc/myvol",
+			expectName:    "de-pvc-myvol",
+			expectKind:    PersistentVolumeClaimKind,
+			expectCreated: true,
+		},
+		{
+			name:          "PVC long alias",
+			input:         "persistentvolumeclaim/myvol",
+			expectName:    "de-pvc-myvol",
+			expectKind:    PersistentVolumeClaimKind,
+			expectCreated: true,
+		},
+		{
+			name:          "VolumeSnapshot short alias",
+			input:         "vs/snap1",
+			expectName:    "de-vs-snap1",
+			expectKind:    VolumeSnapshotKind,
+			expectCreated: true,
+		},
+		{
+			name:          "VolumeSnapshot long alias",
+			input:         "volumesnapshot/snap1",
+			expectName:    "de-vs-snap1",
+			expectKind:    VolumeSnapshotKind,
+			expectCreated: true,
+		},
+		{
+			name:          "Existing DataExport name",
+			input:         "my-export",
+			expectName:    "my-export",
+			expectCreated: false,
+		},
+		{
+			name:          "VirtualDisk short alias",
+			input:         "vd/mydisk",
+			expectName:    "de-vd-mydisk",
+			expectKind:    VirtualDiskKind,
+			expectCreated: true,
+		},
+		{
+			name:          "VirtualDisk long alias",
+			input:         "virtualdisk/mydisk",
+			expectName:    "de-vd-mydisk",
+			expectKind:    VirtualDiskKind,
+			expectCreated: true,
+		},
+		{
+			name:          "VirtualDiskSnapshot short alias",
+			input:         "vds/snap2",
+			expectName:    "de-vds-snap2",
+			expectKind:    VirtualDiskSnapshotKind,
+			expectCreated: true,
+		},
+		{
+			name:          "VirtualDiskSnapshot long alias",
+			input:         "virtualdisksnapshot/snap2",
+			expectName:    "de-vds-snap2",
+			expectKind:    VirtualDiskSnapshotKind,
+			expectCreated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			returnedName, err := CreateDataExporterIfNeeded(ctx, logger, tt.input, "test-ns", false, "2m", c)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectName, returnedName)
+
+			var de v1alpha1.DataExport
+			getErr := c.Get(ctx, ctrlclient.ObjectKey{Name: tt.expectName, Namespace: "test-ns"}, &de)
+			if tt.expectCreated {
+				require.NoError(t, getErr)
+				require.Equal(t, tt.expectKind, de.Spec.TargetRef.Kind)
+				require.Equal(t, "2m", de.Spec.Ttl)
+			} else {
+				require.True(t, apierrors.IsNotFound(getErr))
+			}
+		})
+	}
+}


### PR DESCRIPTION
What’s new  
• `d8 dataexport` now understands two new target kinds:  
  • `VirtualDisk` → prefix `vd/` or full `virtualdisk/`  
  • `VirtualDiskSnapshot` → prefix `vds/` or full `virtualdisksnapshot/`  


Usage examples
```bash
# Export the whole VirtualDisk
d8 data list vd/my-disk -n my-namespace

# Export a VirtualDiskSnapshot
d8 data download --publish vds/my-disk-snap 

# Explicit forms also work
d8 data list virtualdisk/my-disk/
d8 data download virtualdisksnapshot/my-disk-snap
```