### PR TITLE
[deckhouse-cli] fix: Plugins fallback to use homedir

### DIFF
--- a/cmd/plugins/plugin.go
+++ b/cmd/plugins/plugin.go
@@ -106,7 +106,7 @@ func NewPluginCommand(commandName string, description string, aliases []string, 
 				return
 			}
 
-			logger.Info("Executing plugin", slog.Any("args", args))
+			logger.Debug("Executing plugin", slog.Any("args", args))
 
 			command := exec.CommandContext(cmd.Context(), absPath, args...)
 			command.Stdout = os.Stdout

--- a/cmd/plugins/plugins.go
+++ b/cmd/plugins/plugins.go
@@ -85,13 +85,13 @@ func NewCommand(logger *dkplog.Logger) *cobra.Command {
 			if errors.Is(err, os.ErrPermission) {
 				pc.logger.Warn("use homedir instead of default d8 plugins path in '/opt/deckhouse/lib/deckhouse-cli'", slog.String("new_path", flags.DeckhousePluginsDir), dkplog.Err(err))
 
-				flags.DeckhousePluginsDir, err = os.UserHomeDir()
+				newPluginDirectory, err := os.UserHomeDir()
 				if err != nil {
 					logger.Warn("failed to receive home dir to create plugins dir", slog.String("error", err.Error()))
 					return
 				}
 
-				flags.DeckhousePluginsDir = path.Join(flags.DeckhousePluginsDir, ".deckhouse-cli")
+				pc.pluginDirectory = path.Join(newPluginDirectory, ".deckhouse-cli")
 			}
 		},
 	}

--- a/pkg/registry/service/plugin_service.go
+++ b/pkg/registry/service/plugin_service.go
@@ -81,15 +81,13 @@ func (s *PluginService) GetPluginContract(ctx context.Context, pluginName, tag s
 			return nil, fmt.Errorf("no manifests found in index manifest")
 		}
 
-		// hardcoded first
+		// hardcoded first manifest (all contracts must be the same for all manifests)
 		digest := indexManifest.GetManifests()[0].GetDigest()
 		if digest.String() == "" {
 			return nil, fmt.Errorf("no digest found in manifest")
 		}
 
-		digestClient := pluginClient.WithSegment("meta")
-
-		digestManifestResult, err = digestClient.GetManifest(ctx, "@"+digest.String())
+		digestManifestResult, err = pluginClient.GetManifest(ctx, "@"+digest.String())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get manifest: %w", err)
 		}


### PR DESCRIPTION
### Changes made
- Fixed plugins bug when no permissions to /opt/deckhouse and plugins command won't fallback to use user homedir instead.
- Plugins manifests are no longer use /meta in registry
- Switched log to debug:
- - `  {"level":"info","logger":"d8.package-command","msg":"Executing plugin","args":["build","-v","v0.0.1"],"time":"2025-12-26T09:45:39Z"}`

- [x] Manually tested