### PR TITLE
fix(virtualization): mute warnings about home directory

### DIFF
--- a/cmd/commands/virtualization.go
+++ b/cmd/commands/virtualization.go
@@ -28,7 +28,7 @@ import (
 
 func NewVirtualizationCommand() *cobra.Command {
 	virtualizationCmd := command.NewCommand(fmt.Sprintf("%s v", filepath.Base(os.Args[0])))
-	virtualizationCmd.Use = "v"
+	virtualizationCmd.Use = "v [command] [args...]"
 	virtualizationCmd.Aliases = []string{"virtualization"}
 
 	return virtualizationCmd

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/deckhouse/deckhouse/pkg/log v0.2.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260326143935-b535ad6cb730
-	github.com/deckhouse/virtualization/src/cli v1.5.1
+	github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d //  fix/cli/mute-warnings-during-cobra-init-release-1-6-2 (Change to tagged version after migrating d8 cli to Go 1.25)
 	github.com/fatih/color v1.18.0
 	github.com/fluxcd/flagger v1.36.1
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/deckhouse/deckhouse/go_lib/controlplane v0.0.0-20260521055926-efd0886cc5da
 	github.com/deckhouse/deckhouse/pkg/log v0.2.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260414112803-53a5662881d9
-	github.com/deckhouse/virtualization/src/cli v1.5.1
+	github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d //  fix/cli/mute-warnings-during-cobra-init-release-1-6-2 (Change to version 1.8.0 after updating Kubernetes to 0.34)
 	github.com/fatih/color v1.18.0
 	github.com/fluxcd/flagger v1.36.1
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ github.com/deckhouse/delivery-kit/v2 v2.63.1-dk h1:1YDVwEJMoEfiNGdEuiuXIfyJ3Ux8e
 github.com/deckhouse/delivery-kit/v2 v2.63.1-dk/go.mod h1:bwoZNyZ/EmE8HOT2mNsqmnM+l/WAJRUG002iBH0yfBk=
 github.com/deckhouse/virtualization/api v1.5.1 h1:9I0mn4xyrNWfElm0BRTAFpuTc4gFK6Qww61MAsT4KR8=
 github.com/deckhouse/virtualization/api v1.5.1/go.mod h1:hC9CVWrE7umq9qsYKYkbLl8gQ2XO2B+RtBNChFLfhpE=
-github.com/deckhouse/virtualization/src/cli v1.5.1 h1:VEGz7oNxQD4n/ej57OWZW/O1VNlYGwgI3GeROoiqz+w=
-github.com/deckhouse/virtualization/src/cli v1.5.1/go.mod h1:BIXWNx7Sz6rtjT6Ln+p3gBdjindz5/wEsxbkwKqA0Og=
+github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d h1:zDGHNhF+iGDPViRYQPf2iA6W/OQRPoZHAKw7+loYeEw=
+github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d/go.mod h1:BIXWNx7Sz6rtjT6Ln+p3gBdjindz5/wEsxbkwKqA0Og=
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.12.2 h1:1OcPn5GBIobjWNd+8yjfHNIaFX14B1pWI3F9HZy5KXw=
 github.com/denisenkom/go-mssqldb v0.12.2/go.mod h1:lnIw1mZukFRZDJYQ0Pb833QS2IaC3l5HkEfra2LJ+sk=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/deckhouse/delivery-kit/v2 v2.68.0-dk h1:GKdmQgImUfeO6QkiIojXI4kgjPSUa
 github.com/deckhouse/delivery-kit/v2 v2.68.0-dk/go.mod h1:03Dl+3vFV1sMJLVjME9Ru0+iLN2zVpaMFp6vsdpI6/U=
 github.com/deckhouse/virtualization/api v1.5.1 h1:9I0mn4xyrNWfElm0BRTAFpuTc4gFK6Qww61MAsT4KR8=
 github.com/deckhouse/virtualization/api v1.5.1/go.mod h1:hC9CVWrE7umq9qsYKYkbLl8gQ2XO2B+RtBNChFLfhpE=
-github.com/deckhouse/virtualization/src/cli v1.5.1 h1:VEGz7oNxQD4n/ej57OWZW/O1VNlYGwgI3GeROoiqz+w=
-github.com/deckhouse/virtualization/src/cli v1.5.1/go.mod h1:BIXWNx7Sz6rtjT6Ln+p3gBdjindz5/wEsxbkwKqA0Og=
+github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d h1:zDGHNhF+iGDPViRYQPf2iA6W/OQRPoZHAKw7+loYeEw=
+github.com/deckhouse/virtualization/src/cli v0.0.0-20260411164351-43c8e331b69d/go.mod h1:BIXWNx7Sz6rtjT6Ln+p3gBdjindz5/wEsxbkwKqA0Og=
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.12.2 h1:1OcPn5GBIobjWNd+8yjfHNIaFX14B1pWI3F9HZy5KXw=
 github.com/denisenkom/go-mssqldb v0.12.2/go.mod h1:lnIw1mZukFRZDJYQ0Pb833QS2IaC3l5HkEfra2LJ+sk=


### PR DESCRIPTION
Note:
fix in virtualization repo is branched from release-1.6 to be compatible with dependencies in go.mod here.

Note 2:
Change github.com/deckhouse/virtualization/src/cli version to tag after migrating d8 cli to Go 1.25. See https://github.com/deckhouse/virtualization/pull/2204.


Before:

```
# HOME= d8 help
W0411 17:35:50.840692 1639809 ssh.go:67] failed to determine user home directory: $HOME is not defined
W0411 17:35:50.840724 1639809 ssh.go:67] failed to determine user home directory: $HOME is not defined
d8 controls the Deckhouse Kubernetes Platform

Usage:
  d8 [flags]
  d8 [command]
```

After:

```
# HOME= d8 help
d8 controls the Deckhouse Kubernetes Platform

Usage:
  d8 [flags]
  d8 [command]
Before:
```
