### PR TITLE
[system] Add system queue list watch flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/deckhouse/virtualization/src/cli v0.0.0-20250617111832-70fdc2799bf3
+	github.com/fatih/color v1.17.0
 	github.com/google/go-containerregistry v0.20.0
 	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
@@ -107,6 +108,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 // indirect
 	github.com/aws/smithy-go v1.22.1 // indirect
 	github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -186,7 +188,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
-	github.com/fatih/color v1.17.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fluxcd/flagger v1.36.1 // indirect
@@ -374,6 +375,7 @@ require (
 	github.com/linode/linodego v0.7.1 // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/looplab/fsm v1.0.2 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/manifoldco/promptui v0.9.0 // indirect
@@ -416,6 +418,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/montanaflynn/stats v0.7.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a h1:eqjiAL3qooftPm8b9C1GsSSRcmlw7iOva8vdBTmV2PY=
 github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
+github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
+github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -1190,6 +1192,8 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/looplab/fsm v1.0.2 h1:f0kdMzr4CRpXtaKKRUxwLYJ7PirTdwrtNumeLN+mDx8=
 github.com/looplab/fsm v1.0.2/go.mod h1:PmD3fFvQEIsjMEfvZdrCDZ6y8VwKTwWNjlpEr6IKPO4=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.5.3/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1315,6 +1319,8 @@ github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY
 github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
+github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/internal/system/cmd/queue/flags/validation.go
+++ b/internal/system/cmd/queue/flags/validation.go
@@ -31,5 +31,11 @@ func ValidateParameters(cmd *cobra.Command, args []string) error {
 	if _, valid := allowedOutput[outputFormat]; !valid {
 		return fmt.Errorf("Please provide valid output: text, yaml, json. Got '%s', try --help\n", outputFormat)
 	}
+
+	watch, _ := cmd.Flags().GetBool("watch")
+	if watch && outputFormat != "text" {
+		return fmt.Errorf("Watch mode is only supported with text output format. Current format: %s", outputFormat)
+	}
+
 	return nil
 }

--- a/internal/system/cmd/queue/list/flags.go
+++ b/internal/system/cmd/queue/list/flags.go
@@ -27,4 +27,10 @@ func AddFlags(flagSet *pflag.FlagSet) {
 		false,
 		"Show empty queues.",
 	)
+	flagSet.BoolP(
+		"watch",
+		"w",
+		false,
+		"Watch for changes to the queue list.",
+	)
 }

--- a/internal/system/cmd/queue/list/list.go
+++ b/internal/system/cmd/queue/list/list.go
@@ -68,6 +68,11 @@ func listModule(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("Failed to show empty queues from flag: %w", err)
 	}
 
+	watch, err := cmd.Flags().GetBool("watch")
+	if err != nil {
+		return fmt.Errorf("Failed to get watch flag: %w", err)
+	}
+
 	format, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return fmt.Errorf("Failed to get output format: %w", err)
@@ -78,7 +83,7 @@ func listModule(cmd *cobra.Command, _ []string) error {
 		pathFromOption = pathFromOption + "?showEmpty=true"
 	}
 
-	err = operatequeue.OperateQueue(config, kubeCl, pathFromOption)
+	err = operatequeue.OperateQueue(config, kubeCl, pathFromOption, watch)
 	if err != nil {
 		return fmt.Errorf("Error list queues: %w", err)
 	}

--- a/internal/system/cmd/queue/mainqueue/mainqueue.go
+++ b/internal/system/cmd/queue/mainqueue/mainqueue.go
@@ -70,7 +70,7 @@ func mainQueue(cmd *cobra.Command, _ []string) error {
 
 	pathFromOption := "main." + format
 
-	err = operatequeue.OperateQueue(config, kubeCl, pathFromOption)
+	err = operatequeue.OperateQueue(config, kubeCl, pathFromOption, false)
 	if err != nil {
 		return fmt.Errorf("Error list main queue: %w", err)
 	}

--- a/internal/system/cmd/queue/operatequeue/operatequeue.go
+++ b/internal/system/cmd/queue/operatequeue/operatequeue.go
@@ -4,13 +4,27 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+	"github.com/muesli/termenv"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func OperateQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOption string) error {
+func OperateQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOption string, watch bool) error {
+	if !watch {
+		return executeQueueCommand(config, kubeCl, pathFromOption)
+	}
+
+	return watchQueueCommand(config, kubeCl, pathFromOption)
+}
+
+func executeQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOption string) error {
 	const (
 		apiProtocol = "http"
 		apiEndpoint = "127.0.0.1"
@@ -25,7 +39,13 @@ func OperateQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOpt
 	fullEndpointUrl := fmt.Sprintf("%s://%s:%s/%s/%s", apiProtocol, apiEndpoint, apiPort, queuePath, pathFromOption)
 	getApi := []string{"curl", fullEndpointUrl}
 	podName, err := utilk8s.GetDeckhousePod(kubeCl)
+	if err != nil {
+		return err
+	}
 	executor, err := utilk8s.ExecInPod(config, kubeCl, getApi, podName, namespace, containerName)
+	if err != nil {
+		return err
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -39,5 +59,34 @@ func OperateQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOpt
 	}
 
 	fmt.Printf("%s\n", stdout.String())
-	return err
+	return nil
+}
+
+func watchQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOption string) error {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	output := termenv.DefaultOutput()
+
+	fmt.Println("Watching queue (press Ctrl+C to stop)...")
+
+	for {
+		select {
+		case <-signals:
+			fmt.Println("\nWatch stopped.")
+			return nil
+		case <-ticker.C:
+			output.ClearScreen()
+			output.MoveCursor(1, 1)
+			fmt.Printf("Watching queue - %s\n\n", time.Now().Format("15:04:05"))
+
+			err := executeQueueCommand(config, kubeCl, pathFromOption)
+			if err != nil {
+				fmt.Printf("Error fetching queue: %v\n", err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Description

Implements real-time queue monitoring functionality for the d8 system queue list command using the --watch/-w flag. The implementation replaces legacy system-dependent screen clearing with modern cross-platform terminal control using the termenv library.

### Features

- Real-time monitoring: Watch queue changes with automatic updates every second
- Graceful shutdown: Clean exit with Ctrl+C signal handling
- Backward compatibility: Existing commands work unchanged

### Core Changes

- Added --watch/-w flag support
- Refactored queue operations
- Modern terminal handling

### Usage Examples

```bash
# View queues once (existing behavior)
d8 system queue list

# Watch queues in real-time (new feature)
d8 system queue list --watch
d8 system queue list -w

# Watch with other options
d8 system queue list --watch --output text
d8 system queue list -w --show-empty
```
