### PR TITLE
[deckhouse] Bump trdl channels to v0.29.30

### DIFF
--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -2,6 +2,6 @@ groups:
   - name: "0"
     channels:
       - name: ea
-        version: 0.29.28
+        version: 0.29.30
       - name: stable
-        version: 0.29.28
+        version: 0.29.30


### PR DESCRIPTION
**Bump trdl channels to actual version**: `v0.29.30` 