### PR TITLE
Refactor: Move CNI migration commands to network group

### DIFF
--- a/cmd/d8/root.go
+++ b/cmd/d8/root.go
@@ -42,6 +42,7 @@ import (
 	backup "github.com/deckhouse/deckhouse-cli/internal/backup/cmd"
 	data "github.com/deckhouse/deckhouse-cli/internal/data/cmd"
 	mirror "github.com/deckhouse/deckhouse-cli/internal/mirror/cmd"
+	"github.com/deckhouse/deckhouse-cli/internal/network"
 	status "github.com/deckhouse/deckhouse-cli/internal/status/cmd"
 	system "github.com/deckhouse/deckhouse-cli/internal/system/cmd"
 	"github.com/deckhouse/deckhouse-cli/internal/tools"
@@ -106,6 +107,7 @@ func (r *RootCommand) registerCommands() {
 	r.cmd.AddCommand(mirror.NewCommand())
 	r.cmd.AddCommand(status.NewCommand())
 	r.cmd.AddCommand(useroperation.NewCommand())
+	r.cmd.AddCommand(network.NewCommand())
 	r.cmd.AddCommand(tools.NewCommand())
 	r.cmd.AddCommand(commands.NewVirtualizationCommand())
 	r.cmd.AddCommand(commands.NewKubectlCommand())

--- a/internal/cni/common.go
+++ b/internal/cni/common.go
@@ -92,7 +92,7 @@ func FindActiveMigration(ctx context.Context, rtClient client.Client) (*v1alpha1
 	if len(migrationList.Items) > 1 {
 		return nil, fmt.Errorf(
 			"found %d CNI migration objects, which is an inconsistent state. "+
-				"Please run 'd8 tools cni-migration cleanup' to resolve this",
+				"Please run 'd8 network cni-migration cleanup' to resolve this",
 			len(migrationList.Items),
 		)
 	}

--- a/internal/cni/switch.go
+++ b/internal/cni/switch.go
@@ -60,7 +60,7 @@ func RunSwitch(targetCNI string) error {
 	}
 	if existingMigration != nil {
 		return fmt.Errorf("a CNI migration (%s) is already in progress. "+
-			"Please use 'd8 tools cni-migration watch' to monitor it or 'd8 tools cni-migration cleanup' to abort it",
+			"Please use 'd8 network cni-migration watch' to monitor it or 'd8 network cni-migration cleanup' to abort it",
 			existingMigration.Name)
 	}
 

--- a/internal/network/cnimigration/cmd/cni.go
+++ b/internal/network/cnimigration/cmd/cni.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/network/cnimigration/cmd/cni.go
+++ b/internal/network/cnimigration/cmd/cni.go
@@ -39,26 +39,26 @@ This CLI tool is used to trigger the migration and monitor its status.
 
 Workflow:
 
-  1. 'd8 tools cni-migration switch --to-cni <CNI>' - Initiates the migration.
+  1. 'd8 network cni-migration switch --to-cni <CNI>' - Initiates the migration.
      This creates a CNIMigration resource, which triggers the deployment of the migration agent.
      The agent then performs all necessary steps (validation, node checks, CNI switching).
 
-  2. 'd8 tools cni-migration watch' - (Optional) Monitors the progress of the migration.
+  2. 'd8 network cni-migration watch' - (Optional) Monitors the progress of the migration.
      Since the process is automated, this command simply watches the status.
 
-  3. 'd8 tools cni-migration cleanup' - Cleans up the migration resources after completion.`
+  3. 'd8 network cni-migration cleanup' - Cleans up the migration resources after completion.`
 
 	cniSwitchExample = templates.Examples(`
 		# Start the migration to Cilium CNI
-		d8 tools cni-migration switch --to-cni cilium`)
+		d8 network cni-migration switch --to-cni cilium`)
 
 	cniWatchExample = templates.Examples(`
 		# Monitor the ongoing migration
-		d8 tools cni-migration watch`)
+		d8 network cni-migration watch`)
 
 	cniCleanupExample = templates.Examples(`
 		# Cleanup resources created by the 'switch' command
-		d8 tools cni-migration cleanup`)
+		d8 network cni-migration cleanup`)
 
 	supportedCNIs = []string{"cilium", "flannel", "simple-bridge"}
 )

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	cnimigration "github.com/deckhouse/deckhouse-cli/internal/network/cnimigration/cmd"
+)
+
+var networkLong = templates.LongDesc(`
+A group of commands to operate network related tasks in The Deckhouse Ecosystem.
+
+© Flant JSC 2025`)
+
+func NewCommand() *cobra.Command {
+	networkCmd := &cobra.Command{
+		Use:     "network",
+		Short:   "A group of commands to operate network related tasks in The Deckhouse Ecosystem.",
+		Aliases: []string{"n"},
+		Long:    networkLong,
+	}
+
+	networkCmd.AddCommand(
+		cnimigration.NewCommand(),
+	)
+
+	return networkCmd
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	cnimigration "github.com/deckhouse/deckhouse-cli/internal/tools/cnimigration/cmd"
 	farconverter "github.com/deckhouse/deckhouse-cli/internal/tools/farconverter/cmd"
 	gostsum "github.com/deckhouse/deckhouse-cli/internal/tools/gostsum/cmd"
 	imagedigest "github.com/deckhouse/deckhouse-cli/internal/tools/imagedigest/cmd"
@@ -41,7 +40,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	toolsCmd.AddCommand(
-		cnimigration.NewCommand(),
 		farconverter.NewCommand(),
 		gostsum.NewCommand(),
 		imagedigest.NewCommand(),


### PR DESCRIPTION
The CNI migration commands have been moved from the `tools` group to a new `network` group. This change improves the organization of the CLI by placing network-related functionalities together. The CNI migration commands can now be accessed via `d8 network cni-migration ...` instead of `d8 tools cni-migration ...`.