### PR TITLE
[deckhouse-cli] incorrect push operation for extra images

### DIFF
--- a/pkg/libmirror/layouts/pull.go
+++ b/pkg/libmirror/layouts/pull.go
@@ -193,7 +193,7 @@ func PullImageSet(
 
 	pullCount, totalCount := 1, len(imageSet)
 	for imageReferenceString := range imageSet {
-		imageRepo, imageTag := splitImageRefByRepoAndTag(imageReferenceString)
+		imageRepo, _ := splitImageRefByRepoAndTag(imageReferenceString)
 
 		// If we already know the digest of the tagged image, we should pull it by this digest instead of pulling by tag
 		// to avoid race-conditions between mirroring and releasing new builds on release channels.
@@ -227,7 +227,7 @@ func PullImageSet(
 					layout.WithPlatform(v1.Platform{Architecture: "amd64", OS: "linux"}),
 					layout.WithAnnotations(map[string]string{
 						"org.opencontainers.image.ref.name": imageReferenceString,
-						"io.deckhouse.image.short_tag":      imageTag,
+						"io.deckhouse.image.short_tag":      extractExtraImageShortTag(imageReferenceString),
 					}),
 				)
 				if err != nil {
@@ -249,6 +249,20 @@ func splitImageRefByRepoAndTag(imageReferenceString string) (repo, tag string) {
 	repo = imageReferenceString[:splitIndex]
 	tag = imageReferenceString[splitIndex+1:]
 	return
+}
+
+// extractExtraImageShortTag extracts the image name and tag for extra images
+func extractExtraImageShortTag(imageReferenceString string) string {
+	const extraPrefix = "/extra/"
+
+	if extraIndex := strings.LastIndex(imageReferenceString, extraPrefix); extraIndex != -1 {
+		// Extra image: return "imageName:tag" part after "/extra/"
+		return imageReferenceString[extraIndex+len(extraPrefix):]
+	}
+
+	// Regular image: return just the tag
+	_, tag := splitImageRefByRepoAndTag(imageReferenceString)
+	return tag
 }
 
 type pullImageSetOptions struct {

--- a/pkg/libmirror/layouts/push.go
+++ b/pkg/libmirror/layouts/push.go
@@ -19,6 +19,7 @@ package layouts
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,6 +59,21 @@ func PushLayoutToRepo(
 	)
 }
 
+// buildExtraImageRef builds the correct image reference for extra images
+func buildExtraImageRef(registryRepo, tag string) string {
+	if strings.Contains(registryRepo, "/extra") && strings.Contains(tag, ":") {
+		// This is an extra image with format "imageName:tag"
+		// Split tag into image name and actual tag
+		parts := strings.SplitN(tag, ":", 2)
+		if len(parts) == 2 {
+			imageName, imageTag := parts[0], parts[1]
+			return registryRepo + "/" + imageName + ":" + imageTag
+		}
+	}
+	// Regular image or fallback
+	return registryRepo + ":" + tag
+}
+
 func PushLayoutToRepoContext(
 	ctx context.Context,
 	imagesLayout layout.Path,
@@ -91,7 +107,7 @@ func PushLayoutToRepoContext(
 	for _, manifestSet := range batches {
 		if parallelismConfig.Images == 1 {
 			tag := manifestSet[0].Annotations["io.deckhouse.image.short_tag"]
-			imageRef := registryRepo + ":" + tag
+			imageRef := buildExtraImageRef(registryRepo, tag)
 			logger.InfoF("[%d / %d] Pushing image %s", imagesCount, len(indexManifest.Manifests), imageRef)
 			if err = pushImage(ctx, registryRepo, index, manifestSet[0], refOpts, remoteOpts); err != nil {
 				return fmt.Errorf("Push Image: %w", err)
@@ -103,7 +119,8 @@ func PushLayoutToRepoContext(
 		err = logger.Process(fmt.Sprintf("Pushing batch %d / %d", batchesCount, len(batches)), func() error {
 			logger.InfoLn("Images in batch:")
 			for _, manifest := range manifestSet {
-				logger.InfoF("- %s", registryRepo+":"+manifest.Annotations["io.deckhouse.image.short_tag"])
+				tag := manifest.Annotations["io.deckhouse.image.short_tag"]
+				logger.InfoF("- %s", buildExtraImageRef(registryRepo, tag))
 			}
 
 			errMu := &sync.Mutex{}
@@ -137,7 +154,7 @@ func pushImage(
 	remoteOpts []remote.Option,
 ) error {
 	tag := manifest.Annotations["io.deckhouse.image.short_tag"]
-	imageRef := registryRepo + ":" + tag
+	imageRef := buildExtraImageRef(registryRepo, tag)
 	img, err := index.Image(manifest.Digest)
 	if err != nil {
 		return fmt.Errorf("Read image: %v", err)


### PR DESCRIPTION
## Problem

When executing `d8 mirror push` for modules with extra images, images were being pushed to incorrect registry paths:
- **Expected**: `registry/deckhouse/ee/modules/neuvector/extra/scanner:3`
- **Actual**: `registry/deckhouse/ee/modules/neuvector/extra:3`

The issue manifested as missing image name in the path, causing push operations to fail or create incorrect registry structure.

## Root Cause

The problem occurred in the interaction between pull and push phases.

## Solution

Improve pull and push mechanisms by adding proper handling for image and tag names in the URL path.

## Testing on dev registry

### Pull Operation
```bash
./bin/d8 mirror pull test-dev-neuvector-extra \
  --source dev-registry.deckhouse.io/sys/deckhouse-oss \
  --include-module neuvector \
  --only-extra-images \
  --no-platform \
  --no-security-db
```

### Result
```bash
[1 / 1] Pulling dev-registry.deckhouse.io/sys/deckhouse-oss/modules/neuvector/extra/scanner:3
Extra images pulled!
Pull Extra Images succeeded in 9m39.751801s
```

### Push Operation
```bash
./bin/d8 mirror push test-dev-neuvector-extra localhost:6001/deckhouse/test --insecure
```

### Result
```
[1 / 1] Pushing image localhost:6001/deckhouse/test/modules/neuvector/extra/scanner:3
Push module: neuvector succeeded in 1.003924958s
```
