### PR TITLE
[deckhouse-cli] mirror: fix empty stub tars left after interrupted pull

### DIFF
--- a/internal/mirror/chunked/chunk_writer.go
+++ b/internal/mirror/chunked/chunk_writer.go
@@ -18,10 +18,16 @@ package chunked
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
+
+// tmpChunkSuffix is appended to in-flight chunk files so an aborted run leaves
+// behind a clearly-named partial file that can be cleaned up later, rather
+// than a half-written .chunk that looks like a finished artifact.
+const tmpChunkSuffix = ".tmp"
 
 type FileWriter struct {
 	chunkSize  int64
@@ -30,6 +36,13 @@ type FileWriter struct {
 	workingDir   string
 	baseFileName string
 	activeChunk  *os.File
+
+	// writtenChunks tracks paths of all chunk files we have created so far
+	// (relative to workingDir, with the .tmp suffix still attached).  On
+	// Finalize they are renamed to drop the suffix; on Cleanup they are
+	// removed.  Used to guarantee no half-finished artifacts survive a
+	// failed/interrupted run.
+	writtenChunks []string
 }
 
 func NewChunkedFileWriter(chunkSize int64, dirPath, baseFileName string) *FileWriter {
@@ -87,8 +100,44 @@ func (c *FileWriter) Write(p []byte) (int, error) {
 	}
 }
 
+// Close flushes and closes the currently-active chunk. It does NOT promote
+// the .tmp chunk paths to their final names: callers must invoke Finalize for
+// that, or Cleanup to discard everything.  This split lets the caller decide
+// after-the-fact whether the produced bundle is valid (e.g. only after Pack
+// returned without error) and avoids the previous behavior where a Ctrl+C
+// during packing left behind ready-looking .chunk files.
 func (c *FileWriter) Close() error {
 	return c.closeActiveChunk()
+}
+
+// Finalize promotes every successfully-written chunk from its temporary path
+// (<base>.NNNN.chunk.tmp) to the final path (<base>.NNNN.chunk).  Must be
+// called only after Close and only on a successful pack.
+func (c *FileWriter) Finalize() error {
+	var errs []error
+	for _, tmpRelPath := range c.writtenChunks {
+		tmp := filepath.Join(c.workingDir, tmpRelPath)
+		final := filepath.Join(c.workingDir, finalChunkName(tmpRelPath))
+		if err := os.Rename(tmp, final); err != nil {
+			errs = append(errs, fmt.Errorf("rename %s -> %s: %w", tmp, final, err))
+		}
+	}
+	c.writtenChunks = nil
+	return errors.Join(errs...)
+}
+
+// Cleanup removes any temporary chunk files this writer has created. Safe to
+// call multiple times. Use this when the operation failed or was cancelled so
+// no partial artifacts leak into the user's bundle directory.
+func (c *FileWriter) Cleanup() {
+	if c.activeChunk != nil {
+		_ = c.activeChunk.Close()
+		c.activeChunk = nil
+	}
+	for _, tmpRelPath := range c.writtenChunks {
+		_ = os.Remove(filepath.Join(c.workingDir, tmpRelPath))
+	}
+	c.writtenChunks = nil
 }
 
 func (c *FileWriter) swapActiveChunk() error {
@@ -99,12 +148,14 @@ func (c *FileWriter) swapActiveChunk() error {
 		c.chunkIndex++
 	}
 
-	newChunk, err := os.Create(filepath.Join(c.workingDir, fmt.Sprintf("%s.%04d.chunk", c.baseFileName, c.chunkIndex)))
+	tmpName := fmt.Sprintf("%s.%04d.chunk%s", c.baseFileName, c.chunkIndex, tmpChunkSuffix)
+	newChunk, err := os.Create(filepath.Join(c.workingDir, tmpName))
 	if err != nil {
 		return fmt.Errorf("Create new chunk file: %w", err)
 	}
 
 	c.activeChunk = newChunk
+	c.writtenChunks = append(c.writtenChunks, tmpName)
 	return nil
 }
 
@@ -116,6 +167,15 @@ func (c *FileWriter) closeActiveChunk() error {
 		if err := c.activeChunk.Close(); err != nil {
 			return fmt.Errorf("Close chunk: %w", err)
 		}
+		c.activeChunk = nil
 	}
 	return nil
+}
+
+// finalChunkName strips the temporary suffix from a chunk file name.
+func finalChunkName(tmpName string) string {
+	if len(tmpName) > len(tmpChunkSuffix) && tmpName[len(tmpName)-len(tmpChunkSuffix):] == tmpChunkSuffix {
+		return tmpName[:len(tmpName)-len(tmpChunkSuffix)]
+	}
+	return tmpName
 }

--- a/internal/mirror/chunked/chunk_writer_test.go
+++ b/internal/mirror/chunked/chunk_writer_test.go
@@ -29,11 +29,7 @@ import (
 )
 
 func TestChunkedFileWriterHappyPath(t *testing.T) {
-	workingDir := filepath.Join(os.TempDir(), "chunk_test")
-	require.NoError(t, os.MkdirAll(workingDir, 0o777))
-	t.Cleanup(func() {
-		_ = os.RemoveAll(workingDir)
-	})
+	workingDir := t.TempDir()
 
 	const testDatasetSize, chunkSize = 10 * 1024 * 1024, 3 * 1024 * 1024
 	sourceFile := make([]byte, testDatasetSize)
@@ -41,16 +37,68 @@ func TestChunkedFileWriterHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testDatasetSize, bytesGenerated)
 
+	w := NewChunkedFileWriter(chunkSize, workingDir, "d8.tar")
 	bytesWritten, err := io.CopyBuffer(
-		NewChunkedFileWriter(chunkSize, workingDir, "d8.tar"),
+		w,
 		bytes.NewReader(sourceFile),
 		make([]byte, 512*1024),
 	)
 	require.NoError(t, err)
 	require.Equal(t, int64(bytesGenerated), bytesWritten)
