### PR TITLE
[data] Improve error messages for empty PublicURL

### DIFF
--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -108,9 +108,11 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 		if returnErr == nil {
 			switch {
 			case deObj.Status.URL == "":
-				returnErr = fmt.Errorf("DataExport %s/%s has no URL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
+				returnErr = fmt.Errorf("DataExport %s/%s: waiting for internal URL to be assigned by controller",
+					deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
 			case deObj.Spec.Publish && deObj.Status.PublicURL == "":
-				returnErr = fmt.Errorf("DataExport %s/%s has empty PublicURL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
+				returnErr = fmt.Errorf("DataExport %s/%s: waiting for public URL to be created by controller",
+					deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
 			}
 		}
 

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -120,7 +120,8 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 			break
 		}
 		if i > maxRetryAttempts {
-			return nil, returnErr
+			return nil, fmt.Errorf("%w\n\nTo inspect DataExport status, run:\n  d8 k -n %s get de %s -o yaml",
+				returnErr, namespace, deName)
 		}
 		// Every fifth attempt we output it to the terminal so that the user can see the error.
 		if i > 0 && i%5 == 0 {

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -41,6 +41,7 @@ var (
 	CreateDataExporterIfNeededFunc = CreateDataExporterIfNeeded
 )
 
+// var instead of const to allow test override.
 var maxRetryAttempts = 60
 
 func GetDataExport(ctx context.Context, deName, namespace string, rtClient ctrlrtclient.Client) (*v1alpha1.DataExport, error) {

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -108,10 +108,10 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 		}
 		// check DataExport Url
 		if returnErr == nil {
-			if deObj.Status.URL == "" {
+			switch {
+			case deObj.Status.URL == "":
 				returnErr = fmt.Errorf("DataExport %s/%s has no URL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
-			}
-			if deObj.Status.PublicURL == "" && deObj.Spec.Publish {
+			case deObj.Spec.Publish && deObj.Status.PublicURL == "":
 				returnErr = fmt.Errorf("DataExport %s/%s has empty PublicURL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
 			}
 		}

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -41,9 +41,7 @@ var (
 	CreateDataExporterIfNeededFunc = CreateDataExporterIfNeeded
 )
 
-const (
-	maxRetryAttempts = 60
-)
+var maxRetryAttempts = 60
 
 func GetDataExport(ctx context.Context, deName, namespace string, rtClient ctrlrtclient.Client) (*v1alpha1.DataExport, error) {
 	deObj := &v1alpha1.DataExport{}

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -268,9 +268,6 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 
 	switch {
 	case public:
-		if deObj.Status.PublicURL == "" {
-			return "", "", "", fmt.Errorf("empty PublicURL")
-		}
 		podURL = deObj.Status.PublicURL
 		if !strings.HasPrefix(podURL, "http") {
 			podURL = "https://" + podURL

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -107,10 +107,13 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 			}
 		}
 		// check DataExport Url
-		if returnErr == nil && deObj.Status.URL == "" {
-			returnErr = fmt.Errorf("DataExport %s/%s has no URL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
-		} else if deObj.Spec.Publish && deObj.Status.PublicURL == "" {
-			returnErr = fmt.Errorf("DataExport %s/%s has empty PublicURL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
+		if returnErr == nil {
+			if deObj.Status.URL == "" {
+				returnErr = fmt.Errorf("DataExport %s/%s has no URL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
+			}
+			if deObj.Status.PublicURL == "" && deObj.Spec.Publish {
+				returnErr = fmt.Errorf("DataExport %s/%s has empty PublicURL", deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name)
+			}
 		}
 
 		if returnErr == nil {

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -125,9 +125,11 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 		}
 		// Every fifth attempt we output it to the terminal so that the user can see the error.
 		if i > 0 && i%5 == 0 {
+			remaining := time.Duration((maxRetryAttempts-i)*3) * time.Second
 			log.Info("Still waiting for DataExport to be ready",
 				slog.String("name", deName),
 				slog.String("status", returnErr.Error()),
+				slog.String("timeout_in", remaining.String()),
 				slog.Int("attempt", i))
 		}
 		time.Sleep(time.Second * 3)

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -273,7 +273,7 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 		}
 		podURL = deObj.Status.PublicURL
 		if !strings.HasPrefix(podURL, "http") {
-			podURL += "https://"
+			podURL = "https://" + podURL
 		}
 	case deObj.Status.URL != "":
 		podURL = deObj.Status.URL

--- a/internal/data/dataexport/util/util_test.go
+++ b/internal/data/dataexport/util/util_test.go
@@ -177,8 +177,8 @@ func TestGetDataExportWithRestart_ErrorMessages(t *testing.T) {
 			wantErrNotContains: "empty PublicURL",
 		},
 		{
-			// Ready=True but PublicURL not yet generated — correct "empty PublicURL" error.
-			name: "Ready=True, publish=true, PublicURL empty: error mentions PublicURL",
+			// Ready=True but PublicURL not yet generated — race between controllers.
+			name: "Ready=True, publish=true, PublicURL empty: error says waiting for public URL",
 			de: &v1alpha1.DataExport{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
 				Spec:       v1alpha1.DataexportSpec{Publish: true},
@@ -189,12 +189,13 @@ func TestGetDataExportWithRestart_ErrorMessages(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
-			wantErrContains: "empty PublicURL",
+			wantErr:            true,
+			wantErrContains:    "waiting for public URL",
+			wantErrNotContains: "empty PublicURL",
 		},
 		{
-			// URL empty and publish=true: "has no URL" takes priority over "empty PublicURL".
-			name: "URL empty with publish=true: error is about missing URL, not PublicURL",
+			// URL empty and publish=true: "waiting for internal URL" takes priority over public URL check.
+			name: "URL empty with publish=true: error is about waiting for internal URL, not PublicURL",
 			de: &v1alpha1.DataExport{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
 				Spec:       v1alpha1.DataexportSpec{Publish: true},
@@ -205,8 +206,23 @@ func TestGetDataExportWithRestart_ErrorMessages(t *testing.T) {
 				},
 			},
 			wantErr:            true,
-			wantErrContains:    "has no URL",
+			wantErrContains:    "waiting for internal URL",
 			wantErrNotContains: "empty PublicURL",
+		},
+		{
+			// Timeout: after maxRetryAttempts=0 the error should include the d8 k recommendation.
+			name: "timeout: error contains d8 k recommendation",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: false},
+				Status: v1alpha1.DataExportStatus{
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionFalse, "Pending", "Started"),
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "d8 k -n",
 		},
 		{
 			// Happy path: both internal URL and public URL are present.

--- a/internal/data/dataexport/util/util_test.go
+++ b/internal/data/dataexport/util/util_test.go
@@ -17,6 +17,16 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/data/dataexport/api/v1alpha1"
 )
 
+// readyCond builds a Ready condition with the given status/reason/message.
+func readyCond(status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:    "Ready",
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
 func TestCreateDataExporterIfNeeded(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1alpha1.AddToScheme(scheme))
@@ -111,6 +121,148 @@ func TestCreateDataExporterIfNeeded(t *testing.T) {
 				require.Equal(t, "2m", de.Spec.TTL)
 			} else {
 				require.True(t, apierrors.IsNotFound(getErr))
+			}
+		})
+	}
+}
+
+func TestGetDataExportWithRestart_ErrorMessages(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	logger := slog.Default()
+
+	tests := []struct {
+		name               string
+		de                 *v1alpha1.DataExport
+		wantErr            bool
+		wantErrContains    string
+		wantErrNotContains string
+	}{
+		{
+			// Regression: before the fix, the condition message was overwritten by "empty PublicURL"
+			// because the else-if branch triggered whenever returnErr != nil.
+			name: "PublishFailed condition: error shows condition message, not 'empty PublicURL'",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: true},
+				Status: v1alpha1.DataExportStatus{
+					URL: "https://10.0.0.1:8085/",
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionFalse, "PublishFailed",
+							"failed to ensure public URL: ingressPublicDomain not defined"),
+					},
+				},
+			},
+			wantErr:            true,
+			wantErrContains:    "ingressPublicDomain not defined",
+			wantErrNotContains: "empty PublicURL",
+		},
+		{
+			// Regression: before the fix, "Started (Pending)" was overwritten by "empty PublicURL"
+			// because publish=true and PublicURL="" triggered the else-if even when Ready=False.
+			name: "Pending condition with publish=true: error shows Pending reason, not 'empty PublicURL'",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: true},
+				Status: v1alpha1.DataExportStatus{
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionFalse, "Pending", "Started"),
+					},
+				},
+			},
+			wantErr:            true,
+			wantErrContains:    "Pending",
+			wantErrNotContains: "empty PublicURL",
+		},
+		{
+			// Ready=True but PublicURL not yet generated — correct "empty PublicURL" error.
+			name: "Ready=True, publish=true, PublicURL empty: error mentions PublicURL",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: true},
+				Status: v1alpha1.DataExportStatus{
+					URL: "https://10.0.0.1:8085/",
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionTrue, "PodReady", "Pod is ready and export started"),
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "empty PublicURL",
+		},
+		{
+			// URL empty and publish=true: "has no URL" takes priority over "empty PublicURL".
+			name: "URL empty with publish=true: error is about missing URL, not PublicURL",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: true},
+				Status: v1alpha1.DataExportStatus{
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionTrue, "PodReady", "Pod is ready and export started"),
+					},
+				},
+			},
+			wantErr:            true,
+			wantErrContains:    "has no URL",
+			wantErrNotContains: "empty PublicURL",
+		},
+		{
+			// Happy path: both internal URL and public URL are present.
+			name: "Ready=True, publish=true, both URLs set: success",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: true},
+				Status: v1alpha1.DataExportStatus{
+					URL:       "https://10.0.0.1:8085/",
+					PublicURL: "https://api.example.com/ns/pvc/myvol/",
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionTrue, "PodReady", "Pod is ready and export started"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// Happy path without publish: only internal URL is needed.
+			name: "Ready=True, publish=false, URL set: success",
+			de: &v1alpha1.DataExport{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-de", Namespace: "test-ns"},
+				Spec:       v1alpha1.DataexportSpec{Publish: false},
+				Status: v1alpha1.DataExportStatus{
+					URL: "https://10.0.0.1:8085/",
+					Conditions: []metav1.Condition{
+						readyCond(metav1.ConditionTrue, "PodReady", "Pod is ready and export started"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Override maxRetryAttempts so the function returns after the very first
+			// iteration instead of looping 60+ times.
+			orig := maxRetryAttempts
+			maxRetryAttempts = -1
+			t.Cleanup(func() { maxRetryAttempts = orig })
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.de).
+				Build()
+
+			_, err := GetDataExportWithRestart(ctx, "test-de", "test-ns", c, logger)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				if tt.wantErrNotContains != "" {
+					assert.NotContains(t, err.Error(), tt.wantErrNotContains)
+				}
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

When using `--publish` with DataExport commands (`list`, `download`, etc.), CLI showed uninformative `"empty PublicURL"` error if the public URL was not yet available or could not be created.

Now CLI provides clear, actionable messages:
- During wait: `"waiting for public URL to be created by controller"` with remaining timeout
- On timeout: suggests running `d8 k -n <ns> get de <name> -o yaml` to inspect conditions
- Condition messages from the controller (e.g. `PublishFailed`) are shown as-is instead of being overwritten

Also fixed a bug: `podURL += "https://"` → `podURL = "https://" + podURL`.

### Changes

- `internal/data/dataexport/util/util.go` - reworked URL wait logic in `GetDataExportWithRestart`, removed redundant `"empty PublicURL"` check in `getExportStatus`
- `internal/data/dataexport/util/util_test.go` - added 7 test cases covering PublishFailed, Pending, timeout, and happy paths

### Before

<img width="1623" height="1095" alt="image" src="https://github.com/user-attachments/assets/fe70a890-b6b1-4799-820b-20bb262f841a" />

### After

<img width="1623" height="1095" alt="Снимок экрана 2026-04-14 в 20 20 43" src="https://github.com/user-attachments/assets/4cbe2871-cebd-4778-bb84-9780c2435888" />
