### PR TITLE
fix(data): patch publish before waiting Data{Export,Import} 

### DIFF
--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -241,9 +241,10 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 	var podURL, volumeMode, internalCAData string
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
-	deObj, err := GetDataExport(ctx, deName, namespace, rtClient)
+	deObj := &v1alpha1.DataExport{}
+	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: deName}, deObj)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("kube Get dataExport: %s", err.Error())
 	}
 
 	// Patch Spec.Publish if the resolved value differs from what the object has.

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -244,7 +244,7 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 	deObj := &v1alpha1.DataExport{}
 	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: deName}, deObj)
 	if err != nil {
-		return "", "", "", fmt.Errorf("kube Get dataExport: %s", err.Error())
+		return "", "", "", fmt.Errorf("failed to get dataExport: %w", err)
 	}
 
 	// Patch Spec.Publish if the resolved value differs from what the object has.

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -241,7 +241,7 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 	var podURL, volumeMode, internalCAData string
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
-	deObj := &v1alpha1.DataExport{}
+	deObj := new(v1alpha1.DataExport)
 	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: deName}, deObj)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to get dataExport: %w", err)

--- a/internal/data/dataimport/util/util.go
+++ b/internal/data/dataimport/util/util.go
@@ -189,9 +189,10 @@ func PrepareUpload(
 	}
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
-	diObj, err := GetDataImport(ctx, diName, namespace, rtClient)
+	diObj := &v1alpha1.DataImport{}
+	err = rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: diName}, diObj)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, fmt.Errorf("kube Get dataimport: %s", err.Error())
 	}
 
 	// Patch Spec.Publish if the resolved value differs from what the object has.

--- a/internal/data/dataimport/util/util.go
+++ b/internal/data/dataimport/util/util.go
@@ -192,7 +192,7 @@ func PrepareUpload(
 	diObj := &v1alpha1.DataImport{}
 	err = rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: diName}, diObj)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("kube Get dataimport: %s", err.Error())
+		return "", "", nil, fmt.Errorf("failed to get dataImport: %w", err)
 	}
 
 	// Patch Spec.Publish if the resolved value differs from what the object has.

--- a/internal/data/dataimport/util/util.go
+++ b/internal/data/dataimport/util/util.go
@@ -189,7 +189,7 @@ func PrepareUpload(
 	}
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
-	diObj := &v1alpha1.DataImport{}
+	diObj := new(v1alpha1.DataImport)
 	err = rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: diName}, diObj)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to get dataImport: %w", err)


### PR DESCRIPTION
# Description

## Problem
d8 data export download/list and d8 data import upload could fail too early with NotReady because readiness was checked before the new publish-patch flow reached the retry wait loop.

## Solution
Load DataExport/DataImport objects without fail-fast readiness validation, patch spec.publish when needed, then wait for readiness using existing retry logic. This preserves publish reconciliation and restores expected wait behavior for resources in Pending/NotReady states.

## Before fix
<img width="1300" height="617" alt="image" src="https://github.com/user-attachments/assets/69f5815b-f193-4796-ab5a-7eb22750987f" />

## After fix
<img width="1300" height="617" alt="image" src="https://github.com/user-attachments/assets/0aa3fd71-47c7-4e41-9ef1-f0dda968bdfa" />
