### PR TITLE
[deckhouse-cli] add d8 mirror lts channel support

### DIFF
--- a/internal/mirror/operations/utils.go
+++ b/internal/mirror/operations/utils.go
@@ -6,4 +6,5 @@ var Channels = []string{
 	"early-access",
 	"stable",
 	"rock-solid",
+	"lts",
 }

--- a/internal/mirror/releases/versions.go
+++ b/internal/mirror/releases/versions.go
@@ -33,7 +33,7 @@ import (
 )
 
 func VersionsToMirror(pullParams *params.PullParams) ([]semver.Version, error) {
-	releaseChannelsToCopy := []string{"alpha", "beta", "early-access", "stable", "rock-solid"}
+	releaseChannelsToCopy := []string{"alpha", "beta", "early-access", "stable", "rock-solid", "lts"}
 	releaseChannelsVersions := make([]*semver.Version, len(releaseChannelsToCopy))
 	for i, channel := range releaseChannelsToCopy {
 		v, err := getReleaseChannelVersionFromRegistry(pullParams, channel)

--- a/pkg/libmirror/modules/modules.go
+++ b/pkg/libmirror/modules/modules.go
@@ -172,6 +172,7 @@ func getAvailableReleaseChannelsImagesForModule(mod *Module, refOpts []name.Opti
 		releasesRegistryPath + ":early-access",
 		releasesRegistryPath + ":stable",
 		releasesRegistryPath + ":rock-solid",
+		releasesRegistryPath + ":lts",
 	} {
 		imageRef, err := name.ParseReference(imageTag, refOpts...)
 		if err != nil {


### PR DESCRIPTION
### Description

Fixes missing LTS (Long Term Support) channel support in d8 mirror operations. The system was not discovering or pulling LTS release channels, causing incomplete module mirroring.

### Previous problem

The d8 mirror tool was not discovering and pulling LTS (Long Term Support) release channels when mirroring Deckhouse modules. This was causing the system to skip LTS channels entirely, preventing users from mirroring LTS releases.

### Testing

#### Test registry structure:
```
localhost:6002/deckhouse/ce/modules:test-lts-module
localhost:6002/deckhouse/ce/modules/test-lts-module:v1.0.0  
localhost:6002/deckhouse/ce/modules/test-lts-module/release:alpha
localhost:6002/deckhouse/ce/modules/test-lts-module/release:beta
localhost:6002/deckhouse/ce/modules/test-lts-module/release:early-access
localhost:6002/deckhouse/ce/modules/test-lts-module/release:stable
localhost:6002/deckhouse/ce/modules/test-lts-module/release:rock-solid
localhost:6002/deckhouse/ce/modules/test-lts-module/release:lts ✅
localhost:6002/deckhouse/ce/modules/test-lts-module/release:v1.0.0
```

#### Verification with crane
```bash
$ crane ls localhost:6002/deckhouse/ce/modules/test-lts-module/release --insecure
alpha
beta
early-access
lts     ✅
rock-solid
stable
v1.0.0
```

#### Test Execution

```bash
>> ./bin/d8 mirror pull test-lts-final \
  --source localhost:6002/deckhouse/ce \
  --include-module test-lts-module \
  --no-platform \
  --no-security-db \
  --insecure
```

#### Test Results

```bash
INFO ║║ test-lts-module release channels
INFO ║║ [1 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:beta 
INFO ║║ [2 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:early-access 
INFO ║║ [3 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:stable 
INFO ║║ [4 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:rock-solid 
INFO ║║ [5 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:lts ✅
INFO ║║ [6 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:v1.0.0 
INFO ║║ [7 / 7] Pulling localhost:6002/deckhouse/ce/modules/test-lts-module/release:alpha 
INFO ║║ Deckhouse modules pulled!
```
