### PR TITLE
[deckhouse-cli] Fix pull tests leaving bundle artifacts 

### DIFF
--- a/internal/mirror/pull_test.go
+++ b/internal/mirror/pull_test.go
@@ -9,19 +9,18 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	localreg "github.com/deckhouse/deckhouse/pkg/registry"
+	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
 
 	"github.com/deckhouse/deckhouse-cli/pkg"
-	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
-	localreg "github.com/deckhouse/deckhouse/pkg/registry"
-	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
-	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
 	localfake "github.com/deckhouse/deckhouse-cli/pkg/fake"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
 	pkgclient "github.com/deckhouse/deckhouse-cli/pkg/registry/client"
+	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
 )
 
 // pullStubRootURL matches the default host used by NewRegistryClientStub.
@@ -36,6 +35,12 @@ func newPullService(
 	options *PullServiceOptions,
 ) *PullService {
 	t.Helper()
+	if options == nil {
+		options = &PullServiceOptions{}
+	}
+	if options.BundleDir == "" {
+		options.BundleDir = t.TempDir()
+	}
 	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
 	userLogger := log.NewSLogger(slog.LevelWarn)
 	regSvc := registryservice.NewService(stubClient, pkg.NoEdition, logger)


### PR DESCRIPTION
# [mirror] Fix pull tests leaving bundle artifacts in the working tree

## Summary
Pull tests called `newPullService` without setting `BundleDir`, so each `go test` run dropped bundle files into the repo working tree instead of a temp dir.

<img width="967" height="490" alt="2026-04-29 AT 23 00" src="https://github.com/user-attachments/assets/fe48e0ab-b349-4d5a-89fa-bc79193dc3c1" />

## Fix
`newPullService` now fills `BundleDir` with `t.TempDir()` when callers leave it empty (and creates the options struct if `nil`). 
Tests that need a specific path still override it.

## Before / After
**Before:** `go test ./internal/mirror/...` left untracked bundle files in the working tree.
**After:**  Each test gets its own `t.TempDir()`, cleaned up by Go automatically.