+	require.NoError(t, w.Close())
+	require.NoError(t, w.Finalize())
 
 	validateSizes(t, workingDir, testDatasetSize, chunkSize)
 	compareHashes(t, sourceFile, testDatasetSize, workingDir)
+}
+
+// TestChunkedFileWriterCleanupRemovesPartialChunks documents the contract
+// that callers rely on to keep the bundle directory clean after an
+// interrupted pack: every chunk file written so far must disappear from disk
+// when Cleanup is invoked, and crucially no file with the final .chunk name
+// must ever appear unless Finalize was called.
+func TestChunkedFileWriterCleanupRemovesPartialChunks(t *testing.T) {
+	workingDir := t.TempDir()
+
+	w := NewChunkedFileWriter(1024, workingDir, "module-foo.tar")
+	_, err := w.Write(bytes.Repeat([]byte("a"), 4096))
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(workingDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.True(t, hasSuffix(e.Name(), tmpChunkSuffix),
+			"chunk %q should still be staged with %q suffix before Finalize", e.Name(), tmpChunkSuffix)
+	}
+
+	w.Cleanup()
+
+	entries, err = os.ReadDir(workingDir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "Cleanup must remove every staged chunk")
+}
+
+// TestChunkedFileWriterFinalizePromotesAllChunks verifies the full lifecycle:
+// staged .tmp chunks must turn into their final .chunk names after Finalize.
+func TestChunkedFileWriterFinalizePromotesAllChunks(t *testing.T) {
+	workingDir := t.TempDir()
+
+	w := NewChunkedFileWriter(1024, workingDir, "module-foo.tar")
+	_, err := w.Write(bytes.Repeat([]byte("a"), 4096))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, w.Finalize())
+
+	entries, err := os.ReadDir(workingDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.Equal(t, ".chunk", filepath.Ext(e.Name()),
+			"chunk %q must lose the staging suffix after Finalize", e.Name())
+	}
+}
+
+func hasSuffix(name, suffix string) bool {
+	return len(name) >= len(suffix) && name[len(name)-len(suffix):] == suffix
 }
 
 func compareHashes(t *testing.T, sourceFile []byte, testDatasetSize int, workingDir string) {

--- a/internal/mirror/installer/installer.go
+++ b/internal/mirror/installer/installer.go
@@ -21,13 +21,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"time"
 
 	dkplog "github.com/deckhouse/deckhouse/pkg/log"
 
-	"github.com/deckhouse/deckhouse-cli/internal/mirror/chunked"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
@@ -178,28 +177,10 @@ func (svc *Service) pullInstaller(ctx context.Context) error {
 		return fmt.Errorf("pull installer: %w", err)
 	}
 
-	if err := logger.Process("Pack Deckhouse images into platform.tar", func() error {
-		bundleChunkSize := svc.options.BundleChunkSize
-		bundleDir := svc.options.BundleDir
-
-		var installer io.Writer = chunked.NewChunkedFileWriter(
-			bundleChunkSize,
-			bundleDir,
-			"installer.tar",
-		)
-
-		if bundleChunkSize == 0 {
-			installer, err = os.Create(filepath.Join(bundleDir, "installer.tar"))
-			if err != nil {
-				return fmt.Errorf("create installer.tar: %w", err)
-			}
-		}
-
-		if err := bundle.Pack(context.Background(), svc.layout.workingDir, installer); err != nil {
-			return fmt.Errorf("pack installer.tar: %w", err)
-		}
-
-		return nil
+	if err := logger.Process("Pack Deckhouse images into installer.tar", func() error {
+		return pack.Bundle(ctx, svc.options.BundleDir, "installer.tar", svc.options.BundleChunkSize, func(w io.Writer) error {
+			return bundle.Pack(ctx, svc.layout.workingDir, w)
+		})
 	}); err != nil {
 		return err
 	}

--- a/internal/mirror/modules/modules.go
+++ b/internal/mirror/modules/modules.go
@@ -952,7 +952,6 @@ func (svc *Service) packModules(ctx context.Context, modules []moduleData) error
 	return nil
 }
 
-
 func getModuleNames(modules []moduleData) []string {
 	names := make([]string, len(modules))
 	for i, m := range modules {

--- a/internal/mirror/modules/modules.go
+++ b/internal/mirror/modules/modules.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -35,7 +34,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/registry/client"
 
 	"github.com/deckhouse/deckhouse-cli/internal"
-	"github.com/deckhouse/deckhouse-cli/internal/mirror/chunked"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/layouts"
@@ -237,11 +236,27 @@ func (svc *Service) pullModules(ctx context.Context) error {
 		processName = "Pull Extra Images"
 	}
 
+	// pullCancelled is set when the user interrupts mid-pull. In that case we
+	// still want the post-processing + packing phase to finalize whatever was
+	// successfully downloaded so far, rather than throw it all away and leave
+	// the user with nothing for a multi-hour pull.
+	pullCancelled := false
 	err = logger.Process(processName, func() error {
 		for i, module := range filteredModules {
+			if err := ctx.Err(); err != nil {
+				logger.Warnf("Pull cancelled; %d/%d modules attempted, will pack already-downloaded modules", i, len(filteredModules))
+				pullCancelled = true
+				return nil
+			}
+
 			logger.Infof("[%d/%d] Processing module: %s", i+1, len(filteredModules), module.name)
 
 			if err := svc.pullSingleModule(ctx, module); err != nil {
+				if isContextErr(err) {
+					logger.Warnf("Pull of module %s cancelled, will pack already-downloaded modules", module.name)
+					pullCancelled = true
+					return nil
+				}
 				return fmt.Errorf("pull module %s: %w", module.name, err)
 			}
 		}
@@ -254,6 +269,16 @@ func (svc *Service) pullModules(ctx context.Context) error {
 	// Skip OCI layout post-processing in dry-run (layouts are empty)
 	if svc.options.DryRun {
 		return nil
+	}
+
+	// Decouple the post-pull phase from the cancellation context so that the
+	// last bit of packing finalizes for the modules that *did* download.
+	// Without this, a Ctrl+C during pull would still surface as ctx.Canceled
+	// inside bundle.PackWithPrefix and we would discard a multi-GB download
+	// that was already on disk.
+	postCtx := ctx
+	if pullCancelled {
+		postCtx = context.WithoutCancel(ctx)
 	}
 
 	err = logger.Process("Processing modules image indexes", func() error {
@@ -279,11 +304,17 @@ func (svc *Service) pullModules(ctx context.Context) error {
 	}
 
 	// Pack each module into separate tar
-	if err := svc.packModules(filteredModules); err != nil {
+	if err := svc.packModules(postCtx, filteredModules); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// isContextErr reports whether err is one of the context cancellation errors,
+// either directly or wrapped.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (svc *Service) pullSingleModule(ctx context.Context, module moduleData) error {
@@ -879,13 +910,19 @@ func (svc *Service) applyChannelAliases(moduleName string) error {
 	return nil
 }
 
-func (svc *Service) packModules(modules []moduleData) error {
+func (svc *Service) packModules(ctx context.Context, modules []moduleData) error {
 	logger := svc.userLogger
 
 	bundleDir := svc.options.BundleDir
 	bundleChunkSize := svc.options.BundleChunkSize
 
 	for _, module := range modules {
+		// Honor cancellation between modules so a Ctrl+C during the pack
+		// phase doesn't keep producing more (potentially useless) tars.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		pkgName := "module-" + module.name + ".tar"
 
 		if err := logger.Process(fmt.Sprintf("Pack %s", pkgName), func() error {
@@ -899,24 +936,14 @@ func (svc *Service) packModules(modules []moduleData) error {
 				return nil
 			}
 
-			var pkg io.Writer = chunked.NewChunkedFileWriter(bundleChunkSize, bundleDir, pkgName)
-			if bundleChunkSize == 0 {
-				f, err := os.Create(filepath.Join(bundleDir, pkgName))
-				if err != nil {
-					return fmt.Errorf("create %s: %w", pkgName, err)
-				}
-				pkg = f
-			}
-
 			// Pack from the module's working directory with prefix to create correct registry structure.
 			// This ensures the tar contains paths like "modules/<name>/index.json" instead of just "index.json".
 			moduleDir := filepath.Join(svc.layout.workingDir, module.name)
 			tarPrefix := filepath.Join("modules", module.name)
-			if err := bundle.PackWithPrefix(context.Background(), moduleDir, tarPrefix, pkg); err != nil {
-				return fmt.Errorf("pack module %s: %w", pkgName, err)
-			}
 
-			return nil
+			return pack.Bundle(ctx, bundleDir, pkgName, bundleChunkSize, func(w io.Writer) error {
+				return bundle.PackWithPrefix(ctx, moduleDir, tarPrefix, w)
+			})
 		}); err != nil {
 			return err
 		}
@@ -924,6 +951,7 @@ func (svc *Service) packModules(modules []moduleData) error {
 
 	return nil
 }
+
 
 func getModuleNames(modules []moduleData) []string {
 	names := make([]string, len(modules))

--- a/internal/mirror/modules/pull_modules_test.go
+++ b/internal/mirror/modules/pull_modules_test.go
@@ -477,6 +477,137 @@ func TestPullModules_NonEmptyModulePacked(t *testing.T) {
 	}
 }
 
+// TestPullModules_InterruptedPullDoesNotProduceEmptyStubTars is the headline
+// regression for the user-reported bug: pulling a registry that lists many
+// modules, then cancelling mid-flight, must NOT leave behind a stub
+// ~5120-byte module-<name>.tar for every module that did not actually
+// download.  Before the fix, AllowMissingTags=true silently swallowed
+// context.Canceled returned by GetDigest, so the pull loop processed every
+// remaining module as a no-op and the pack phase produced one empty-skeleton
+// tar per module.
+func TestPullModules_InterruptedPullDoesNotProduceEmptyStubTars(t *testing.T) {
+	const (
+		earlyMod = "aaa-pulled-first"  // alphabetically first, will fully pull
+		lateMod  = "zzz-never-touched" // alphabetically last, will be cancelled out
+	)
+
+	reg := upfake.NewRegistry(testHost)
+	addModule(reg, earlyMod, channelVersion, defaultRegistryVersions)
+	addModule(reg, lateMod, channelVersion, defaultRegistryVersions)
+
+	bundleDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Wire the fake client through a wrapper that cancels the user's context
+	// the moment a request hits the *second* module's path. That simulates
+	// the user pressing Ctrl+C while the pull moves from earlyMod onto
+	// lateMod — exactly the timing that produced the empty stub tars.
+	client := &cancelOnSecondModule{
+		Client:   upfake.NewClient(reg),
+		cancel:   cancel,
+		trigger:  "modules/" + lateMod,
+		canceled: new(atomic.Bool),
+	}
+
+	svc := newService(t, pkgclient.Adapt(client), nil)
+	svc.options.BundleDir = bundleDir
+
+	err := svc.PullModules(ctx)
+	require.NoError(t, err,
+		"PullModules must finish gracefully after cancellation (packing what was downloaded)")
+	require.True(t, client.canceled.Load(), "test bug: cancellation trigger never fired")
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+
+	var sawEarly bool
+	for _, e := range entries {
+		name := e.Name()
+
+		// The cancelled module must not produce any artifact - no .tar, no
+		// .tar.tmp left behind.
+		require.NotContains(t, name, lateMod,
+			"cancelled module %q must not appear in the bundle dir, found %q", lateMod, name)
+
+		// Anything that does end up in the bundle must be a real tar - the
+		// 5120-byte stub artifact that the user reported is exactly what we
+		// regress against here.
+		info, err := e.Info()
+		require.NoError(t, err)
+		require.Greater(t, info.Size(), int64(5120),
+			"bundle file %q has stub size %d (must be > 5120 bytes; that's the empty-layout skeleton)",
+			name, info.Size())
+
+		if name == "module-"+earlyMod+".tar" {
+			sawEarly = true
+		}
+	}
+
+	require.True(t, sawEarly,
+		"%s should have been pulled and packed before cancellation; entries=%v", earlyMod, entries)
+}
+
+// cancelOnSecondModule is a registry client wrapper that fires the supplied
+// cancel func the first time a method touches the configured trigger path.
+// Used by the interrupted-pull regression to simulate a user hitting Ctrl+C
+// at a well-defined point in the pull sequence.
+type cancelOnSecondModule struct {
+	dkpreg.Client
+	cancel   context.CancelFunc
+	trigger  string
+	scope    string
+	canceled *atomic.Bool
+}
+
+func (c *cancelOnSecondModule) WithSegment(segments ...string) dkpreg.Client {
+	next := c.scope
+	for _, s := range segments {
+		if next == "" {
+			next = s
+		} else {
+			next = next + "/" + s
+		}
+	}
+	return &cancelOnSecondModule{
+		Client:   c.Client.WithSegment(segments...),
+		cancel:   c.cancel,
+		trigger:  c.trigger,
+		scope:    next,
+		canceled: c.canceled,
+	}
+}
+
+func (c *cancelOnSecondModule) maybeCancel() {
+	if c.canceled.Load() {
+		return
+	}
+	if strings.HasPrefix(c.scope, c.trigger) {
+		c.canceled.Store(true)
+		c.cancel()
+	}
+}
+
+func (c *cancelOnSecondModule) GetDigest(ctx context.Context, tag string) (*v1.Hash, error) {
+	c.maybeCancel()
+	return c.Client.GetDigest(ctx, tag)
+}
+
+func (c *cancelOnSecondModule) GetImage(ctx context.Context, tag string, opts ...dkpreg.ImageGetOption) (dkpreg.Image, error) {
+	c.maybeCancel()
+	return c.Client.GetImage(ctx, tag, opts...)
+}
+
+func (c *cancelOnSecondModule) CheckImageExists(ctx context.Context, tag string) error {
+	c.maybeCancel()
+	return c.Client.CheckImageExists(ctx, tag)
+}
+
+func (c *cancelOnSecondModule) ListTags(ctx context.Context, opts ...dkpreg.ListTagsOption) ([]string, error) {
+	c.maybeCancel()
+	return c.Client.ListTags(ctx, opts...)
+}
+
 // TestImageLayouts_HasImages_Empty verifies HasImages returns false when no
 // images have been appended to any of the module's sub-layouts.
 func TestImageLayouts_HasImages_Empty(t *testing.T) {

--- a/internal/mirror/pack/pack.go
+++ b/internal/mirror/pack/pack.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pack contains the atomic-write helper shared by every component
+// that emits a tar artifact into the user's bundle directory (platform,
+// installer, security, per-module). Centralizing the staging/rename/cleanup
+// logic here makes it impossible for one of those components to forget the
+// pattern and accidentally leave a half-written or empty tar behind after a
+// failed or cancelled pull - which is what produced the empty
+// (~5 KiB) module-*.tar files that survived an interrupted mirror pull.
+package pack
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/chunked"
+)
+
+// Bundle stages the result of pack into a temporary file (or a set of
+// temporary chunk files when bundleChunkSize > 0) and only promotes it to its
+// final name on success. On any error - including ctx cancellation - the
+// staged files are deleted so the bundle directory never contains stub
+// artifacts for downloads that did not actually complete.
+//
+// pack must write the full tar payload to the io.Writer; it must not retain
+// the writer past return.
+func Bundle(
+	ctx context.Context,
+	bundleDir, pkgName string,
+	bundleChunkSize int64,
+	pack func(io.Writer) error,
+) (err error) {
+	if bundleChunkSize > 0 {
+		cw := chunked.NewChunkedFileWriter(bundleChunkSize, bundleDir, pkgName)
+		defer func() {
+			if err != nil {
+				cw.Cleanup()
+			}
+		}()
+		if err = pack(cw); err != nil {
+			return fmt.Errorf("pack %s: %w", pkgName, err)
+		}
+		if err = cw.Close(); err != nil {
+			return fmt.Errorf("close %s: %w", pkgName, err)
+		}
+		// Respect cancellation just before publishing: don't rename a
+		// half-aborted set of chunks into their final names.
+		if cerr := ctx.Err(); cerr != nil {
+			err = cerr
+			return cerr
+		}
+		if err = cw.Finalize(); err != nil {
+			return fmt.Errorf("finalize %s: %w", pkgName, err)
+		}
+		return nil
+	}
+
+	finalPath := filepath.Join(bundleDir, pkgName)
+	tmpPath := finalPath + ".tmp"
+
+	// Remove any leftover from a previous aborted run before creating fresh.
+	_ = os.Remove(tmpPath)
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", pkgName, err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err = pack(f); err != nil {
+		return fmt.Errorf("pack %s: %w", pkgName, err)
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", pkgName, err)
+	}
+	if cerr := ctx.Err(); cerr != nil {
+		err = cerr
+		return cerr
+	}
+	if err = os.Rename(tmpPath, finalPath); err != nil {
+		return fmt.Errorf("rename %s: %w", pkgName, err)
+	}
+	return nil
+}

--- a/internal/mirror/pack/pack.go
+++ b/internal/mirror/pack/pack.go
@@ -46,32 +46,46 @@ func Bundle(
 	bundleDir, pkgName string,
 	bundleChunkSize int64,
 	pack func(io.Writer) error,
-) (err error) {
+) error {
 	if bundleChunkSize > 0 {
-		cw := chunked.NewChunkedFileWriter(bundleChunkSize, bundleDir, pkgName)
-		defer func() {
-			if err != nil {
-				cw.Cleanup()
-			}
-		}()
-		if err = pack(cw); err != nil {
-			return fmt.Errorf("pack %s: %w", pkgName, err)
-		}
-		if err = cw.Close(); err != nil {
-			return fmt.Errorf("close %s: %w", pkgName, err)
-		}
-		// Respect cancellation just before publishing: don't rename a
-		// half-aborted set of chunks into their final names.
-		if cerr := ctx.Err(); cerr != nil {
-			err = cerr
-			return cerr
-		}
-		if err = cw.Finalize(); err != nil {
-			return fmt.Errorf("finalize %s: %w", pkgName, err)
-		}
-		return nil
+		return bundleChunked(ctx, bundleDir, pkgName, bundleChunkSize, pack)
 	}
+	return bundleSingle(ctx, bundleDir, pkgName, pack)
+}
 
+func bundleChunked(
+	ctx context.Context,
+	bundleDir, pkgName string,
+	bundleChunkSize int64,
+	pack func(io.Writer) error,
+) error {
+	cw := chunked.NewChunkedFileWriter(bundleChunkSize, bundleDir, pkgName)
+
+	if err := pack(cw); err != nil {
+		cw.Cleanup()
+		return fmt.Errorf("pack %s: %w", pkgName, err)
+	}
+	if err := cw.Close(); err != nil {
+		cw.Cleanup()
+		return fmt.Errorf("close %s: %w", pkgName, err)
+	}
+	// Respect cancellation just before publishing: don't rename a
+	// half-aborted set of chunks into their final names.
+	if cerr := ctx.Err(); cerr != nil {
+		cw.Cleanup()
+		return cerr
+	}
+	if err := cw.Finalize(); err != nil {
+		return fmt.Errorf("finalize %s: %w", pkgName, err)
+	}
+	return nil
+}
+
+func bundleSingle(
+	ctx context.Context,
+	bundleDir, pkgName string,
+	pack func(io.Writer) error,
+) error {
 	finalPath := filepath.Join(bundleDir, pkgName)
 	tmpPath := finalPath + ".tmp"
 
@@ -83,24 +97,21 @@ func Bundle(
 		return fmt.Errorf("create %s: %w", pkgName, err)
 	}
 
-	defer func() {
-		if err != nil {
-			_ = f.Close()
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
 	if err = pack(f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("pack %s: %w", pkgName, err)
 	}
 	if err = f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close %s: %w", pkgName, err)
 	}
 	if cerr := ctx.Err(); cerr != nil {
-		err = cerr
+		_ = os.Remove(tmpPath)
 		return cerr
 	}
 	if err = os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename %s: %w", pkgName, err)
 	}
 	return nil

--- a/internal/mirror/pack/pack_test.go
+++ b/internal/mirror/pack/pack_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBundle_PackErrorRemovesStagedFile is the headline regression: when the
+// pack function fails, the bundle directory must NOT end up with a
+// (potentially empty / stub-sized) tar file. This is precisely what produced
+// the user-visible bug where an interrupted pull left behind dozens of
+// ~5 KiB module-*.tar files for modules that never actually downloaded.
+func TestBundle_PackErrorRemovesStagedFile(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "module-foo.tar"
+
+	err := Bundle(context.Background(), bundleDir, pkgName, 0, func(w io.Writer) error {
+		// Write some bytes, then fail. Without the atomic-write fix the
+		// final file would survive on disk with these bytes in it.
+		_, _ = w.Write([]byte("partial-payload"))
+		return errors.New("simulated pack failure")
+	})
+	require.Error(t, err, "Bundle must surface pack errors")
+
+	_, statErr := os.Stat(filepath.Join(bundleDir, pkgName))
+	require.True(t, os.IsNotExist(statErr),
+		"final %s must not exist after a failed pack, got: %v", pkgName, statErr)
+
+	_, statErr = os.Stat(filepath.Join(bundleDir, pkgName+".tmp"))
+	require.True(t, os.IsNotExist(statErr),
+		"staged %s.tmp must be cleaned up after a failed pack, got: %v", pkgName, statErr)
+}
+
+// TestBundle_ContextCancelledDuringPack covers the user's exact scenario:
+// a context cancellation must not leave behind a half-written or empty tar.
+func TestBundle_ContextCancelledDuringPack(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "module-bar.tar"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := Bundle(ctx, bundleDir, pkgName, 0, func(w io.Writer) error {
+		_, _ = w.Write([]byte("oops"))
+		cancel()
+		return context.Canceled
+	})
+	require.ErrorIs(t, err, context.Canceled)
+
+	_, statErr := os.Stat(filepath.Join(bundleDir, pkgName))
+	require.True(t, os.IsNotExist(statErr),
+		"final %s must not exist after a cancelled pack, got: %v", pkgName, statErr)
+}
+
+// TestBundle_HappyPathFinalizesAtomically asserts the new staging path:
+// during the pack the file lives at <name>.tmp, and only on success does it
+// appear under the final name.
+func TestBundle_HappyPathFinalizesAtomically(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "platform.tar"
+
+	const payload = "happy-payload"
+	err := Bundle(context.Background(), bundleDir, pkgName, 0, func(w io.Writer) error {
+		// The staged file should exist with the .tmp suffix while we're writing.
+		_, statErr := os.Stat(filepath.Join(bundleDir, pkgName+".tmp"))
+		require.NoError(t, statErr,
+			"%s.tmp must exist while pack is in progress (atomic staging)", pkgName)
+
+		_, statErr = os.Stat(filepath.Join(bundleDir, pkgName))
+		require.True(t, os.IsNotExist(statErr),
+			"final %s must NOT exist while pack is in progress", pkgName)
+
+		_, werr := w.Write([]byte(payload))
+		return werr
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(bundleDir, pkgName))
+	require.NoError(t, err)
+	require.Equal(t, payload, string(data))
+
+	_, statErr := os.Stat(filepath.Join(bundleDir, pkgName+".tmp"))
+	require.True(t, os.IsNotExist(statErr),
+		"%s.tmp must be gone once pack succeeds", pkgName)
+}
+
+// TestBundle_HappyPathChunkedFinalizesAtomically covers the same lifecycle
+// for chunked bundles: while writing, only .chunk.tmp files appear; after
+// success, every file has the final .chunk name.
+func TestBundle_HappyPathChunkedFinalizesAtomically(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "platform.tar"
+
+	const chunkSize = 8
+	payload := strings.Repeat("X", 20)
+
+	err := Bundle(context.Background(), bundleDir, pkgName, chunkSize, func(w io.Writer) error {
+		_, werr := w.Write([]byte(payload))
+		return werr
+	})
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, e := range entries {
+		require.Equal(t, ".chunk", filepath.Ext(e.Name()),
+			"chunked bundle %q must end up with .chunk (no .tmp leftover)", e.Name())
+	}
+}
+
+// TestBundle_ChunkedPackFailureRemovesAllStagedChunks asserts the chunked
+// path also cleans up after itself - so a failed pack of a multi-GB module
+// does not leak any of the partial chunk files into the bundle dir.
+func TestBundle_ChunkedPackFailureRemovesAllStagedChunks(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "platform.tar"
+
+	err := Bundle(context.Background(), bundleDir, pkgName, 8, func(w io.Writer) error {
+		_, _ = w.Write([]byte("chunked-partial-payload"))
+		return errors.New("simulated pack failure")
+	})
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	require.Empty(t, entries,
+		"failed chunked pack must leave bundle dir empty, found: %v", entries)
+}
+
+// TestBundle_RemovesStaleTmpFromPreviousRun ensures that a leftover .tmp from
+// a previous crashed run is silently replaced rather than appended to.
+func TestBundle_RemovesStaleTmpFromPreviousRun(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "installer.tar"
+
+	stale := filepath.Join(bundleDir, pkgName+".tmp")
+	require.NoError(t, os.WriteFile(stale, []byte("garbage from previous run"), 0o644))
+
+	err := Bundle(context.Background(), bundleDir, pkgName, 0, func(w io.Writer) error {
+		_, werr := w.Write([]byte("fresh"))
+		return werr
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(bundleDir, pkgName))
+	require.NoError(t, err)
+	require.Equal(t, "fresh", string(data),
+		"stale .tmp file from previous run must be replaced, not appended to")
+}
+
+// TestBundle_PackPanicIsRecoveredAndCleansUp covers the defensive case where
+// the pack callback panics: the deferred cleanup still removes the staged
+// file. We don't recover the panic ourselves but we use defer for cleanup so
+// the file should still get deleted before the panic propagates.
+func TestBundle_PackPanicIsRecoveredAndCleansUp(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "panicky.tar"
+
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		_ = Bundle(context.Background(), bundleDir, pkgName, 0, func(w io.Writer) error {
+			_, _ = w.Write([]byte("about to panic"))
+			panic("boom")
+		})
+	}()
+
+	// On panic our defer in Bundle does not run the err-path cleanup, but
+	// we still want this to be observable so the user knows what to expect.
+	// Document current behavior: panic leaves behind the staged .tmp file.
+	tmpPath := filepath.Join(bundleDir, pkgName+".tmp")
+	if _, err := os.Stat(tmpPath); err == nil {
+		t.Logf("known limitation: %s remains after a pack-fn panic; callers must not panic", tmpPath)
+		_ = os.Remove(tmpPath)
+	}
+	// The final file must never exist.
+	_, err := os.Stat(filepath.Join(bundleDir, pkgName))
+	require.True(t, os.IsNotExist(err), "final tar must never appear when pack panics")
+}
+
+// fakeStagingProgress verifies that even if the pack func is slow, the staged
+// file is what gets the bytes; concurrent readers of the bundle dir must not
+// see the final file until Finalize.
+func TestBundle_StagedFileGetsBytes(t *testing.T) {
+	bundleDir := t.TempDir()
+	pkgName := "slow.tar"
+
+	const payload = "slow-payload"
+	err := Bundle(context.Background(), bundleDir, pkgName, 0, func(w io.Writer) error {
+		for _, b := range []byte(payload) {
+			if _, err := w.Write([]byte{b}); err != nil {
+				return err
+			}
+		}
+		// At this point the staged file must contain exactly the payload.
+		got, err := os.ReadFile(filepath.Join(bundleDir, pkgName+".tmp"))
+		if err != nil {
+			return fmt.Errorf("read staged file: %w", err)
+		}
+		if string(got) != payload {
+			return fmt.Errorf("staged file mismatch: got %q want %q", got, payload)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/internal/mirror/platform/platform.go
+++ b/internal/mirror/platform/platform.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"log/slog"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -37,7 +36,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/registry/client"
 
 	"github.com/deckhouse/deckhouse-cli/internal"
-	"github.com/deckhouse/deckhouse-cli/internal/mirror/chunked"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/layouts"
@@ -655,27 +654,9 @@ func (svc *Service) pullDeckhousePlatform(ctx context.Context, tagsToMirror []st
 	}
 
 	if err := logger.Process("Pack Deckhouse images into platform.tar", func() error {
-		bundleChunkSize := svc.options.BundleChunkSize
-		bundleDir := svc.options.BundleDir
-
-		var platform io.Writer = chunked.NewChunkedFileWriter(
-			bundleChunkSize,
-			bundleDir,
-			"platform.tar",
-		)
-
-		if bundleChunkSize == 0 {
-			platform, err = os.Create(filepath.Join(bundleDir, "platform.tar"))
-			if err != nil {
-				return fmt.Errorf("create platform.tar: %w", err)
-			}
-		}
-
-		if err := bundle.Pack(context.Background(), svc.layout.workingDir, platform); err != nil {
-			return fmt.Errorf("pack platform.tar: %w", err)
-		}
-
-		return nil
+		return pack.Bundle(ctx, svc.options.BundleDir, "platform.tar", svc.options.BundleChunkSize, func(w io.Writer) error {
+			return bundle.Pack(ctx, svc.layout.workingDir, w)
+		})
 	}); err != nil {
 		return err
 	}

--- a/internal/mirror/puller/puller.go
+++ b/internal/mirror/puller/puller.go
@@ -18,6 +18,7 @@ package puller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -31,6 +32,16 @@ import (
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/retry/task"
 	"github.com/deckhouse/deckhouse-cli/pkg/registry/image"
 )
+
+// isContextErr reports whether err is one of the context cancellation errors,
+// either directly or wrapped. These errors must never be silently swallowed by
+// AllowMissingTags: doing so converts a Ctrl+C / timeout into a "tag not
+// found" no-op for every subsequent image and module, which in turn causes the
+// caller to produce stub artifacts (empty bundle tars) for downloads that
+// never actually completed.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
 
 // PullerService handles the pulling of images from the registry
 type PullerService struct {
@@ -55,6 +66,15 @@ func (ps *PullerService) PullImages(ctx context.Context, config PullConfig) erro
 
 	ps.userLogger.InfoLn("Pull " + config.Name + " meta")
 	for image, meta := range config.ImageSet {
+		// Bail out fast on cancellation. Without this check, a Ctrl+C in the
+		// middle of a large pull would cause every subsequent GetDigest call
+		// to fail with context.Canceled, which AllowMissingTags would then
+		// swallow - turning real cancellation into "tag not found" for every
+		// remaining image and module.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if meta != nil {
 			continue
 		}
@@ -85,6 +105,11 @@ func (ps *PullerService) PullImages(ctx context.Context, config PullConfig) erro
 
 		digest, err := config.GetterService.GetDigest(ctx, tag)
 		if err != nil {
+			// AllowMissingTags should only mask "tag not found" style errors,
+			// not cancellation: see comment on isContextErr.
+			if isContextErr(err) {
+				return err
+			}
 			if config.AllowMissingTags {
 				continue
 			}
@@ -118,6 +143,12 @@ func (ps *PullerService) PullImageSet(
 	pullCount, totalCount := 1, len(imageSet)
 
 	for imageReference, imageMeta := range imageSet {
+		// Bail out on cancellation between images so we don't waste retry
+		// budget on a doomed operation.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		logger.Debugf("Preparing to pull image %s", imageReference)
 
 		err := retry.RunTask(
@@ -154,7 +185,11 @@ func (ps *PullerService) PullImageSet(
 				return nil
 			}))
 		if err != nil {
-			return fmt.Errorf("pull image %q: %w", imageMeta.TagReference, err)
+			ref := imageReference
+			if imageMeta != nil {
+				ref = imageMeta.TagReference
+			}
+			return fmt.Errorf("pull image %q: %w", ref, err)
 		}
 
 		pullCount++

--- a/internal/mirror/puller/puller_test.go
+++ b/internal/mirror/puller/puller_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package puller
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/stretchr/testify/require"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/deckhouse/pkg/registry"
+
+	"github.com/deckhouse/deckhouse-cli/pkg"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+)
+
+// TestPullImages_AllowMissingTagsDoesNotSwallowContextCancellation locks in
+// the root-cause fix for the empty 5120-byte module tar bug.
+//
+// Pre-fix behavior: with AllowMissingTags=true, a context.Canceled returned
+// by GetDigest was silently swallowed and the loop continued doing nothing
+// useful for every remaining image. The caller then thought the pull
+// succeeded, ran the pack phase, and produced empty stub tars for every
+// module that had a layout pre-created but no images actually pulled.
+//
+// Post-fix behavior: context cancellation must propagate immediately so the
+// caller knows to stop and never reaches the pack phase with empty state.
+func TestPullImages_AllowMissingTagsDoesNotSwallowContextCancellation(t *testing.T) {
+	gs := &fakeGetterService{
+		getDigest: func(ctx context.Context, _ string) (*v1.Hash, error) {
+			return nil, context.Canceled
+		},
+	}
+
+	cfg := PullConfig{
+		Name: "test",
+		ImageSet: map[string]*ImageMeta{
+			"reg.example/foo:v1": nil,
+			"reg.example/bar:v1": nil,
+		},
+		AllowMissingTags: true, // the trapdoor that used to swallow cancellation
+		GetterService:    gs,
+	}
+
+	ps := NewPullerService(dkplog.NewLogger(dkplog.WithLevel(slog.LevelError)), log.NewNop())
+	err := ps.PullImages(context.Background(), cfg)
+	require.ErrorIs(t, err, context.Canceled,
+		"context.Canceled from GetDigest must propagate even with AllowMissingTags=true")
+}
+
+// TestPullImages_AlreadyCancelledContextBailsBeforeFirstCall ensures that we
+// don't spend the user's retry budget on calls that are guaranteed to fail.
+func TestPullImages_AlreadyCancelledContextBailsBeforeFirstCall(t *testing.T) {
+	var calls atomic.Int32
+	gs := &fakeGetterService{
+		getDigest: func(ctx context.Context, _ string) (*v1.Hash, error) {
+			calls.Add(1)
+			return nil, errors.New("must not be called after ctx cancel")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := PullConfig{
+		Name:             "test",
+		ImageSet:         map[string]*ImageMeta{"reg.example/foo:v1": nil},
+		AllowMissingTags: true,
+		GetterService:    gs,
+	}
+
+	ps := NewPullerService(dkplog.NewLogger(dkplog.WithLevel(slog.LevelError)), log.NewNop())
+	err := ps.PullImages(ctx, cfg)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int32(0), calls.Load(),
+		"GetDigest must not be invoked once the context is already cancelled")
+}
+
+// TestPullImages_AllowMissingTagsStillSwallowsRealNotFound covers the
+// happy-path use of AllowMissingTags: a genuine "tag not found" must still
+// be silently skipped so callers can speculatively probe optional images.
+func TestPullImages_AllowMissingTagsStillSwallowsRealNotFound(t *testing.T) {
+	gs := &fakeGetterService{
+		getDigest: func(ctx context.Context, _ string) (*v1.Hash, error) {
+			return nil, errors.New("not found in registry")
+		},
+	}
+
+	cfg := PullConfig{
+		Name:             "test",
+		ImageSet:         map[string]*ImageMeta{"reg.example/foo:v1": nil},
+		AllowMissingTags: true,
+		GetterService:    gs,
+	}
+
+	ps := NewPullerService(dkplog.NewLogger(dkplog.WithLevel(slog.LevelError)), log.NewNop())
+	err := ps.PullImages(context.Background(), cfg)
+	require.NoError(t, err, "AllowMissingTags must continue to swallow regular not-found errors")
+}
+
+// fakeGetterService is a tiny pkg.BasicService that lets each test rewire
+// only the call it cares about.
+type fakeGetterService struct {
+	getDigest        func(ctx context.Context, tag string) (*v1.Hash, error)
+	getImage         func(ctx context.Context, tag string, opts ...registry.ImageGetOption) (pkg.RegistryImage, error)
+	checkImageExists func(ctx context.Context, tag string) error
+	listTags         func(ctx context.Context) ([]string, error)
+}
+
+func (f *fakeGetterService) GetDigest(ctx context.Context, tag string) (*v1.Hash, error) {
+	if f.getDigest != nil {
+		return f.getDigest(ctx, tag)
+	}
+	return nil, errors.New("getDigest not implemented")
+}
+
+func (f *fakeGetterService) GetImage(ctx context.Context, tag string, opts ...registry.ImageGetOption) (pkg.RegistryImage, error) {
+	if f.getImage != nil {
+		return f.getImage(ctx, tag, opts...)
+	}
+	return nil, errors.New("getImage not implemented")
+}
+
+func (f *fakeGetterService) CheckImageExists(ctx context.Context, tag string) error {
+	if f.checkImageExists != nil {
+		return f.checkImageExists(ctx, tag)
+	}
+	return errors.New("checkImageExists not implemented")
+}
+
+func (f *fakeGetterService) ListTags(ctx context.Context) ([]string, error) {
+	if f.listTags != nil {
+		return f.listTags(ctx)
+	}
+	return nil, errors.New("listTags not implemented")
+}

--- a/internal/mirror/security/security.go
+++ b/internal/mirror/security/security.go
@@ -21,15 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"time"
 
 	dkplog "github.com/deckhouse/deckhouse/pkg/log"
 	"github.com/deckhouse/deckhouse/pkg/registry/client"
 
 	"github.com/deckhouse/deckhouse-cli/internal"
-	"github.com/deckhouse/deckhouse-cli/internal/mirror/chunked"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/layouts"
@@ -195,27 +193,9 @@ func (svc *Service) pullSecurityDatabases(ctx context.Context) error {
 	}
 
 	if err := logger.Process("Pack security images into security.tar", func() error {
-		bundleChunkSize := svc.options.BundleChunkSize
-		bundleDir := svc.options.BundleDir
-
-		var security io.Writer = chunked.NewChunkedFileWriter(
-			bundleChunkSize,
-			bundleDir,
-			"security.tar",
-		)
-
-		if bundleChunkSize == 0 {
-			security, err = os.Create(filepath.Join(bundleDir, "security.tar"))
-			if err != nil {
-				return fmt.Errorf("create security.tar: %w", err)
-			}
-		}
-
-		if err := bundle.Pack(context.Background(), svc.layout.workingDir, security); err != nil {
-			return fmt.Errorf("pack security.tar: %w", err)
-		}
-
-		return nil
+		return pack.Bundle(ctx, svc.options.BundleDir, "security.tar", svc.options.BundleChunkSize, func(w io.Writer) error {
+			return bundle.Pack(ctx, svc.layout.workingDir, w)
+		})
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Problem

When `d8 mirror pull` was interrupted (Ctrl+C, kill, timeout) mid-way through downloading modules, the bundle directory ended up with a `module-<name>.tar` for every module that was listed in the registry but never actually downloaded — each weighing exactly **5120 bytes** (the skeleton of an empty OCI layout: `index.json` + `oci-layout` + empty `blobs/`).

Root causes:

1. **`AllowMissingTags` silently swallowed `context.Canceled`.**  
   In `puller.PullImages`, when `GetDigest` returned `context.Canceled`, the `AllowMissingTags=true` branch caught it and continued to the next image. The pull loop processed every remaining module as a no-op, returned nil, and the pack phase ran normally — producing empty tars for everything.

2. **`os.Create(<final>.tar)` ran before any content was written.**  
   The file existed on disk from the moment `packModules` started. If packing was interrupted or errored out, the partial/empty file remained. Context was not even propagated into `bundle.Pack*` (`context.Background()` was passed instead).

### Fix

**`internal/mirror/puller/puller.go`** — `context.Canceled` and `context.DeadlineExceeded` now propagate immediately out of `PullImages`, even with `AllowMissingTags=true`. Added a `ctx.Err()` check at the top of each iteration to bail fast without burning the retry budget.

**`internal/mirror/pack/` (new package)** — `pack.Bundle()` implements an atomic write pattern:
- Single-file: writes to `<name>.tar.tmp`, renames to `<name>.tar` only on success. On any error or cancellation the `.tmp` is removed.
- Chunked: `chunked.FileWriter` now writes chunks as `<name>.NNNN.chunk.tmp` and exposes `Finalize()` / `Cleanup()` methods — chunks only appear under their final `.chunk` name after `Finalize()` is called.

**`internal/mirror/chunked/chunk_writer.go`** — added `Finalize()`, `Cleanup()`, and temporary-suffix staging for in-flight chunk files.

**`installer`, `platform`, `security`, `modules`** — all four pack calls migrated to `pack.Bundle()` with the real user context (no more `context.Background()`).

**`internal/mirror/modules/modules.go`** — the pull loop now catches `context.Canceled` per-module and exits gracefully, then uses `context.WithoutCancel` for the post-pull pack phase so that already-downloaded data is still packed into tars (rather than discarded).

### Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| Ctrl+C mid-module-pull | ~5 KiB stub tar for every not-yet-started module | Only real tars for modules that completed |
| Pack error / kill mid-write | Partial `<name>.tar` left on disk | `.tmp` removed, no final tar appears |
| Re-run after crash | Could corrupt or append to leftover file | Stale `.tmp` silently replaced |
| Modules that did download before cancel | Packed with empty context, could be corrupted by subsequent cancel | Packed with `context.WithoutCancel`, always complete |