### PR TITLE
[deckhouse-cli] Skip database pulling when they don't exist

### DIFF
--- a/internal/mirror/security/security.go
+++ b/internal/mirror/security/security.go
@@ -103,37 +103,39 @@ func NewService(
 // PullSecurity pulls the security databases
 // It validates access to the registry and pulls the security database images
 func (svc *Service) PullSecurity(ctx context.Context) error {
-	err := svc.validateSecurityAccess(ctx)
+	available, err := svc.securityDatabasesAvailable(ctx)
 	if err != nil {
-		return fmt.Errorf("validate security access: %w", err)
+		return fmt.Errorf("check security databases availability: %w", err)
 	}
 
-	err = svc.pullSecurityDatabases(ctx)
-	if err != nil {
+	if !available {
+		return nil
+	}
+
+	if err := svc.pullSecurityDatabases(ctx); err != nil {
 		return fmt.Errorf("pull security databases: %w", err)
 	}
 
 	return nil
 }
 
-// validateSecurityAccess validates access to the security registry
-// It checks if the security database image exists in the source registry
-func (svc *Service) validateSecurityAccess(ctx context.Context) error {
-	svc.logger.Debug("Validating access to the security registry")
+// securityDatabasesAvailable checks if security database images exist in the source registry.
+// Returns false for editions that do not include security databases (e.g. CE, BE, SE).
+func (svc *Service) securityDatabasesAvailable(ctx context.Context) (bool, error) {
+	svc.logger.Debug("Checking if security databases are available in registry")
 
-	// For specific tags, check if the tag exists
 	err := svc.securityService.Security(internal.SecurityTrivyDBSegment).CheckImageExists(ctx, "2")
 	if errors.Is(err, client.ErrImageNotFound) {
-		svc.userLogger.Warnf("Skipping pull of security databases: %v", err)
+		svc.userLogger.WarnLn("Security databases are not available in this edition, skipping")
 
-		return nil
+		return false, nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to check security database tag %q in registry: %w", "2", err)
+		return false, fmt.Errorf("failed to check security database tag %q in registry: %w", "2", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 func (svc *Service) pullSecurityDatabases(ctx context.Context) error {

--- a/internal/mirror/security/security_test.go
+++ b/internal/mirror/security/security_test.go
@@ -32,11 +32,11 @@ func newTestSecurityService(
 	}
 }
 
-func TestService_validateSecurityAccess(t *testing.T) {
+func TestService_securityDatabasesAvailable(t *testing.T) {
 	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
 	userLogger := log.NewSLogger(slog.LevelWarn)
 
-	t.Run("trivy-db tag 2 exists – no error", func(t *testing.T) {
+	t.Run("trivy-db tag 2 exists – available", func(t *testing.T) {
 		reg := upfake.NewRegistry("registry.example.com")
 		trivyImg := upfake.NewImageBuilder().MustBuild()
 		reg.MustAddImage("security/trivy-db", "2", trivyImg)
@@ -46,25 +46,27 @@ func TestService_validateSecurityAccess(t *testing.T) {
 		securityService := registryservice.NewSecurityServices("security", securityClient, logger)
 
 		svc := newTestSecurityService(securityService, logger, userLogger)
-		err := svc.validateSecurityAccess(context.Background())
+		available, err := svc.securityDatabasesAvailable(context.Background())
 		require.NoError(t, err)
+		require.True(t, available)
 	})
 
-	t.Run("trivy-db tag 2 absent – no error (graceful skip)", func(t *testing.T) {
+	t.Run("trivy-db tag 2 absent – not available (graceful skip)", func(t *testing.T) {
 		reg := upfake.NewRegistry("registry.example.com")
 		stubClient := pkgclient.Adapt(upfake.NewClient(reg))
 		securityClient := stubClient.WithSegment("security")
 		securityService := registryservice.NewSecurityServices("security", securityClient, logger)
 
 		svc := newTestSecurityService(securityService, logger, userLogger)
-		err := svc.validateSecurityAccess(context.Background())
+		available, err := svc.securityDatabasesAvailable(context.Background())
 		require.NoError(t, err)
+		require.False(t, available)
 	})
 }
 
-// TestService_validateSecurityAccess_MultipleDatabases verifies that when all
-// security databases are present the service reports no error.
-func TestService_validateSecurityAccess_MultipleDatabases(t *testing.T) {
+// TestService_securityDatabasesAvailable_MultipleDatabases verifies that when all
+// security databases are present the service reports available.
+func TestService_securityDatabasesAvailable_MultipleDatabases(t *testing.T) {
 	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
 	userLogger := log.NewSLogger(slog.LevelWarn)
 
@@ -85,25 +87,26 @@ func TestService_validateSecurityAccess_MultipleDatabases(t *testing.T) {
 	securityService := registryservice.NewSecurityServices("security", securityClient, logger)
 
 	svc := newTestSecurityService(securityService, logger, userLogger)
-	err := svc.validateSecurityAccess(context.Background())
+	available, err := svc.securityDatabasesAvailable(context.Background())
 	require.NoError(t, err)
+	require.True(t, available)
 }
 
-// TestService_validateSecurityAccess_PerDatabase exercises validateSecurityAccess
-// for each known security database variant. Only trivy-db is checked during
-// access validation; the others are handled with AllowMissingTags in the puller.
-func TestService_validateSecurityAccess_PerDatabase(t *testing.T) {
+// TestService_securityDatabasesAvailable_PerDatabase exercises securityDatabasesAvailable
+// for each known security database variant. Only trivy-db:2 is checked during
+// the availability check; the others are handled with AllowMissingTags in the puller.
+func TestService_securityDatabasesAvailable_PerDatabase(t *testing.T) {
 	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
 	userLogger := log.NewSLogger(slog.LevelWarn)
 
 	databases := []struct {
-		segment string
-		wantErr bool
+		segment       string
+		wantAvailable bool
 	}{
-		{internal.SecurityTrivyDBSegment, false},
-		{internal.SecurityTrivyBDUSegment, false},
-		{internal.SecurityTrivyJavaDBSegment, false},
-		{internal.SecurityTrivyChecksSegment, false},
+		{internal.SecurityTrivyDBSegment, true},      // trivy-db:2 exists - available
+		{internal.SecurityTrivyBDUSegment, false},     // only trivy-bdu:2 added, but check looks for trivy-db:2
+		{internal.SecurityTrivyJavaDBSegment, false},  // same - trivy-db:2 not present
+		{internal.SecurityTrivyChecksSegment, false},  // same - trivy-db:2 not present
 	}
 
 	for _, db := range databases {
@@ -117,13 +120,9 @@ func TestService_validateSecurityAccess_PerDatabase(t *testing.T) {
 			securityService := registryservice.NewSecurityServices("security", securityClient, logger)
 
 			svc := newTestSecurityService(securityService, logger, userLogger)
-			err := svc.validateSecurityAccess(context.Background())
-
-			if db.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			available, err := svc.securityDatabasesAvailable(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, db.wantAvailable, available)
 		})
 	}
 }

--- a/internal/mirror/security/security_test.go
+++ b/internal/mirror/security/security_test.go
@@ -6,17 +6,19 @@ package security
 import (
 	"context"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
 
 	"github.com/deckhouse/deckhouse-cli/internal"
+	"github.com/deckhouse/deckhouse-cli/pkg"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
-	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
-	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
 	pkgclient "github.com/deckhouse/deckhouse-cli/pkg/registry/client"
+	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
 )
 
 func newTestSecurityService(
@@ -104,9 +106,9 @@ func TestService_securityDatabasesAvailable_PerDatabase(t *testing.T) {
 		wantAvailable bool
 	}{
 		{internal.SecurityTrivyDBSegment, true},      // trivy-db:2 exists - available
-		{internal.SecurityTrivyBDUSegment, false},     // only trivy-bdu:2 added, but check looks for trivy-db:2
-		{internal.SecurityTrivyJavaDBSegment, false},  // same - trivy-db:2 not present
-		{internal.SecurityTrivyChecksSegment, false},  // same - trivy-db:2 not present
+		{internal.SecurityTrivyBDUSegment, false},    // only trivy-bdu:2 added, but check looks for trivy-db:2
+		{internal.SecurityTrivyJavaDBSegment, false}, // same - trivy-db:2 not present
+		{internal.SecurityTrivyChecksSegment, false}, // same - trivy-db:2 not present
 	}
 
 	for _, db := range databases {
@@ -125,4 +127,32 @@ func TestService_securityDatabasesAvailable_PerDatabase(t *testing.T) {
 			require.Equal(t, db.wantAvailable, available)
 		})
 	}
+}
+
+// TestPullSecurity_SkipsWhenDatabasesNotAvailable verifies the full PullSecurity flow
+// (not dry-run) when security databases don't exist in the registry.
+// This simulates CE/BE/SE editions where security images are not published.
+// Expected: PullSecurity returns nil (no error), and security.tar is NOT created.
+func TestPullSecurity_SkipsWhenDatabasesNotAvailable(t *testing.T) {
+	workingDir := t.TempDir()
+	// bundleDir  - where security.tar would be written if pull proceeded (but it shouldn't in this test)
+	bundleDir := t.TempDir()
+
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+
+	// Empty registry - no security images (trivy-db, trivy-bdu, etc.)
+	reg := upfake.NewRegistry("registry.example.com")
+	stubClient := pkgclient.Adapt(upfake.NewClient(reg))
+
+	regSvc := registryservice.NewService(stubClient, pkg.FEEdition, logger)
+	securitySvc := NewService(regSvc, workingDir, &Options{BundleDir: bundleDir}, logger, userLogger)
+
+	err := securitySvc.PullSecurity(context.Background())
+	require.NoError(t, err)
+
+	// bundleDir must be empty when databases are not available - security.tar should not be created.
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "security.tar should not be created when databases are not available")
 }


### PR DESCRIPTION
## Problem

When running `d8 mirror pull` for editions without security databases (CE, BE, SE), the logs are contradictory:

1. "Skipping pull of security databases" 
2. for each of the 4 databases - "Not found in registry, skipping pull"
3. "All required Security Databases are pulled!"
4. After pulling - an empty `security.tar` is created with no actual data.

The user sees "skipping" and "all pulled" at the same time and cannot understand what actually happened.

### Root cause

`validateSecurityAccess` detects missing security images in the registry, logs "Skipping", but returns `nil`.

- The caller cannot distinguish "images exist" from "images not found" - both cases return `err == nil`.
- It proceeds with the pull, making 4 unnecessary requests to the registry and packing empty OCI layouts into `security.tar`.

### Fix

Rename `validateSecurityAccess` with `securityDatabasesAvailable` which returns `(bool, error)`.
When `!available`, the entire pull is skipped - no unnecessary requests, no contradictory logs, no empty `security.tar`.

## Before (Pulling non existing security)

<img width="1247" height="678" alt="2026-04-14 AT 17 29" src="https://github.com/user-attachments/assets/276b934c-0305-4cbe-a0fd-fb923745d5b1" />


## After (Pulling non existing security)

<img width="902" height="110" alt="2026-04-14 AT 17 29" src="https://github.com/user-attachments/assets/6fec392d-2999-4c73-9573-92a260ee855b" />


## After - (Pulling existing security) 


<img width="946" height="744" alt="2026-04-14 AT 17 31" src="https://github.com/user-attachments/assets/ce3d8a7e-55cc-44d8-8f0e-a480ffa194a5" />
