### PR TITLE
[deckhouse-cli] chore: add wsl_v5 linter and fix 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - unused
     - usestdlibvars
     - whitespace
+    - wsl_v5
   settings:
     errcheck:
       exclude-functions:

--- a/cmd/commands/helpjson.go
+++ b/cmd/commands/helpjson.go
@@ -87,6 +87,7 @@ func extractCommands(cmd *cobra.Command) CommandInfo {
 
 	if cmd.Use == "d8" {
 		flagSet := flag.NewFlagSet("globalFlags", flag.ExitOnError)
+
 		plainTextFlags := []string{
 			"version:v:version for d8",
 			"help:h:help for d8",
@@ -104,6 +105,7 @@ func extractCommands(cmd *cobra.Command) CommandInfo {
 	}
 
 	var subcommands []CommandInfo
+
 	for _, subCmd := range cmd.Commands() {
 		if !subCmd.Hidden {
 			subcommands = append(subcommands, extractCommands(subCmd))

--- a/cmd/commands/kubectl.go
+++ b/cmd/commands/kubectl.go
@@ -94,7 +94,9 @@ func wrapRunE(cmd *cobra.Command) {
 			os.Stderr = w
 
 			err = originalRunE(cmd, args)
+
 			w.Close()
+
 			os.Stderr = oldStderr
 
 			// Read the captured output
@@ -125,6 +127,7 @@ func getDebugImage(cmd *cobra.Command) (string, error) {
 	if val, err := cmd.InheritedFlags().GetString("kubeconfig"); err == nil {
 		configFlags.KubeConfig = &val
 	}
+
 	if val, err := cmd.InheritedFlags().GetString("context"); err == nil {
 		configFlags.Context = &val
 	}
@@ -140,6 +143,7 @@ func getDebugImage(cmd *cobra.Command) (string, error) {
 	}
 
 	var ErrGenericImageFetch = errors.New("Cannot get debug image from cluster, please specify --image explicitly")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -191,6 +195,7 @@ func NewKubectlCommand() *cobra.Command {
 	wrapRunE(kubectlCmd)
 
 	var debugCmd *cobra.Command
+
 	for _, cmd := range kubectlCmd.Commands() {
 		if cmd.Name() == "debug" {
 			debugCmd = cmd
@@ -231,6 +236,7 @@ func NewKubectlCommand() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "Continuing with default kubectl behavior...\n")
 				} else {
 					fmt.Fprintf(os.Stderr, "Using debug container image: %s\n", debugImage)
+
 					if err := cmd.Flags().Set("image", debugImage); err != nil {
 						fmt.Fprintf(os.Stderr, "Warning: cannot set debug image flag: %v\n", err)
 					}
@@ -241,6 +247,7 @@ func NewKubectlCommand() *cobra.Command {
 		if originalPersistentPreRunE != nil {
 			return originalPersistentPreRunE(cmd, args)
 		}
+
 		panic("originalPersistentPreRunE is nil, cannot proceed")
 	}
 

--- a/cmd/commands/stronghold_commands.go
+++ b/cmd/commands/stronghold_commands.go
@@ -35,6 +35,7 @@ func sortedSynopsisKeys(synopses map[string]string) []string {
 	for k := range synopses {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 
 	return keys
@@ -45,6 +46,7 @@ func sortedCommandKeys(nodes map[string]*commandNode) []string {
 	for k := range nodes {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 
 	return keys
@@ -68,6 +70,7 @@ func buildCommandTree(synopses map[string]string) map[string]*commandNode {
 		if len(parts) == 0 {
 			continue
 		}
+
 		synopsis := synopses[key]
 
 		nodes := roots
@@ -80,9 +83,11 @@ func buildCommandTree(synopses map[string]string) map[string]*commandNode {
 				}
 				nodes[part] = node
 			}
+
 			if i == len(parts)-1 {
 				node.synopsis = synopsis
 			}
+
 			nodes = node.children
 		}
 	}
@@ -137,5 +142,6 @@ func buildCobraCommands(nodes map[string]*commandNode, pathPrefix []string) []*c
 func StrongholdSubcommands() []*cobra.Command {
 	synopses := vaultcommand.CommandSynopses()
 	tree := buildCommandTree(synopses)
+
 	return buildCobraCommands(tree, nil)
 }

--- a/cmd/commands/utils.go
+++ b/cmd/commands/utils.go
@@ -29,5 +29,6 @@ func ReplaceCommandName(from, to string, c *cobra.Command) *cobra.Command {
 	for _, sub := range c.Commands() {
 		ReplaceCommandName(from, to, sub)
 	}
+
 	return c
 }

--- a/cmd/d8/root.go
+++ b/cmd/d8/root.go
@@ -162,21 +162,25 @@ func (r *RootCommand) Execute() error {
 		case helm_v3.IsPluginError(err):
 			common.ShutdownTelemetry(ctx, helm_v3.PluginErrorCode(err))
 			graceful.Terminate(ctx, err, helm_v3.PluginErrorCode(err))
+
 			return err
 		case errors.Is(err, action.ErrChangesPlanned):
 			common.ShutdownTelemetry(ctx, 2)
 			logs.FlushLogs()
 			graceful.Terminate(ctx, action.ErrChangesPlanned, 2)
+
 			return err
 		}
 
 		common.ShutdownTelemetry(ctx, 1)
 		graceful.Terminate(ctx, err, 1)
+
 		return err
 	}
 
 	common.ShutdownTelemetry(ctx, 0)
 	logs.FlushLogs()
+
 	return nil
 }
 
@@ -192,6 +196,7 @@ func execute() {
 		} else {
 			fmt.Fprintf(os.Stderr, "Error executing command: %v\n", err)
 		}
+
 		os.Exit(1)
 	}
 }

--- a/internal/auth/tokenexchange/cmd/tokenexchange.go
+++ b/internal/auth/tokenexchange/cmd/tokenexchange.go
@@ -181,6 +181,7 @@ func runTokenExchange(flags *tokenExchangeFlags) error {
 	case "json":
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
+
 		if err := encoder.Encode(resp); err != nil {
 			return fmt.Errorf("failed to encode response: %w", err)
 		}

--- a/internal/auth/tokenexchange/tokenexchange.go
+++ b/internal/auth/tokenexchange/tokenexchange.go
@@ -125,15 +125,19 @@ func (c *Config) Validate() error {
 	if c.DexURL == "" {
 		errs = multierror.Append(errs, fmt.Errorf("--dex-url is required"))
 	}
+
 	if c.ClientID == "" {
 		errs = multierror.Append(errs, fmt.Errorf("--client-id is required"))
 	}
+
 	if c.ClientSecret == "" {
 		errs = multierror.Append(errs, fmt.Errorf("--client-secret is required"))
 	}
+
 	if c.SubjectToken == "" {
 		errs = multierror.Append(errs, fmt.Errorf("--subject-token is required"))
 	}
+
 	if c.ConnectorID == "" {
 		errs = multierror.Append(errs, fmt.Errorf("--connector-id is required"))
 	}
@@ -192,10 +196,12 @@ func (c *Client) Exchange() (*Response, error) {
 // buildTokenURL constructs the Dex token endpoint URL.
 func (c *Client) buildTokenURL() (string, error) {
 	baseURL := strings.TrimSuffix(c.config.DexURL, "/")
+
 	tokenURL, err := url.JoinPath(baseURL, "/token")
 	if err != nil {
 		return "", err
 	}
+
 	return tokenURL, nil
 }
 
@@ -211,6 +217,7 @@ func (c *Client) buildFormData() url.Values {
 	if subjectTokenType == "" {
 		subjectTokenType = "id_token"
 	}
+
 	if subjectTokenType == "id_token" {
 		data.Set("subject_token_type", TokenTypeIDToken)
 	} else {
@@ -222,6 +229,7 @@ func (c *Client) buildFormData() url.Values {
 	if scope == "" {
 		scope = DefaultScope
 	}
+
 	data.Set("scope", scope)
 
 	// Set requested token type
@@ -229,6 +237,7 @@ func (c *Client) buildFormData() url.Values {
 	if requestedTokenType == "" {
 		requestedTokenType = "id_token"
 	}
+
 	if requestedTokenType == "id_token" {
 		data.Set("requested_token_type", TokenTypeIDToken)
 	} else {
@@ -254,6 +263,7 @@ func (c *Client) handleErrorResponse(statusCode int, body []byte) error {
 	if hint != "" {
 		return fmt.Errorf("token exchange failed (status %d): %s\nHint: %s", statusCode, baseMsg, hint)
 	}
+
 	return fmt.Errorf("token exchange failed (status %d): %s", statusCode, baseMsg)
 }
 
@@ -305,6 +315,7 @@ func createHTTPClient(cfg *Config) (*http.Client, error) {
 		if !caCertPool.AppendCertsFromPEM(caCert) {
 			return nil, fmt.Errorf("failed to parse CA certificate")
 		}
+
 		tlsConfig.RootCAs = caCertPool
 	}
 

--- a/internal/backup/cmd/cluster-config/cluster_config.go
+++ b/internal/backup/cmd/cluster-config/cluster_config.go
@@ -48,6 +48,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(clusterConfigCmd.Flags())
+
 	return clusterConfigCmd
 }
 
@@ -74,6 +75,7 @@ func backupConfigs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	namespaces, err := getNamespacesFromCluster(kubeCl)
 	if err != nil {
 		return err
@@ -83,9 +85,11 @@ func backupConfigs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to create temp file: %v", err)
 	}
+
 	defer func() {
 		os.Remove(tarFile.Name())
 	}()
+
 	backup := tarball.NewBackup(tarFile, tarball.BackupOptions{Compress: compress})
 
 	backupStages := []*BackupStage{
@@ -124,9 +128,11 @@ func backupConfigs(cmd *cobra.Command, args []string) error {
 	if err = backup.Close(); err != nil {
 		return fmt.Errorf("close tarball failed: %w", err)
 	}
+
 	if err = tarFile.Sync(); err != nil {
 		return fmt.Errorf("tarball flush failed: %w", err)
 	}
+
 	if err = tarFile.Close(); err != nil {
 		return fmt.Errorf("tarball close failed: %w", err)
 	}
@@ -143,9 +149,11 @@ func getNamespacesFromCluster(kubeCl *kubernetes.Clientset) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to list namespaces: %w", err)
 	}
+
 	namespaces := lo.Map(namespaceList.Items, func(ns corev1.Namespace, _ int) string {
 		return ns.Name
 	})
+
 	return namespaces, nil
 }
 
@@ -166,5 +174,6 @@ func setupK8sClients(cmd *cobra.Command) (*rest.Config, *kubernetes.Clientset, *
 	}
 
 	dynamicCl := dynamic.New(kubeCl.RESTClient())
+
 	return restConfig, kubeCl, dynamicCl, nil
 }

--- a/internal/backup/cmd/etcd/etcd.go
+++ b/internal/backup/cmd/etcd/etcd.go
@@ -62,6 +62,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	addFlags(etcdCmd.Flags())
+
 	return etcdCmd
 }
 
@@ -80,6 +81,7 @@ var (
 
 func etcd(cmd *cobra.Command, args []string) error {
 	log.SetFlags(log.LstdFlags)
+
 	if len(args) != 1 {
 		return fmt.Errorf("This command requires exactly 1 argument")
 	}
@@ -148,6 +150,7 @@ func etcd(cmd *cobra.Command, args []string) error {
 			log.Printf("%s: Fail, %v\n", etcdPodName, err)
 			continue
 		}
+
 		if !snapshotStreamingSupported {
 			log.Printf("%s: etcd instance does not support snapshot streaming\n", etcdPodName)
 			continue
@@ -155,9 +158,11 @@ func etcd(cmd *cobra.Command, args []string) error {
 
 		if err = streamCommand(kubeCl, config, pipeExecOpts, etcdPodName, etcdPodNamespace, stdout, stderr); err != nil {
 			log.Printf("%s: Fail, %v\n", etcdPodName, err)
+
 			if verboseLog {
 				log.Println("STDERR:", stderr.String())
 			}
+
 			continue
 		}
 
@@ -170,6 +175,7 @@ func etcd(cmd *cobra.Command, args []string) error {
 		}
 
 		log.Println("Snapshot successfully taken from", etcdPodName)
+
 		return nil
 	}
 
@@ -195,6 +201,7 @@ func checkEtcdInstanceSupportsSnapshotStreaming(
 		if verboseLog {
 			log.Println("HELP STDERR:", stderr.String())
 		}
+
 		return false, fmt.Errorf("streamCommand: %w", err)
 	}
 
@@ -213,6 +220,7 @@ func streamCommand(
 	stdout, stderr io.Writer,
 ) error {
 	scheme := runtime.NewScheme()
+
 	parameterCodec := runtime.NewParameterCodec(scheme)
 	if err := v1.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("Failed to create parameter codec: %w", err)

--- a/internal/backup/cmd/etcd/flags.go
+++ b/internal/backup/cmd/etcd/flags.go
@@ -49,6 +49,7 @@ func validateFlags(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("Invalid --kubeconfig: %w", err)
 	}
+
 	if !stats.Mode().IsRegular() {
 		return fmt.Errorf("Invalid --kubeconfig: %s is not a regular file", kubeconfigPath)
 	}

--- a/internal/backup/cmd/loki/loki.go
+++ b/internal/backup/cmd/loki/loki.go
@@ -60,6 +60,7 @@ func NewCommand() *cobra.Command {
 		RunE:          backupLoki,
 	}
 	addFlags(lokiCmd.Flags())
+
 	return lokiCmd
 }
 
@@ -128,6 +129,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error get end timestamp for loki: %w", err)
 	}
+
 	chunkSize := time.Duration(chunkDaysFlag) * 24 * time.Hour
 	for chunkEnd := endDumpTimestamp; chunkEnd > 0; chunkEnd -= chunkSize.Nanoseconds() {
 		chunkStart := chunkEnd - chunkSize.Nanoseconds()
@@ -137,6 +139,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 				return err
 			}
 		}
+
 		curlParamStreamList := CurlRequest{
 			BaseURL: "series",
 			Params: map[string]string{
@@ -147,6 +150,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 		}
 
 		streamListDumpCurl := curlParamStreamList.GenerateCurlCommand()
+
 		_, streamListDumpJSON, err := getLogWithRetry(config, kubeCl, streamListDumpCurl)
 		if err != nil {
 			return fmt.Errorf("error get stream list JSON from loki: %w", err)
@@ -164,6 +168,7 @@ func backupLoki(cmd *cobra.Command, _ []string) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -172,6 +177,7 @@ func fetchLogs(chunkStart, endDumpTimestamp int64, token string, r map[string]st
 	for key, value := range r {
 		filters = append(filters, fmt.Sprintf(`%s=%q`, key, value))
 	}
+
 	q := fmt.Sprintf(`{%s}`, strings.Join(filters, ", "))
 
 	chunkEnd := endDumpTimestamp
@@ -188,6 +194,7 @@ func fetchLogs(chunkStart, endDumpTimestamp int64, token string, r map[string]st
 			AuthToken: token,
 		}
 		dumpLogCurl := curlParamDumpLog.GenerateCurlCommand()
+
 		dumpLogCurlJSON, _, err := getLogWithRetry(config, kubeCl, dumpLogCurl)
 		if err != nil {
 			return fmt.Errorf("error get JSON from Loki: %w", err)
@@ -203,32 +210,39 @@ func fetchLogs(chunkStart, endDumpTimestamp int64, token string, r map[string]st
 				if err != nil {
 					return fmt.Errorf("error converting timestamp: %w", err)
 				}
+
 				timestampUtc := time.Unix(0, timestampInt64).UTC()
 				fmt.Printf("Timestamp: [%v], Log: %s\n", timestampUtc, entry[1])
 			}
 		}
 		// get last timestamp value from stream Loki api response to use pagination and get all log strings.
 		lastLog := dumpLogCurlJSON.Data.Result[0].Values[len(dumpLogCurlJSON.Data.Result[0].Values)-1][0]
+
 		lastTimestamp, err := strconv.ParseInt(lastLog, 10, 64)
 		if err != nil {
 			return fmt.Errorf("error converting timestamp: %w", err)
 		}
+
 		chunkEnd = lastTimestamp
 	}
+
 	return nil
 }
 
 func (c *CurlRequest) GenerateCurlCommand() []string {
 	curlParts := []string{"curl", "--insecure", "-v"}
+
 	curlParts = append(curlParts, fmt.Sprintf("%s/%s", lokiURL, c.BaseURL))
 	for key, value := range c.Params {
 		if value != "" {
 			curlParts = append(curlParts, []string{"--data-urlencode", fmt.Sprintf("%s=%s", key, value)}...)
 		}
 	}
+
 	if c.AuthToken != "" {
 		curlParts = append(curlParts, []string{"-H", fmt.Sprintf("Authorization: Bearer %s", c.AuthToken)}...)
 	}
+
 	return curlParts
 }
 
@@ -240,10 +254,12 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 		if err != nil {
 			return nil, nil, err
 		}
+
 		executor, err := utilk8s.ExecInPod(config, kubeCl, fullCommand, podName, namespaceDeckhouse, containerName)
 		if err != nil {
 			return nil, nil, err
 		}
+
 		if err = executor.StreamWithContext(
 			context.Background(),
 			remotecommand.StreamOptions{
@@ -256,25 +272,32 @@ func getLogTimestamp(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 
 		if apiURLLoki == fmt.Sprintf("%s/series", lokiURL) {
 			var series SeriesAPI
+
 			if !json.Valid(stdout.Bytes()) {
 				return nil, nil, fmt.Errorf("error response from loki api: %s", stdout.String())
 			}
+
 			err = json.Unmarshal(stdout.Bytes(), &series)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed unmarshal loki response: %w", err)
 			}
+
 			return nil, &series, nil
 		} else if apiURLLoki == fmt.Sprintf("%s/query_range", lokiURL) {
 			var queryRange QueryRange
+
 			if !json.Valid(stdout.Bytes()) {
 				return nil, nil, fmt.Errorf("error response from loki api: %s", stdout.String())
 			}
+
 			err = json.Unmarshal(stdout.Bytes(), &queryRange)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed unmarshal loki response: %w", err)
 			}
+
 			return &queryRange, nil, nil
 		}
+
 		stdout.Reset()
 	}
 
@@ -287,6 +310,7 @@ func parseEndTimestampFromFlag(dateStr string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error parsing date: %w, please provide correct date", err)
 	}
+
 	return end.UnixNano(), nil
 }
 
@@ -303,6 +327,7 @@ func fetchEndTimestampFromLoki(config *rest.Config, kubeCl kubernetes.Interface,
 	}
 
 	curlCmd := curlParam.GenerateCurlCommand()
+
 	response, _, err := getLogWithRetryFunc(config, kubeCl, curlCmd)
 	if err != nil {
 		return 0, fmt.Errorf("error get latest timestamp JSON from loki: %w", err)
@@ -325,6 +350,7 @@ func getEndTimestamp(config *rest.Config, kubeCl kubernetes.Interface, token str
 	if endTimestamp != "" {
 		return parseEndTimestampFromFlag(endTimestamp)
 	}
+
 	return fetchEndTimestampFromLoki(config, kubeCl, token)
 }
 
@@ -333,6 +359,7 @@ func getStartTimestamp() (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error parsing date: %w, please provide correct date", err)
 	}
+
 	startTimestampNanoSec := start.UnixNano()
 
 	return startTimestampNanoSec, nil
@@ -348,6 +375,7 @@ func getTokenLokiSa(kubeCl kubernetes.Interface) (string, error) {
 	if !exists {
 		return "", fmt.Errorf("token not found in secret: %w", err)
 	}
+
 	return string(tokenBase64), err
 }
 
@@ -367,10 +395,12 @@ func getLogWithRetry(config *rest.Config, kubeCl kubernetes.Interface, fullComma
 			if err != nil {
 				return fmt.Errorf("error get JSON response from loki: %w", err)
 			}
+
 			return nil
 		}))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error get JSON from loki: %w", err)
 	}
+
 	return QueryRangeDump, SeriesAPIDump, nil
 }

--- a/internal/backup/configs/configmaps/backup.go
+++ b/internal/backup/configs/configmaps/backup.go
@@ -38,6 +38,7 @@ func BackupConfigMaps(
 				Kind:       "ConfigMap",
 				APIVersion: corev1.SchemeGroupVersion.String(),
 			}
+
 			return &item
 		})
 	})

--- a/internal/backup/configs/crds/custom_resources.go
+++ b/internal/backup/configs/crds/custom_resources.go
@@ -84,6 +84,7 @@ func BackupCustomResources(
 
 	cwResources := lo.Map(clusterwideResourcesToBackup, func(resource *customResourceDescription, _ int) []runtime.Object {
 		query := dynamic.ResourceInterface(dynamicCl.Resource(resource.gvr))
+
 		list, err := query.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			log.Fatalf("Failed to list %s: %v", resource.gvr, err)

--- a/internal/backup/configs/roles/cluster_roles.go
+++ b/internal/backup/configs/roles/cluster_roles.go
@@ -36,6 +36,7 @@ func BackupClusterRoles(
 			Kind:       "ClusterRole",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		}
+
 		return &item
 	}), nil
 }
@@ -61,6 +62,7 @@ func BackupClusterRoleBindings(
 			Kind:       "ClusterRoleBinding",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
 		}
+
 		return &item
 	}), nil
 }

--- a/internal/backup/configs/secrets/backup.go
+++ b/internal/backup/configs/secrets/backup.go
@@ -38,6 +38,7 @@ func BackupSecrets(
 				Kind:       "Secret",
 				APIVersion: corev1.SchemeGroupVersion.String(),
 			}
+
 			return &secret
 		})
 	})

--- a/internal/backup/configs/storageclasses/storage_classes.go
+++ b/internal/backup/configs/storageclasses/storage_classes.go
@@ -34,6 +34,7 @@ func BackupStorageClasses(
 			Kind:       "StorageClass",
 			APIVersion: v1.SchemeGroupVersion.String(),
 		}
+
 		return &item
 	}), nil
 }

--- a/internal/backup/configs/tarball/backup.go
+++ b/internal/backup/configs/tarball/backup.go
@@ -30,6 +30,7 @@ type BackupOptions struct {
 
 func NewBackup(sink io.Writer, opts BackupOptions) *Backup {
 	w := sink
+
 	var gzipWriter *gzip.Writer
 	if opts.Compress {
 		gzipWriter = gzip.NewWriter(w)
@@ -54,6 +55,7 @@ func (b *Backup) PutObject(object runtime.Object) error {
 	metadataAccessor.SetManagedFields(nil)
 
 	kind := object.GetObjectKind().GroupVersionKind().Kind
+
 	name, namespace := metadataAccessor.GetName(), metadataAccessor.GetNamespace()
 	if namespace == "" {
 		namespace = "Cluster-Scoped"

--- a/internal/backup/configs/whitelist/whitelist.go
+++ b/internal/backup/configs/whitelist/whitelist.go
@@ -34,6 +34,7 @@ func (f *BakedInFilter) Matches(obj runtime.Object) bool {
 		log.Printf("%s does not contain metadata to filter with", obj.GetObjectKind().GroupVersionKind().String())
 		return false
 	}
+
 	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	name, namespace := metadataAccessor.GetName(), metadataAccessor.GetNamespace()
 

--- a/internal/cni/api/v1alpha1/register.go
+++ b/internal/cni/api/v1alpha1/register.go
@@ -46,5 +46,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&CNINodeMigrationList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
 	return nil
 }

--- a/internal/cni/cleanup.go
+++ b/internal/cni/cleanup.go
@@ -56,10 +56,12 @@ func RunCleanup() error {
 
 	for _, m := range migrations.Items {
 		fmt.Printf("Deleting CNIMigration '%s'...", m.Name)
+
 		if err := rtClient.Delete(ctx, &m); err != nil {
 			if !errors.IsNotFound(err) {
 				return fmt.Errorf("deleting CNIMigration %s: %w", m.Name, err)
 			}
+
 			fmt.Println(" already deleted")
 		} else {
 			fmt.Println(" done")
@@ -67,5 +69,6 @@ func RunCleanup() error {
 	}
 
 	fmt.Println("🎉 Cleanup triggered. The cluster-internal controllers will handle the rest")
+
 	return nil
 }

--- a/internal/cni/switch.go
+++ b/internal/cni/switch.go
@@ -35,6 +35,7 @@ func RunSwitch(targetCNI string) error {
 	if err != nil {
 		return fmt.Errorf("asking for confirmation: %w", err)
 	}
+
 	if !confirmed {
 		fmt.Println("Operation cancelled by user")
 		return ErrCancelled
@@ -58,6 +59,7 @@ func RunSwitch(targetCNI string) error {
 	if err != nil {
 		return fmt.Errorf("checking for existing migration: %w", err)
 	}
+
 	if existingMigration != nil {
 		return fmt.Errorf("a CNI migration (%s) is already in progress. "+
 			"Please use 'd8 network cni-migration watch' to monitor it or 'd8 network cni-migration cleanup' to abort it",

--- a/internal/cni/watch.go
+++ b/internal/cni/watch.go
@@ -39,6 +39,7 @@ func isNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
+
 	errStr := err.Error()
 	if strings.Contains(errStr, "EOF") ||
 		strings.Contains(errStr, "connection refused") ||
@@ -58,6 +59,7 @@ func isNetworkError(err error) bool {
 		strings.Contains(errStr, "connection reset by peer") {
 		return true
 	}
+
 	return false
 }
 
@@ -99,28 +101,35 @@ func RunWatch() error {
 			if err != nil {
 				// Clear footer before warning
 				clearFooter(footerLines)
+
 				if isNetworkError(err) || apiDown {
 					if !apiDown {
 						fmt.Printf(
 							"[%s] ⏳ API Server is temporarily unavailable (restarting). Waiting!\n",
 							time.Now().Format("15:04:05"),
 						)
+
 						apiDown = true
 					}
+
 					footerLines = 0
+
 					if lastPhaseMsg != "" {
 						termWidth := getTermWidth()
 						if termWidth <= 0 {
 							termWidth = 80
 						}
+
 						footerLines = printFooter(lastPhaseMsg, termWidth)
 					}
 				} else {
 					msg := fmt.Sprintf("⚠️ Error finding active migration: %v", err)
+
 					termWidth := getTermWidth()
 					if termWidth <= 0 {
 						termWidth = 80
 					}
+
 					footerLines = printFooter(msg, termWidth)
 				}
 
@@ -133,6 +142,7 @@ func RunWatch() error {
 
 			if apiDown {
 				fmt.Printf("[%s] ⚡️ API Server is back online\n", time.Now().Format("15:04:05"))
+
 				apiDown = false
 			}
 
@@ -143,6 +153,7 @@ func RunWatch() error {
 				} else {
 					fmt.Println("🔎 No active migration found")
 				}
+
 				return nil
 			}
 
@@ -170,6 +181,7 @@ func RunWatch() error {
 					c.Type, c.Status, c.Reason, c.Message)
 
 				var icon string
+
 				shouldPrint := false
 				isProgress := false
 
@@ -204,6 +216,7 @@ func RunWatch() error {
 								c.Message,
 								stepDuration.Round(time.Second))
 						}
+
 						printedEvents[eventKey] = true
 					}
 
@@ -219,6 +232,7 @@ func RunWatch() error {
 				failKey := fmt.Sprintf("fail|%s|%s", f.Node, f.Reason)
 				if !printedEvents[failKey] {
 					fmt.Printf("⚠️ Node %s failed: %s\n", f.Node, f.Reason)
+
 					printedEvents[failKey] = true
 				}
 			}
@@ -230,8 +244,10 @@ func RunWatch() error {
 					fmt.Printf("🎉 CNI switch to '%s' completed successfully! (Total time: %s)\n",
 						activeMigration.Spec.TargetCNI,
 						totalDuration.Round(time.Second))
+
 					return nil
 				}
+
 				if cond.Status == metav1.ConditionFalse && cond.Reason == "Error" {
 					return ErrMigrationFailed
 				}
@@ -246,6 +262,7 @@ func RunWatch() error {
 					phaseMsg += fmt.Sprintf(" (Failed Nodes: %d)", count)
 				}
 			}
+
 			lastPhaseMsg = phaseMsg
 
 			if phaseMsg != "" {
@@ -253,6 +270,7 @@ func RunWatch() error {
 				if termWidth <= 0 {
 					termWidth = 80
 				}
+
 				lines := printFooter(phaseMsg, termWidth)
 				footerLines += lines
 			}
@@ -271,6 +289,7 @@ func getTermWidth() int {
 	if err != nil {
 		return 80
 	}
+
 	return width
 }
 

--- a/internal/cr/cmd/basic/catalog.go
+++ b/internal/cr/cmd/basic/catalog.go
@@ -30,6 +30,7 @@ import (
 
 func NewCatalogCmd(opts *registry.Options) *cobra.Command {
 	var fullRef bool
+
 	cmd := &cobra.Command{
 		Use:               "catalog REGISTRY",
 		Short:             "List the repositories in a registry",
@@ -40,6 +41,7 @@ func NewCatalogCmd(opts *registry.Options) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "Print the full repository reference (registry/repo)")
+
 	return cmd
 }
 
@@ -50,10 +52,12 @@ func runCatalog(ctx context.Context, w io.Writer, src string, fullRef bool, opts
 			if fullRef {
 				line = path.Join(src, repo)
 			}
+
 			if _, err := fmt.Fprintln(w, line); err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 }

--- a/internal/cr/cmd/basic/config.go
+++ b/internal/cr/cmd/basic/config.go
@@ -36,7 +36,9 @@ resolved to a single image via --platform.`,
 			if err != nil {
 				return err
 			}
+
 			_, err = cmd.OutOrStdout().Write(data)
+
 			return err
 		},
 	}

--- a/internal/cr/cmd/basic/digest.go
+++ b/internal/cr/cmd/basic/digest.go
@@ -34,6 +34,7 @@ func NewDigestCmd(opts *registry.Options) *cobra.Command {
 		tarballPath string
 		fullRef     bool
 	)
+
 	cmd := &cobra.Command{
 		Use:   "digest [IMAGE]",
 		Short: "Print the digest of an image",
@@ -48,6 +49,7 @@ selects an entry by tag (the first entry is used if omitted).
 			if fullRef && tarballPath != "" {
 				return errors.New("--full-ref cannot be combined with --tarball")
 			}
+
 			if tarballPath == "" && len(args) == 0 {
 				return errors.New("image reference required when --tarball is not used")
 			}
@@ -68,12 +70,15 @@ selects an entry by tag (the first entry is used if omitted).
 			if err != nil {
 				return fmt.Errorf("parse reference %q: %w", args[0], err)
 			}
+
 			_, err = fmt.Fprintln(w, ref.Context().Digest(digest))
+
 			return err
 		},
 	}
 	cmd.Flags().StringVar(&tarballPath, "tarball", "", "Read the digest from a local tarball instead of the registry")
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "Print the full image reference with digest (registry/repo@sha256:...); incompatible with --tarball")
+
 	return cmd
 }
 
@@ -86,13 +91,16 @@ func resolveDigest(ctx context.Context, tarballPath string, args []string, opts 
 	if len(args) > 0 {
 		tag = args[0]
 	}
+
 	img, err := imageio.LoadTarball(tarballPath, tag)
 	if err != nil {
 		return "", err
 	}
+
 	d, err := img.Digest()
 	if err != nil {
 		return "", fmt.Errorf("compute digest: %w", err)
 	}
+
 	return d.String(), nil
 }

--- a/internal/cr/cmd/basic/export.go
+++ b/internal/cr/cmd/basic/export.go
@@ -58,6 +58,7 @@ Examples:
 			if len(args) > 1 {
 				dst = args[1]
 			}
+
 			return runExport(cmd, args[0], dst, opts)
 		},
 	}
@@ -76,6 +77,7 @@ func runExport(cmd *cobra.Command, src, dst string, opts *registry.Options) erro
 
 	exportErr := exportImage(img, w)
 	closeErr := closeFn()
+
 	if exportErr != nil {
 		// File-sink target is now a half-written tar that callers would
 		// likely consume by mistake (`tar tf` happily reads short streams).
@@ -83,8 +85,10 @@ func runExport(cmd *cobra.Command, src, dst string, opts *registry.Options) erro
 		if dst != "-" {
 			_ = os.Remove(dst)
 		}
+
 		return exportErr
 	}
+
 	return closeErr
 }
 
@@ -102,28 +106,35 @@ func exportImage(img v1.Image, w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("get layers: %w", err)
 	}
+
 	if len(layers) == 1 {
 		mt, err := layers[0].MediaType()
 		if err != nil {
 			return fmt.Errorf("media type: %w", err)
 		}
+
 		if !mt.IsLayer() {
 			rc, err := layers[0].Uncompressed()
 			if err != nil {
 				return fmt.Errorf("uncompress: %w", err)
 			}
 			defer rc.Close()
+
 			if _, err := io.Copy(w, rc); err != nil {
 				return fmt.Errorf("copy: %w", err)
 			}
+
 			return nil
 		}
 	}
+
 	rc := mutate.Extract(img)
 	defer rc.Close()
+
 	if _, err := io.Copy(w, rc); err != nil {
 		return fmt.Errorf("copy: %w", err)
 	}
+
 	return nil
 }
 
@@ -131,14 +142,17 @@ func openExportSink(cmd *cobra.Command, dst string) (io.Writer, func() error, er
 	if dst == "-" {
 		return cmd.OutOrStdout(), func() error { return nil }, nil
 	}
+
 	f, err := os.Create(dst)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create %s: %w", dst, err)
 	}
+
 	return f, func() error {
 		if err := f.Close(); err != nil {
 			return fmt.Errorf("close %s: %w", dst, err)
 		}
+
 		return nil
 	}, nil
 }

--- a/internal/cr/cmd/basic/ls.go
+++ b/internal/cr/cmd/basic/ls.go
@@ -36,6 +36,7 @@ func NewLsCmd(opts *registry.Options) *cobra.Command {
 		fullRef        bool
 		omitDigestTags bool
 	)
+
 	cmd := &cobra.Command{
 		Use:               "ls REPO",
 		Short:             "List the tags in a repository",
@@ -47,16 +48,19 @@ func NewLsCmd(opts *registry.Options) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&fullRef, "full-ref", false, "Print the full image reference (registry/repo:tag)")
 	cmd.Flags().BoolVarP(&omitDigestTags, "omit-digest-tags", "O", false, "Skip digest-based tags (sha256-*) created by signing tools")
+
 	return cmd
 }
 
 func runLs(ctx context.Context, w io.Writer, src string, fullRef, omitDigestTags bool, opts *registry.Options) error {
 	var repo name.Repository
+
 	if fullRef {
 		r, err := name.NewRepository(src, opts.Name...)
 		if err != nil {
 			return fmt.Errorf("parse repository %q: %w", src, err)
 		}
+
 		repo = r
 	}
 
@@ -65,14 +69,17 @@ func runLs(ctx context.Context, w io.Writer, src string, fullRef, omitDigestTags
 			if omitDigestTags && strings.HasPrefix(tag, digestTagPrefix) {
 				continue
 			}
+
 			line := tag
 			if fullRef {
 				line = repo.Tag(tag).String()
 			}
+
 			if _, err := fmt.Fprintln(w, line); err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 }

--- a/internal/cr/cmd/basic/manifest.go
+++ b/internal/cr/cmd/basic/manifest.go
@@ -36,7 +36,9 @@ registry returned them. Suitable for piping to jq or for signature verification.
 			if err != nil {
 				return err
 			}
+
 			_, err = cmd.OutOrStdout().Write(data)
+
 			return err
 		},
 	}

--- a/internal/cr/cmd/basic/pull.go
+++ b/internal/cr/cmd/basic/pull.go
@@ -32,6 +32,7 @@ func NewPullCmd(opts *registry.Options) *cobra.Command {
 		cachePath string
 		format    string
 	)
+
 	cmd := &cobra.Command{
 		Use:   "pull IMAGE... PATH",
 		Short: "Pull one or more remote images to a local path",
@@ -76,6 +77,7 @@ On interruption (Ctrl+C):
 	cmd.Flags().StringVar(&format, "format", imageio.PullFormatTarball,
 		fmt.Sprintf("Output format (one of: %s, %s, %s)", imageio.PullFormatTarball, imageio.PullFormatLegacy, imageio.PullFormatOCI))
 	_ = cmd.RegisterFlagCompletionFunc("format", completion.Static(completion.PullFormats()...))
+
 	return cmd
 }
 
@@ -87,6 +89,7 @@ func runPull(cmd *cobra.Command, args []string, format, cachePath string, opts *
 	srcList, dst := args[:len(args)-1], args[len(args)-1]
 
 	keepIndex := format == imageio.PullFormatOCI
+
 	resolved, err := image.Resolve(cmd.Context(), srcList, keepIndex, cachePath, opts)
 	if err != nil {
 		return err

--- a/internal/cr/cmd/basic/push.go
+++ b/internal/cr/cmd/basic/push.go
@@ -35,6 +35,7 @@ func NewPushCmd(opts *registry.Options) *cobra.Command {
 		asIndex       bool
 		imageRefsPath string
 	)
+
 	cmd := &cobra.Command{
 		Use:   "push PATH IMAGE",
 		Short: "Push a local image to a registry",
@@ -51,6 +52,7 @@ write it to a file. --image-refs overwrites the target file if it exists.`,
 	}
 	cmd.Flags().BoolVar(&asIndex, "index", false, "Push a multi-manifest OCI layout as an index (OCI layout dirs only)")
 	cmd.Flags().StringVar(&imageRefsPath, "image-refs", "", "Persist the pushed reference (with digest) to this file")
+
 	return cmd
 }
 
@@ -80,6 +82,8 @@ func runPush(ctx context.Context, w io.Writer, path, tagRef string, asIndex bool
 			return fmt.Errorf("write image refs %s: %w", imageRefsPath, err)
 		}
 	}
+
 	_, err = fmt.Fprintln(w, fullRef)
+
 	return err
 }

--- a/internal/cr/cmd/completion/completion.go
+++ b/internal/cr/cmd/completion/completion.go
@@ -103,13 +103,16 @@ func parseRef(s string) refParts {
 	if s == "" {
 		return refParts{kind: kindEmpty}
 	}
+
 	host, pathPart, found := strings.Cut(s, "/")
 	if !found {
 		return refParts{kind: kindHost, host: s}
 	}
+
 	if pathPart == "" {
 		return refParts{kind: kindHostSlash, host: host}
 	}
+
 	if before, _, found := strings.Cut(pathPart, "@"); found {
 		return refParts{
 			kind:     kindRepoDigest,
@@ -117,6 +120,7 @@ func parseRef(s string) refParts {
 			repoPath: strings.TrimRight(before, "/"),
 		}
 	}
+
 	if i := strings.LastIndex(pathPart, ":"); i != -1 {
 		return refParts{
 			kind:     kindRepoColon,
@@ -165,10 +169,12 @@ func Static(values ...string) cobra.CompletionFunc {
 // for the first positional, image completion for the rest.
 func PathThenImage() cobra.CompletionFunc {
 	imgFn := ImageRef()
+
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return nil, cobra.ShellCompDirectiveDefault
 		}
+
 		return imgFn(cmd, args, toComplete)
 	}
 }
@@ -177,10 +183,12 @@ func PathThenImage() cobra.CompletionFunc {
 // completion for the first positional, file completion for the rest.
 func ImageThenPath() cobra.CompletionFunc {
 	imgFn := ImageRef()
+
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return imgFn(cmd, args, toComplete)
 		}
+
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 }
@@ -192,10 +200,12 @@ func ImageThenPath() cobra.CompletionFunc {
 // returned to avoid misleading the user with local file suggestions.
 func ImageThenInImagePath() cobra.CompletionFunc {
 	imgFn := ImageRef()
+
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return imgFn(cmd, args, toComplete)
 		}
+
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 }
@@ -219,6 +229,7 @@ func completeRefValue(cmd *cobra.Command, toComplete string, withTags bool) ([]s
 		if len(repos) == 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+
 		suggestions := make([]string, 0, len(repos))
 		for _, r := range repos {
 			suggestions = append(suggestions, parts.host+"/"+r)
@@ -238,17 +249,22 @@ func completeRefValue(cmd *cobra.Command, toComplete string, withTags bool) ([]s
 		if !withTags {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+
 		repoFull := parts.host + "/" + parts.repoPath
+
 		tags := tryListTags(cmd, repoFull)
 		if len(tags) == 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+
 		suggestions := make([]string, 0, len(tags))
 		for _, t := range tags {
 			suggestions = append(suggestions, repoFull+":"+t)
 		}
+
 		return filterByPrefix(suggestions, toComplete), cobra.ShellCompDirectiveNoFileComp
 	}
+
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -258,22 +274,27 @@ func completeRefValue(cmd *cobra.Command, toComplete string, withTags bool) ([]s
 func tryListCatalog(cmd *cobra.Command, host string) []string {
 	ctx, cancel := completionContext(cmd)
 	defer cancel()
+
 	opts := buildCompletionOpts(cmd)
 
 	var items []string
+
 	err := listCatalogFn(ctx, host, opts, func(repos []string) error {
 		items = append(items, repos...)
 		if len(items) >= completionMaxItems {
 			return errStopPagination
 		}
+
 		return nil
 	})
 	if err != nil && !errors.Is(err, errStopPagination) {
 		return nil
 	}
+
 	if len(items) > completionMaxItems {
 		items = items[:completionMaxItems]
 	}
+
 	return items
 }
 
@@ -281,22 +302,27 @@ func tryListCatalog(cmd *cobra.Command, host string) []string {
 func tryListTags(cmd *cobra.Command, repoRef string) []string {
 	ctx, cancel := completionContext(cmd)
 	defer cancel()
+
 	opts := buildCompletionOpts(cmd)
 
 	var items []string
+
 	err := listTagsFn(ctx, repoRef, opts, func(tags []string) error {
 		items = append(items, tags...)
 		if len(items) >= completionMaxItems {
 			return errStopPagination
 		}
+
 		return nil
 	})
 	if err != nil && !errors.Is(err, errStopPagination) {
 		return nil
 	}
+
 	if len(items) > completionMaxItems {
 		items = items[:completionMaxItems]
 	}
+
 	return items
 }
 
@@ -305,6 +331,7 @@ func completionContext(cmd *cobra.Command) (context.Context, context.CancelFunc)
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
 	return context.WithTimeout(ctx, completionTimeout)
 }
 
@@ -318,11 +345,13 @@ func buildCompletionOpts(cmd *cobra.Command) *registry.Options {
 	if insecure, err := cmd.Flags().GetBool(rootflagnames.Insecure); err == nil && insecure {
 		opts.WithInsecure().WithTransport(registry.InsecureTransport())
 	}
+
 	if platform, err := cmd.Flags().GetString(rootflagnames.Platform); err == nil && platform != "" {
 		if p, err := v1.ParsePlatform(platform); err == nil {
 			opts.WithPlatform(p)
 		}
 	}
+
 	return opts
 }
 
@@ -335,10 +364,12 @@ func dockerConfigDir() string {
 	if d := os.Getenv("DOCKER_CONFIG"); d != "" {
 		return d
 	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
+
 	return filepath.Join(home, ".docker")
 }
 
@@ -352,10 +383,12 @@ func loadDockerConfigRegistries() []string {
 	if dir == "" {
 		return nil
 	}
+
 	data, err := os.ReadFile(filepath.Join(dir, "config.json"))
 	if err != nil {
 		return nil
 	}
+
 	var cfg struct {
 		Auths       map[string]json.RawMessage `json:"auths"`
 		CredHelpers map[string]string          `json:"credHelpers"`
@@ -363,26 +396,34 @@ func loadDockerConfigRegistries() []string {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil
 	}
+
 	seen := make(map[string]struct{}, len(cfg.Auths)+len(cfg.CredHelpers))
+
 	var hosts []string
+
 	add := func(raw string) {
 		h := normalizeHost(raw)
 		if h == "" {
 			return
 		}
+
 		if _, dup := seen[h]; dup {
 			return
 		}
+
 		seen[h] = struct{}{}
 		hosts = append(hosts, h)
 	}
 	for k := range cfg.Auths {
 		add(k)
 	}
+
 	for k := range cfg.CredHelpers {
 		add(k)
 	}
+
 	sort.Strings(hosts)
+
 	return hosts
 }
 
@@ -391,10 +432,12 @@ func loadDockerConfigRegistries() []string {
 func normalizeHost(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "https://")
+
 	s = strings.TrimPrefix(s, "http://")
 	if i := strings.Index(s, "/"); i != -1 {
 		s = s[:i]
 	}
+
 	return s
 }
 
@@ -404,11 +447,13 @@ func filterByPrefix(items []string, prefix string) []string {
 	if prefix == "" {
 		return items
 	}
+
 	out := make([]string, 0, len(items))
 	for _, item := range items {
 		if strings.HasPrefix(item, prefix) {
 			out = append(out, item)
 		}
 	}
+
 	return out
 }

--- a/internal/cr/cmd/fs/cat.go
+++ b/internal/cr/cmd/fs/cat.go
@@ -47,9 +47,12 @@ files deleted by upper layers are reported as not-found.`,
 			if err != nil {
 				return err
 			}
+
 			_, err = cmd.OutOrStdout().Write(content)
+
 			return err
 		},
 	}
+
 	return cmd
 }

--- a/internal/cr/cmd/fs/extract.go
+++ b/internal/cr/cmd/fs/extract.go
@@ -29,6 +29,7 @@ import (
 
 func newExtractCmd(opts *registry.Options) *cobra.Command {
 	var outputDir string
+
 	cmd := &cobra.Command{
 		Use:   "extract IMAGE",
 		Short: "Extract a container image filesystem to a local directory",
@@ -59,10 +60,12 @@ re-materialized from layer 0.`,
 			fmt.Fprintf(w, "  symlinks:  %d\n", stats.Symlinks)
 			fmt.Fprintf(w, "  hardlinks: %d\n", stats.Hardlinks)
 			fmt.Fprintf(w, "  total:     %s (%d bytes)\n", output.HumanSize(stats.TotalSize), stats.TotalSize)
+
 			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "Write the filesystem into this directory")
 	_ = cmd.MarkFlagRequired("output")
+
 	return cmd
 }

--- a/internal/cr/cmd/fs/ls.go
+++ b/internal/cr/cmd/fs/ls.go
@@ -27,6 +27,7 @@ import (
 
 func newLsCmd(opts *registry.Options) *cobra.Command {
 	var longForm bool
+
 	cmd := &cobra.Command{
 		Use:   "ls IMAGE [PATH]",
 		Short: "List files inside a container image",
@@ -39,6 +40,7 @@ stripped, so "/etc" and "etc" are equivalent. Output paths are tar-relative
 		ValidArgsFunction: completion.ImageThenInImagePath(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
+
 			subpath := ""
 			if len(args) == 2 {
 				subpath = args[1]
@@ -53,11 +55,13 @@ stripped, so "/etc" and "etc" are equivalent. Output paths are tar-relative
 			if err != nil {
 				return err
 			}
+
 			entries = imagefs.FilterBySubpath(entries, subpath)
 
 			return output.WriteEntriesText(cmd.OutOrStdout(), entries, longForm)
 		},
 	}
 	cmd.Flags().BoolVarP(&longForm, "long", "l", false, "Long format with mode and size")
+
 	return cmd
 }

--- a/internal/cr/cmd/fs/tree.go
+++ b/internal/cr/cmd/fs/tree.go
@@ -43,6 +43,7 @@ func newTreeCmd(opts *registry.Options) *cobra.Command {
 		dirsFirst bool
 		showSize  bool
 	)
+
 	cmd := &cobra.Command{
 		Use:   "tree IMAGE [PATH]",
 		Short: "Show the filesystem of a container image as a tree",
@@ -56,6 +57,7 @@ The merged filesystem is rendered.`,
 		ValidArgsFunction: completion.ImageThenInImagePath(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := args[0]
+
 			root := ""
 			if len(args) == 2 {
 				root = imagefs.NormalizeScopePath(args[1])
@@ -75,49 +77,60 @@ The merged filesystem is rendered.`,
 			}
 
 			tree := buildTree(entries, root)
+
 			rootLabel := "/"
 			if root != "" {
 				rootLabel = "/" + root
 			}
+
 			return writeTreeText(cmd.OutOrStdout(), tree, rootLabel, maxDepth, dirsFirst, showSize)
 		},
 	}
 	cmd.Flags().IntVarP(&maxDepth, "depth", "L", 0, "Max depth to descend (0 = unlimited)")
 	cmd.Flags().BoolVar(&dirsFirst, "dirsfirst", false, "List directories before files")
 	cmd.Flags().BoolVar(&showSize, "size", false, "Show file sizes (human-readable: B / KB / MB)")
+
 	return cmd
 }
 
 func buildTree(entries []imagefs.Entry, root string) *treeNode {
 	tree := &treeNode{name: root, isDir: true, children: make(map[string]*treeNode)}
+
 	for _, e := range entries {
 		if e.Type == imagefs.TypeWhiteout {
 			continue
 		}
+
 		rel := e.Path
 		if root != "" {
 			if rel == root {
 				tree.entry = e
 				continue
 			}
+
 			prefix := root + "/"
 			if !strings.HasPrefix(rel, prefix) {
 				continue
 			}
+
 			rel = strings.TrimPrefix(rel, prefix)
 		}
+
 		insert(tree, rel, e)
 	}
+
 	return tree
 }
 
 func insert(parent *treeNode, rel string, entry imagefs.Entry) {
 	parts := strings.Split(rel, "/")
 	cur := parent
+
 	for i, part := range parts {
 		if part == "" {
 			continue
 		}
+
 		child, ok := cur.children[part]
 		if !ok {
 			child = &treeNode{name: part, children: make(map[string]*treeNode)}
@@ -131,10 +144,12 @@ func insert(parent *treeNode, rel string, entry imagefs.Entry) {
 		// "etc/passwd" (file under it) could flip "etc" back to non-dir
 		// after its children were registered, hiding the subtree.
 		isDirNow := i < len(parts)-1 || entry.IsDir()
+
 		child.isDir = child.isDir || isDirNow
 		if i == len(parts)-1 {
 			child.entry = entry
 		}
+
 		cur = child
 	}
 }
@@ -143,6 +158,7 @@ func writeTreeText(w io.Writer, tree *treeNode, rootLabel string, maxDepth int, 
 	if _, err := fmt.Fprintln(w, rootLabel); err != nil {
 		return err
 	}
+
 	return writeSubtree(w, tree, "", 1, maxDepth, dirsFirst, showSize)
 }
 
@@ -150,10 +166,12 @@ func writeSubtree(w io.Writer, node *treeNode, prefix string, depth, maxDepth in
 	if maxDepth > 0 && depth > maxDepth {
 		return nil
 	}
+
 	names := make([]string, 0, len(node.children))
 	for n := range node.children {
 		names = append(names, n)
 	}
+
 	sortChildren(names, node.children, dirsFirst)
 
 	for i, name := range names {
@@ -161,27 +179,33 @@ func writeSubtree(w io.Writer, node *treeNode, prefix string, depth, maxDepth in
 		isLast := i == len(names)-1
 		branch := "├── "
 		nextPrefix := prefix + "│   "
+
 		if isLast {
 			branch = "└── "
 			nextPrefix = prefix + "    "
 		}
+
 		displayName := name
 		if child.isDir {
 			displayName += "/"
 		}
+
 		line := prefix + branch + displayName
 		if !child.isDir && showSize {
 			line += "  " + output.HumanSize(child.entry.Size)
 		}
+
 		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err
 		}
+
 		if child.isDir {
 			if err := writeSubtree(w, child, nextPrefix, depth+1, maxDepth, dirsFirst, showSize); err != nil {
 				return err
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -194,6 +218,7 @@ func sortChildren(names []string, children map[string]*treeNode, dirsFirst bool)
 				return di
 			}
 		}
+
 		return ni < nj
 	})
 }

--- a/internal/cr/cmd/rootflags.go
+++ b/internal/cr/cmd/rootflags.go
@@ -63,19 +63,24 @@ func setupRootFlags(cmd *cobra.Command, opts *registry.Options) {
 		*opts = *registry.New()
 		opts.WithContext(c.Context())
 		applyVerbose(verbose)
+
 		if insecure {
 			opts.WithInsecure().WithTransport(registry.InsecureTransport())
 		}
+
 		if ndLayers {
 			opts.WithNondistributable()
 		}
+
 		if platform != "" {
 			p, err := v1.ParsePlatform(platform)
 			if err != nil {
 				return fmt.Errorf("parse --platform: %w", err)
 			}
+
 			opts.WithPlatform(p)
 		}
+
 		return nil
 	}
 }
@@ -89,5 +94,6 @@ func applyVerbose(verbose bool) {
 		logs.Debug.SetOutput(os.Stderr)
 		return
 	}
+
 	logs.Debug.SetOutput(io.Discard)
 }

--- a/internal/cr/internal/image/resolve.go
+++ b/internal/cr/internal/image/resolve.go
@@ -59,6 +59,7 @@ func Resolve(ctx context.Context, srcList []string, keepMultiArchIndex bool, cac
 		if _, dup := seen[src]; dup {
 			return nil, fmt.Errorf("duplicate source reference %q", src)
 		}
+
 		seen[src] = struct{}{}
 	}
 
@@ -85,12 +86,15 @@ func Resolve(ctx context.Context, srcList []string, keepMultiArchIndex bool, cac
 			if err != nil {
 				return nil, fmt.Errorf("read index %s: %w", src, err)
 			}
+
 			if fsCache != nil {
 				// Without this, --cache-path was a no-op for OCI pulls of
 				// multi-arch images (the most common shape, e.g. alpine).
 				idx = cache.ImageIndex(idx, fsCache)
 			}
+
 			out.Indices[src] = idx
+
 			continue
 		}
 
@@ -98,10 +102,13 @@ func Resolve(ctx context.Context, srcList []string, keepMultiArchIndex bool, cac
 		if err != nil {
 			return nil, fmt.Errorf("read image %s: %w", src, err)
 		}
+
 		if fsCache != nil {
 			img = cache.Image(img, fsCache)
 		}
+
 		out.Images[src] = img
 	}
+
 	return out, nil
 }

--- a/internal/cr/internal/imagefs/extractor.go
+++ b/internal/cr/internal/imagefs/extractor.go
@@ -51,29 +51,36 @@ func ExtractMerged(ctx context.Context, img v1.Image, destDir string) (ExtractSt
 	if err != nil {
 		return ExtractStats{}, fmt.Errorf("get layers: %w", err)
 	}
+
 	absDest, err := filepath.Abs(destDir)
 	if err != nil {
 		return ExtractStats{}, fmt.Errorf("resolve dest: %w", err)
 	}
+
 	if err := os.MkdirAll(absDest, 0o755); err != nil {
 		return ExtractStats{}, fmt.Errorf("create dest: %w", err)
 	}
 
 	var stats ExtractStats
+
 	for i, layer := range layers {
 		if err := ctx.Err(); err != nil {
 			return stats, err
 		}
+
 		rc, err := layer.Uncompressed()
 		if err != nil {
 			return stats, fmt.Errorf("layer %d: uncompress: %w", i+1, err)
 		}
+
 		err = extractTarTo(ctx, rc, absDest, &stats)
 		_ = rc.Close()
+
 		if err != nil {
 			return stats, fmt.Errorf("layer %d: %w", i+1, err)
 		}
 	}
+
 	return stats, nil
 }
 
@@ -82,6 +89,7 @@ func extractTarTo(ctx context.Context, rc io.Reader, destAbs string, stats *Extr
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
 		name := normalizePath(hdr.Name)
 		if name == "." {
 			return nil
@@ -101,15 +109,18 @@ func extractTarTo(ctx context.Context, rc io.Reader, destAbs string, stats *Extr
 			if err := ensureNoSymlinkComponents(destAbs, absPath, true); err != nil {
 				return err
 			}
+
 			if err := os.MkdirAll(absPath, fs.FileMode(hdr.Mode&0o777)|0o700); err != nil {
 				return fmt.Errorf("mkdir %s: %w", absPath, err)
 			}
+
 			stats.Dirs++
 
 		case tar.TypeReg:
 			if err := ensureNoSymlinkComponents(destAbs, absPath, true); err != nil {
 				return err
 			}
+
 			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				return fmt.Errorf("mkdir parent %s: %w", absPath, err)
 			}
@@ -120,18 +131,23 @@ func extractTarTo(ctx context.Context, rc io.Reader, destAbs string, stats *Extr
 			if err := clearStalePath(absPath); err != nil {
 				return err
 			}
+
 			f, err := os.OpenFile(absPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fs.FileMode(hdr.Mode&0o777))
 			if err != nil {
 				return fmt.Errorf("create %s: %w", absPath, err)
 			}
+
 			n, err := io.Copy(f, r)
 			closeErr := f.Close()
+
 			if err != nil {
 				return fmt.Errorf("write %s: %w", absPath, err)
 			}
+
 			if closeErr != nil {
 				return fmt.Errorf("close %s: %w", absPath, closeErr)
 			}
+
 			stats.Files++
 			stats.TotalSize += n
 
@@ -139,43 +155,55 @@ func extractTarTo(ctx context.Context, rc io.Reader, destAbs string, stats *Extr
 			if err := ensureNoSymlinkComponents(destAbs, absPath, true); err != nil {
 				return err
 			}
+
 			linkname, err := resolveSymlinkTarget(destAbs, absPath, hdr.Linkname)
 			if err != nil {
 				return err
 			}
+
 			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				return fmt.Errorf("mkdir parent %s: %w", absPath, err)
 			}
+
 			if err := clearStalePath(absPath); err != nil {
 				return err
 			}
+
 			if err := os.Symlink(linkname, absPath); err != nil {
 				return fmt.Errorf("symlink %s -> %s: %w", absPath, linkname, err)
 			}
+
 			stats.Symlinks++
 
 		case tar.TypeLink:
 			if err := ensureNoSymlinkComponents(destAbs, absPath, true); err != nil {
 				return err
 			}
+
 			if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 				return fmt.Errorf("mkdir parent %s: %w", absPath, err)
 			}
+
 			linkTarget, err := safeJoin(destAbs, normalizePath(hdr.Linkname))
 			if err != nil {
 				return err
 			}
+
 			if err := ensureNoSymlinkComponents(destAbs, linkTarget, false); err != nil {
 				return err
 			}
+
 			if err := clearStalePath(absPath); err != nil {
 				return err
 			}
+
 			if err := os.Link(linkTarget, absPath); err != nil {
 				return fmt.Errorf("hardlink %s -> %s: %w", absPath, linkTarget, err)
 			}
+
 			stats.Hardlinks++
 		}
+
 		return nil
 	})
 }
@@ -185,17 +213,22 @@ func applyWhiteout(destAbs, target string, opaque bool) error {
 	if opaque && t == "." {
 		return clearDirContents(destAbs)
 	}
+
 	absPath, err := safeJoin(destAbs, t)
 	if err != nil {
 		return err
 	}
+
 	if err := ensureNoSymlinkComponents(destAbs, absPath, false); err != nil {
 		return err
 	}
+
 	if opaque {
 		return clearDirContents(absPath)
 	}
+
 	_ = os.RemoveAll(absPath)
+
 	return nil
 }
 
@@ -213,6 +246,7 @@ func clearStalePath(path string) error {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
+
 		return fmt.Errorf("lstat %s: %w", path, err)
 	}
 	// Lstat on a symlink does NOT set IsDir even when the target is a
@@ -221,11 +255,14 @@ func clearStalePath(path string) error {
 		if err := os.RemoveAll(path); err != nil {
 			return fmt.Errorf("remove stale dir %s: %w", path, err)
 		}
+
 		return nil
 	}
+
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove stale entry %s: %w", path, err)
 	}
+
 	return nil
 }
 
@@ -240,15 +277,19 @@ func clearDirContents(dir string) error {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
+
 		return fmt.Errorf("read whiteout dir %s: %w", dir, err)
 	}
+
 	var errs []error
+
 	for _, e := range entries {
 		entryPath := filepath.Join(dir, e.Name())
 		if rerr := os.RemoveAll(entryPath); rerr != nil {
 			errs = append(errs, fmt.Errorf("remove %s: %w", entryPath, rerr))
 		}
 	}
+
 	return errors.Join(errs...)
 }
 
@@ -256,10 +297,12 @@ func safeJoin(base, rel string) (string, error) {
 	if slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), "..") {
 		return "", fmt.Errorf("unsafe path (contains ..): %q", rel)
 	}
+
 	joined := filepath.Clean(filepath.Join(base, filepath.FromSlash(rel)))
 	if !withinBase(base, joined) {
 		return "", fmt.Errorf("unsafe path (escapes destination): %q", rel)
 	}
+
 	return joined, nil
 }
 
@@ -271,6 +314,7 @@ func withinBase(base, path string) bool {
 	if err != nil {
 		return false
 	}
+
 	return rel == "." || (!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != "..")
 }
 
@@ -278,31 +322,40 @@ func ensureNoSymlinkComponents(base, absPath string, allowFinalMissing bool) err
 	if !withinBase(base, absPath) {
 		return fmt.Errorf("unsafe path (escapes destination): %q", absPath)
 	}
+
 	rel, err := filepath.Rel(base, absPath)
 	if err != nil {
 		return fmt.Errorf("resolve relative path: %w", err)
 	}
+
 	if rel == "." {
 		return nil
 	}
+
 	cur := base
+
 	parts := strings.Split(rel, string(filepath.Separator))
 	for i, part := range parts {
 		cur = filepath.Join(cur, part)
+
 		info, err := os.Lstat(cur)
 		if err != nil {
 			if os.IsNotExist(err) {
 				if allowFinalMissing && i == len(parts)-1 {
 					return nil
 				}
+
 				continue
 			}
+
 			return fmt.Errorf("lstat %s: %w", cur, err)
 		}
+
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("unsafe path (symlink component): %q", cur)
 		}
 	}
+
 	return nil
 }
 
@@ -317,6 +370,7 @@ func resolveSymlinkTarget(destAbs, linkPathAbs, target string) (string, error) {
 	if target == "" {
 		return "", fmt.Errorf("unsafe symlink target (empty)")
 	}
+
 	if err := ensureNoSymlinkComponents(destAbs, filepath.Dir(linkPathAbs), false); err != nil {
 		return "", err
 	}
@@ -329,10 +383,12 @@ func resolveSymlinkTarget(destAbs, linkPathAbs, target string) (string, error) {
 		if !withinBase(destAbs, rooted) {
 			return "", fmt.Errorf("unsafe symlink target (escapes destination): %q", target)
 		}
+
 		rel, err := filepath.Rel(filepath.Dir(linkPathAbs), rooted)
 		if err != nil {
 			return "", fmt.Errorf("resolve symlink target %q: %w", target, err)
 		}
+
 		return rel, nil
 	}
 
@@ -340,5 +396,6 @@ func resolveSymlinkTarget(destAbs, linkPathAbs, target string) (string, error) {
 	if !withinBase(destAbs, resolved) {
 		return "", fmt.Errorf("unsafe symlink target (escapes destination): %q", target)
 	}
+
 	return target, nil
 }

--- a/internal/cr/internal/imagefs/reader.go
+++ b/internal/cr/internal/imagefs/reader.go
@@ -37,17 +37,21 @@ func MergedFS(img v1.Image) ([]Entry, error) {
 	}
 
 	fileMap := make(map[string]Entry)
+
 	for i, layer := range layers {
 		rc, err := layer.Uncompressed()
 		if err != nil {
 			return nil, fmt.Errorf("uncompress layer %d: %w", i+1, err)
 		}
+
 		err = mergeLayer(rc, fileMap)
 		_ = rc.Close()
+
 		if err != nil {
 			return nil, fmt.Errorf("layer %d: %w", i+1, err)
 		}
 	}
+
 	return sortedEntries(fileMap), nil
 }
 
@@ -59,6 +63,7 @@ func ReadFile(img v1.Image, filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get layers: %w", err)
 	}
+
 	want := normalizePath(filePath)
 
 	for i := len(layers) - 1; i >= 0; i-- {
@@ -66,6 +71,7 @@ func ReadFile(img v1.Image, filePath string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("layer %d: %w", i+1, err)
 		}
+
 		switch status {
 		case readFound:
 			return content, nil
@@ -75,6 +81,7 @@ func ReadFile(img v1.Image, filePath string) ([]byte, error) {
 			return nil, fmt.Errorf("%w: %s", ErrNotFound, filePath)
 		}
 	}
+
 	return nil, fmt.Errorf("%w: %s", ErrNotFound, filePath)
 }
 
@@ -122,6 +129,7 @@ func readFromLayer(layer v1.Layer, wantPath string) ([]byte, readStatus, error) 
 		hasReal    bool
 		deleted    bool
 	)
+
 	err = WalkTar(rc, func(hdr *tar.Header, r io.Reader) error {
 		name := normalizePath(hdr.Name)
 		if target, opaque := Whiteout(name); target != "" || opaque {
@@ -129,37 +137,49 @@ func readFromLayer(layer v1.Layer, wantPath string) ([]byte, readStatus, error) 
 			if t == wantPath || isAncestor(t, wantPath) {
 				deleted = true
 			}
+
 			return nil
 		}
+
 		if name != wantPath {
 			return nil
 		}
+
 		hasReal = true
+
 		if !isRegularTarFile(hdr.Typeflag) {
 			realStatus = readNonRegular
 			content = nil
+
 			return nil
 		}
+
 		b, rerr := io.ReadAll(io.LimitReader(r, maxReadFileSize+1))
 		if rerr != nil {
 			return rerr
 		}
+
 		if int64(len(b)) > maxReadFileSize {
 			return fmt.Errorf("%w: %s (limit %d bytes)", ErrFileTooLarge, wantPath, maxReadFileSize)
 		}
+
 		content = b
 		realStatus = readFound
+
 		return nil
 	})
 	if err != nil {
 		return nil, readMissing, err
 	}
+
 	if hasReal {
 		return content, realStatus, nil
 	}
+
 	if deleted {
 		return nil, readDeleted, nil
 	}
+
 	return nil, readMissing, nil
 }
 
@@ -185,16 +205,20 @@ func mergeLayer(rc io.Reader, fileMap map[string]Entry) error {
 
 	if err := WalkTar(rc, func(hdr *tar.Header, _ io.Reader) error {
 		name := normalizePath(hdr.Name)
+
 		target, opaque := Whiteout(name)
 		if opaque {
 			opaques[normalizePath(target)] = struct{}{}
 			return nil
 		}
+
 		if target != "" {
 			whiteouts[normalizePath(target)] = struct{}{}
 			return nil
 		}
+
 		thisLayer[name] = headerToEntry(hdr)
+
 		return nil
 	}); err != nil {
 		return err
@@ -202,26 +226,32 @@ func mergeLayer(rc io.Reader, fileMap map[string]Entry) error {
 
 	for wt := range whiteouts {
 		delete(fileMap, wt)
+
 		for k := range fileMap {
 			if isAncestor(wt, k) {
 				delete(fileMap, k)
 			}
 		}
 	}
+
 	for dir := range opaques {
 		if dir == "." {
 			for k := range fileMap {
 				delete(fileMap, k)
 			}
+
 			continue
 		}
+
 		for k := range fileMap {
 			if isAncestor(dir, k) {
 				delete(fileMap, k)
 			}
 		}
 	}
+
 	maps.Copy(fileMap, thisLayer)
+
 	return nil
 }
 
@@ -230,12 +260,15 @@ func sortedEntries(m map[string]Entry) []Entry {
 	for _, e := range m {
 		out = append(out, e)
 	}
+
 	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+
 	return out
 }
 
 func headerToEntry(hdr *tar.Header) Entry {
 	mode := fs.FileMode(hdr.Mode & 0o777)
+
 	entryType := mapType(hdr.Typeflag)
 	switch entryType {
 	case TypeDir:
@@ -243,6 +276,7 @@ func headerToEntry(hdr *tar.Header) Entry {
 	case TypeSymlink:
 		mode |= fs.ModeSymlink
 	}
+
 	return Entry{
 		Path:     normalizePath(hdr.Name),
 		Type:     entryType,

--- a/internal/cr/internal/imagefs/scope.go
+++ b/internal/cr/internal/imagefs/scope.go
@@ -27,17 +27,21 @@ func FilterBySubpath(entries []Entry, subpath string) []Entry {
 	if subpath == "" {
 		return entries
 	}
+
 	sub := NormalizeScopePath(subpath)
 	if sub == "." {
 		return entries
 	}
+
 	prefix := sub + "/"
+
 	out := make([]Entry, 0, len(entries))
 	for _, e := range entries {
 		if e.Path == sub || strings.HasPrefix(e.Path, prefix) {
 			out = append(out, e)
 		}
 	}
+
 	return out
 }
 
@@ -50,5 +54,6 @@ func NormalizeScopePath(raw string) string {
 	if v == "" {
 		return "."
 	}
+
 	return strings.TrimPrefix(path.Clean(v), "./")
 }

--- a/internal/cr/internal/imagefs/walker.go
+++ b/internal/cr/internal/imagefs/walker.go
@@ -38,13 +38,16 @@ func WalkTar(rc io.Reader, fn func(*tar.Header, io.Reader) error) error {
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
+
 		if err != nil {
 			return fmt.Errorf("tar next: %w", err)
 		}
+
 		if err := fn(hdr, tr); err != nil {
 			if errors.Is(err, ErrStopWalk) {
 				return nil
 			}
+
 			return err
 		}
 	}
@@ -55,10 +58,12 @@ func WalkTar(rc io.Reader, fn func(*tar.Header, io.Reader) error) error {
 func normalizePath(p string) string {
 	p = strings.TrimPrefix(p, "./")
 	p = strings.TrimPrefix(p, "/")
+
 	p = strings.TrimSuffix(p, "/")
 	if p == "" {
 		return "."
 	}
+
 	return path.Clean(p)
 }
 
@@ -67,5 +72,6 @@ func isAncestor(ancestor, descendant string) bool {
 	if ancestor == "." {
 		return descendant != "."
 	}
+
 	return strings.HasPrefix(descendant, ancestor+"/")
 }

--- a/internal/cr/internal/imagefs/whiteout.go
+++ b/internal/cr/internal/imagefs/whiteout.go
@@ -38,8 +38,10 @@ func Whiteout(name string) (string, bool) {
 		if dir == "." || dir == "/" {
 			return ".", true
 		}
+
 		return strings.TrimPrefix(dir, "./"), true
 	}
+
 	if target, ok := strings.CutPrefix(base, whiteoutPrefix); ok {
 		// Reject malformed markers whose suffix is empty (".wh.") or just
 		// a dot (".wh..") - both would resolve to the directory itself
@@ -48,10 +50,13 @@ func Whiteout(name string) (string, bool) {
 		if target == "" || target == "." {
 			return "", false
 		}
+
 		if dir == "." || dir == "/" {
 			return target, false
 		}
+
 		return path.Join(strings.TrimPrefix(dir, "./"), target), false
 	}
+
 	return "", false
 }

--- a/internal/cr/internal/imageio/layout.go
+++ b/internal/cr/internal/imageio/layout.go
@@ -33,16 +33,19 @@ func SaveOCI(path string, imgs map[string]v1.Image, idxs map[string]v1.ImageInde
 	if err != nil {
 		return err
 	}
+
 	for refStr, img := range imgs {
 		if err := p.AppendImage(img); err != nil {
 			return fmt.Errorf("append image %s: %w", refStr, err)
 		}
 	}
+
 	for refStr, idx := range idxs {
 		if err := p.AppendIndex(idx); err != nil {
 			return fmt.Errorf("append index %s: %w", refStr, err)
 		}
 	}
+
 	return nil
 }
 
@@ -59,6 +62,7 @@ func LoadLocal(path string, asIndex bool) (partial.WithRawManifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stat %s: %w", path, err)
 	}
+
 	if !stat.IsDir() {
 		return LoadTarball(path, "")
 	}
@@ -95,6 +99,7 @@ func LoadLocal(path string, asIndex bool) (partial.WithRawManifest, error) {
 	if !asIndex {
 		return nil, fmt.Errorf("layout %s contains %d entries; pass --index to push as an index", path, len(manifest.Manifests))
 	}
+
 	return idx, nil
 }
 
@@ -115,10 +120,12 @@ func openOrCreateLayout(path string) (layout.Path, error) {
 		if p, lerr := layout.FromPath(path); lerr == nil {
 			return p, nil
 		}
+
 		entries, rerr := os.ReadDir(path)
 		if rerr != nil {
 			return "", fmt.Errorf("read %s: %w", path, rerr)
 		}
+
 		if len(entries) > 0 {
 			return "", fmt.Errorf("%s exists, is not an OCI layout, and is not empty; refusing to overwrite", path)
 		}
@@ -128,5 +135,6 @@ func openOrCreateLayout(path string) (layout.Path, error) {
 	if err != nil {
 		return "", fmt.Errorf("create OCI layout %s: %w", path, err)
 	}
+
 	return p, nil
 }

--- a/internal/cr/internal/imageio/tarball.go
+++ b/internal/cr/internal/imageio/tarball.go
@@ -33,17 +33,21 @@ func SaveTarball(path string, imgs map[string]v1.Image) error {
 	if len(imgs) == 0 {
 		return fmt.Errorf("save tarball %s: at least one image is required", path)
 	}
+
 	refToImage := make(map[name.Reference]v1.Image, len(imgs))
 	for refStr, img := range imgs {
 		ref, err := name.ParseReference(refStr)
 		if err != nil {
 			return fmt.Errorf("parse reference %q: %w", refStr, err)
 		}
+
 		refToImage[ref] = img
 	}
+
 	if err := tarball.MultiRefWriteToFile(path, refToImage); err != nil {
 		return fmt.Errorf("write tarball %s: %w", path, err)
 	}
+
 	return nil
 }
 
@@ -55,17 +59,21 @@ func SaveLegacy(path string, imgs map[string]v1.Image) error {
 	if len(imgs) == 0 {
 		return fmt.Errorf("save legacy tarball %s: at least one image is required", path)
 	}
+
 	tagToImage := make(map[name.Tag]v1.Image, len(imgs))
 	for refStr, img := range imgs {
 		tag, err := name.NewTag(refStr)
 		if err != nil {
 			return fmt.Errorf("parse tag %q (legacy tarballs require tagged refs): %w", refStr, err)
 		}
+
 		tagToImage[tag] = img
 	}
+
 	if err := tarball.MultiWriteToFile(path, tagToImage); err != nil {
 		return fmt.Errorf("write legacy tarball %s: %w", path, err)
 	}
+
 	return nil
 }
 
@@ -77,15 +85,19 @@ func LoadTarball(path, tag string) (v1.Image, error) {
 		if err != nil {
 			return nil, fmt.Errorf("load tarball %s: %w", path, err)
 		}
+
 		return img, nil
 	}
+
 	ref, err := name.NewTag(tag)
 	if err != nil {
 		return nil, fmt.Errorf("parse tag %q: %w", tag, err)
 	}
+
 	img, err := tarball.ImageFromPath(path, &ref)
 	if err != nil {
 		return nil, fmt.Errorf("load tarball %s with tag %s: %w", path, tag, err)
 	}
+
 	return img, nil
 }

--- a/internal/cr/internal/output/text.go
+++ b/internal/cr/internal/output/text.go
@@ -32,16 +32,20 @@ func WriteEntriesText(w io.Writer, entries []imagefs.Entry, long bool) error {
 		if e.IsDir() {
 			path += "/"
 		}
+
 		if long {
 			if _, err := fmt.Fprintf(w, "%-11s %8s  %s\n", e.ModeStr, HumanSize(e.Size), path); err != nil {
 				return err
 			}
+
 			continue
 		}
+
 		if _, err := fmt.Fprintln(w, path); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -51,11 +55,14 @@ func HumanSize(n int64) string {
 	if n < unit {
 		return fmt.Sprintf("%d B", n)
 	}
+
 	div, exp := unit, 0
 	for v := n / unit; v >= unit; v /= unit {
 		div *= unit
 		exp++
 	}
+
 	units := "KMGTPE"
+
 	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), units[exp])
 }

--- a/internal/cr/internal/registry/catalog.go
+++ b/internal/cr/internal/registry/catalog.go
@@ -47,13 +47,16 @@ func ListCatalog(ctx context.Context, regRef string, opts *Options, visit func(r
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
 		page, err := catalogger.Next(ctx)
 		if err != nil {
 			return fmt.Errorf("read next catalog page: %w", err)
 		}
+
 		if err := visit(page.Repos); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/internal/cr/internal/registry/fetch.go
+++ b/internal/cr/internal/registry/fetch.go
@@ -33,10 +33,12 @@ func Fetch(ctx context.Context, ref string, opts *Options) (v1.Image, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse reference %q: %w", ref, err)
 	}
+
 	img, err := remote.Image(parsed, opts.remoteWithContext(ctx)...)
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", ref, err)
 	}
+
 	return img, nil
 }
 
@@ -47,10 +49,12 @@ func FetchDescriptor(ctx context.Context, ref string, opts *Options) (*remote.De
 	if err != nil {
 		return nil, fmt.Errorf("parse reference %q: %w", ref, err)
 	}
+
 	desc, err := remote.Get(parsed, opts.remoteWithContext(ctx)...)
 	if err != nil {
 		return nil, fmt.Errorf("fetch descriptor %s: %w", ref, err)
 	}
+
 	return desc, nil
 }
 
@@ -64,16 +68,21 @@ func (o *Options) remoteWithContext(ctx context.Context) []remote.Option {
 	if ctx == nil {
 		ctx = o.Context
 	}
+
 	out := make([]remote.Option, 0, len(o.Remote)+3)
+
 	out = append(out, o.Remote...)
 	if o.Keychain != nil {
 		out = append(out, remote.WithAuthFromKeychain(o.Keychain))
 	}
+
 	if o.Platform != nil {
 		out = append(out, remote.WithPlatform(*o.Platform))
 	}
+
 	if ctx != nil {
 		out = append(out, remote.WithContext(ctx))
 	}
+
 	return out
 }

--- a/internal/cr/internal/registry/inspect.go
+++ b/internal/cr/internal/registry/inspect.go
@@ -28,6 +28,7 @@ func FetchManifest(ctx context.Context, ref string, opts *Options) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
+
 	return desc.Manifest, nil
 }
 
@@ -38,10 +39,12 @@ func FetchConfig(ctx context.Context, ref string, opts *Options) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
+
 	cfg, err := img.RawConfigFile()
 	if err != nil {
 		return nil, fmt.Errorf("read config %s: %w", ref, err)
 	}
+
 	return cfg, nil
 }
 
@@ -51,5 +54,6 @@ func FetchDigest(ctx context.Context, ref string, opts *Options) (string, error)
 	if err != nil {
 		return "", err
 	}
+
 	return desc.Digest.String(), nil
 }

--- a/internal/cr/internal/registry/options.go
+++ b/internal/cr/internal/registry/options.go
@@ -73,7 +73,9 @@ func (o *Options) WithPlatform(p *v1.Platform) *Options {
 	if p == nil {
 		return o
 	}
+
 	o.Platform = p
+
 	return o
 }
 

--- a/internal/cr/internal/registry/push.go
+++ b/internal/cr/internal/registry/push.go
@@ -36,21 +36,26 @@ func Push(ctx context.Context, ref string, obj partial.WithRawManifest, opts *Op
 	if obj == nil {
 		return v1.Hash{}, fmt.Errorf("push %s: object is nil", ref)
 	}
+
 	parsed, err := name.ParseReference(ref, opts.Name...)
 	if err != nil {
 		return v1.Hash{}, fmt.Errorf("parse reference %q: %w", ref, err)
 	}
+
 	remoteOpts := opts.remoteWithContext(ctx)
+
 	switch t := obj.(type) {
 	case v1.Image:
 		if err := remote.Write(parsed, t, remoteOpts...); err != nil {
 			return v1.Hash{}, fmt.Errorf("push image %s: %w", ref, err)
 		}
+
 		return t.Digest()
 	case v1.ImageIndex:
 		if err := remote.WriteIndex(parsed, t, remoteOpts...); err != nil {
 			return v1.Hash{}, fmt.Errorf("push index %s: %w", ref, err)
 		}
+
 		return t.Digest()
 	default:
 		return v1.Hash{}, fmt.Errorf("push %s: unsupported type %T", ref, obj)

--- a/internal/cr/internal/registry/tags.go
+++ b/internal/cr/internal/registry/tags.go
@@ -46,13 +46,16 @@ func ListTags(ctx context.Context, repoRef string, opts *Options, visit func(tag
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+
 		page, err := lister.Next(ctx)
 		if err != nil {
 			return fmt.Errorf("read next tag page: %w", err)
 		}
+
 		if err := visit(page.Tags); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/internal/cr/internal/registry/transport.go
+++ b/internal/cr/internal/registry/transport.go
@@ -29,5 +29,6 @@ import (
 func InsecureTransport() http.RoundTripper {
 	t := remote.DefaultTransport.(*http.Transport).Clone()
 	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-opted via --insecure
+
 	return t
 }

--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -37,6 +37,7 @@ func ShouldCleanup(cleanup, cleanupExplicit bool) bool {
 	if cleanupExplicit {
 		return cleanup
 	}
+
 	return AskYesNoWithTimeout(
 		"DataExport will auto-delete in 30 sec [press y+Enter to delete now, n+Enter to cancel]",
 		time.Second*30,
@@ -51,15 +52,20 @@ func AskYesNoWithTimeout(prompt string, timeout time.Duration) bool {
 
 	// Buffered channel avoids blocking send if timeout branch wins first.
 	inputChan := make(chan string, 1)
+
 	go func() {
 		reader := bufio.NewReader(os.Stdin)
+
 		for {
 			fmt.Printf("%s: ", prompt)
+
 			input, err := reader.ReadString('\n')
 			if err != nil {
 				// Read errors (EOF/closed stdin/etc.) can repeat forever; fall back once and exit.
 				fmt.Println("Error reading input, chosen default value: no.")
+
 				inputChan <- defaultInputOnErr
+
 				return
 			}
 
@@ -78,6 +84,7 @@ func AskYesNoWithTimeout(prompt string, timeout time.Duration) bool {
 		if input == "n" || input == "no" {
 			return false
 		}
+
 		return true
 	case <-time.After(timeout):
 		fmt.Printf("\n")

--- a/internal/data/dataexport/api/v1alpha1/register.go
+++ b/internal/data/dataexport/api/v1alpha1/register.go
@@ -44,5 +44,6 @@ func AddKnownTypes(scheme *runtime.Scheme) error {
 		&DataExportList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
 	return nil
 }

--- a/internal/data/dataexport/cmd/create/create.go
+++ b/internal/data/dataexport/cmd/create/create.go
@@ -42,6 +42,7 @@ func cmdExamples() string {
 		"  # Start data exporting with extra flags",
 		fmt.Sprintf("    ... %s --kubeconfig='kube_tmp.conf' -n target-namespace --ttl 17m export-name pvc/test-pvc-name", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -72,11 +73,14 @@ func parseArgs(args []string) ( /*deName*/ string /*volumeKind*/, string /*volum
 	if len(args) != 2 {
 		return "", "", "", fmt.Errorf("invalid arguments")
 	}
+
 	deName = args[0]
+
 	resourceTypeAndName := strings.Split(args[1], "/")
 	if len(resourceTypeAndName) != 2 {
 		return "", "", "", fmt.Errorf("invalid volume format, expect: <type>/<name>")
 	}
+
 	volumeKind, volumeName = strings.ToLower(resourceTypeAndName[0]), resourceTypeAndName[1]
 	switch volumeKind {
 	case "pvc", "persistentvolumeclaim":
@@ -97,6 +101,7 @@ func parseArgs(args []string) ( /*deName*/ string /*volumeKind*/, string /*volum
 func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
+
 	namespace, _ := cmd.Flags().GetString("namespace")
 	ttl, _ := cmd.Flags().GetString("ttl")
 
@@ -106,10 +111,12 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	flags := cmd.PersistentFlags()
+
 	sc, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
 	}
+
 	rtClient, err := sc.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {
 		return err
@@ -131,5 +138,6 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	log.Info("DataExport created", slog.String("name", deName), slog.String("namespace", namespace))
+
 	return nil
 }

--- a/internal/data/dataexport/cmd/delete/delete.go
+++ b/internal/data/dataexport/cmd/delete/delete.go
@@ -39,6 +39,7 @@ func cmdExamples() string {
 	resp := []string{
 		fmt.Sprintf("  ... -n target-namespace %s my-volume", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -72,6 +73,7 @@ func parseArgs(args []string) ( /*deName*/ string, error) {
 func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(ctx, 25*time.Second)
 	defer cancel()
+
 	namespace, _ := cmd.Flags().GetString("namespace")
 
 	deName, err := parseArgs(args)
@@ -80,10 +82,12 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	flags := cmd.PersistentFlags()
+
 	safeClient, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
 	}
+
 	rtClient, err := safeClient.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {
 		return err
@@ -95,5 +99,6 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	log.Info("Deleted DataExport", slog.String("name", deName), slog.String("namespace", namespace))
+
 	return nil
 }

--- a/internal/data/dataexport/cmd/download/download.go
+++ b/internal/data/dataexport/cmd/download/download.go
@@ -60,6 +60,7 @@ func cmdExamples() string {
 		"  # Start exporter + Download + Stop for VirtualDiskSnapshot (Block)",
 		fmt.Sprintf("    ... %s -n target-namespace vds/my-virtualdisk-snapshot -o file.img", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -106,21 +107,26 @@ func forRespItems(jsonStream io.ReadCloser, workFunc func(*dirItem) error) error
 			if err != nil {
 				return err
 			}
+
 			if t != json.Delim('[') {
 				return fmt.Errorf("JSON items is not list")
 			}
+
 			break
 		}
+
 		dec.More()
 	}
 
 	// read items
 	for dec.More() {
 		var i dirItem
+
 		err := dec.Decode(&i)
 		if err != nil {
 			break
 		}
+
 		err = workFunc(&i)
 		if err != nil {
 			return err
@@ -132,6 +138,7 @@ func forRespItems(jsonStream io.ReadCloser, workFunc func(*dirItem) error) error
 	if err != nil {
 		return err
 	}
+
 	if t != json.Delim(']') {
 		return fmt.Errorf("items loading is not completed")
 	}
@@ -150,6 +157,7 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 	}
 
 	req, _ := http.NewRequest(http.MethodGet, dataURL, nil)
+
 	resp, err := sClient.HTTPDo(req)
 	if err != nil {
 		return fmt.Errorf("HTTPDo: %s", err.Error())
@@ -168,15 +176,18 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 	}
 
 	if srcPath != "" && srcPath[len(srcPath)-1:] == "/" {
-		var wg sync.WaitGroup
-		var mu sync.Mutex
-		var firstErr error
+		var (
+			wg       sync.WaitGroup
+			mu       sync.Mutex
+			firstErr error
+		)
 
 		// Keep only the first non-nil sub-download error.
 		setFirstErr := func(subPath string, subErr error) {
 			if subErr == nil {
 				return
 			}
+
 			mu.Lock()
 			if firstErr == nil {
 				firstErr = fmt.Errorf("download %s: %w", filepath.Join(srcPath, subPath), subErr)
@@ -197,6 +208,7 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 				if err != nil {
 					return fmt.Errorf("Create dir error: %s", err.Error())
 				}
+
 				subPath += "/"
 			case itemTypeFile, itemTypeLink:
 				// downloadable, proceed below
@@ -210,11 +222,13 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 			select {
 			case sem <- struct{}{}:
 				wg.Add(1)
+
 				go func(sp string) {
 					defer func() {
 						<-sem
 						wg.Done()
 					}()
+
 					downloadOne(sp)
 				}(subPath)
 			default:
@@ -228,8 +242,10 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 		}
 
 		wg.Wait()
+
 		return firstErr
 	}
+
 	if dstPath != "" {
 		// Create out file
 		out, err := os.Create(dstPath)
@@ -242,6 +258,7 @@ func recursiveDownload(ctx context.Context, sClient *safeClient.SafeClient, log 
 		if err != nil {
 			return err
 		}
+
 		log.Info("Downloaded file", slog.String("path", dstPath))
 	} else {
 		_, err = io.Copy(os.Stdout, resp.Body)
@@ -267,10 +284,12 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 
 	flags := cmd.PersistentFlags()
 	safeClient.SupportNoAuth = false
+
 	sClient, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
 	}
+
 	rtClient, err := sClient.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {
 		return err
@@ -303,12 +322,14 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		if srcPath == "" {
 			return fmt.Errorf("invalid source path: '%s'", srcPath)
 		}
+
 		if dstPath == "" {
 			pathList := strings.Split(srcPath, "/")
 			dstPath = pathList[len(pathList)-1]
 		}
 	case "Block":
 		srcPath = ""
+
 		if dstPath == "" {
 			dstPath = deName
 		}
@@ -317,7 +338,9 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	log.Info("Start downloading", slog.String("url", url+srcPath), slog.String("dstPath", dstPath))
+
 	sem := make(chan struct{}, 10)
+
 	err = recursiveDownload(ctx, subClient, log, sem, url, srcPath, dstPath)
 	if err != nil {
 		log.Error("Not all files have been downloaded", slog.String("error", err.Error()))

--- a/internal/data/dataexport/cmd/list/list.go
+++ b/internal/data/dataexport/cmd/list/list.go
@@ -46,6 +46,7 @@ func cmdExamples() string {
 		fmt.Sprintf(`  ... -n target-namespace %s my-file-volume /mydir/testdir/`, cmdName),
 		fmt.Sprintf(`  ... -n target-namespace %s my-block-volume`, cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -101,11 +102,13 @@ func downloadFunc(
 	}
 
 	var req *http.Request
+
 	switch volumeMode {
 	case "Filesystem":
 		if srcPath == "" || srcPath[len(srcPath)-1:] != "/" {
 			return fmt.Errorf("invalid source path: '%s'", srcPath)
 		}
+
 		dataURL, err := neturl.JoinPath(url, srcPath)
 		if err != nil {
 			return err
@@ -128,16 +131,19 @@ func downloadFunc(
 
 	if resp.StatusCode != http.StatusOK {
 		const maxLen = 4096
+
 		msg, err := io.ReadAll(io.LimitReader(resp.Body, maxLen))
 		if err != nil {
 			return fmt.Errorf("Backend response \"%s\"", resp.Status)
 		}
+
 		return fmt.Errorf("Backend response \"%s\" Msg: %s", resp.Status, string(msg))
 	}
 
 	switch volumeMode {
 	case "Block":
 		body := ""
+
 		if contLen := resp.Header.Get("Content-Length"); contLen != "" {
 			// Convert raw bytes value to human-readable size using k8s quantity library.
 			// We deliberately ignore conversion errors and fallback to raw bytes if any.
@@ -150,6 +156,7 @@ func downloadFunc(
 			// Ensure the size information is printed on a dedicated line for better readability.
 			body += "\n"
 		}
+
 		return foo(strings.NewReader(body))
 	case "Filesystem":
 		return foo(resp.Body)
@@ -174,6 +181,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 
 	flags := cmd.PersistentFlags()
 	safeClient.SupportNoAuth = false
+
 	sClient, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
@@ -206,9 +214,9 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		if err == io.EOF {
 			err = nil
 		}
+
 		return err
 	})
-
 	if err != nil {
 		return err
 	}

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -46,6 +46,7 @@ var maxRetryAttempts = 60
 
 func GetDataExport(ctx context.Context, deName, namespace string, rtClient ctrlrtclient.Client) (*v1alpha1.DataExport, error) {
 	deObj := &v1alpha1.DataExport{}
+
 	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: deName}, deObj)
 	if err != nil {
 		return nil, fmt.Errorf("kube Get dataexport: %s", err.Error())
@@ -59,6 +60,7 @@ func GetDataExport(ctx context.Context, deName, namespace string, rtClient ctrlr
 					deObj.ObjectMeta.Namespace, deObj.ObjectMeta.Name,
 					condition.Message, condition.Reason)
 			}
+
 			break
 		}
 	}
@@ -85,6 +87,7 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 					if err := DeleteDataExport(ctx, deName, namespace, rtClient); err != nil {
 						return nil, err
 					}
+
 					if err := CreateDataExport(
 						ctx,
 						deName, namespace, "",
@@ -120,6 +123,7 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 		if returnErr == nil {
 			break
 		}
+
 		if i > maxRetryAttempts {
 			return nil, fmt.Errorf("%w\n\nTo inspect DataExport status, run:\n  d8 k -n %s get de %s -o yaml",
 				returnErr, namespace, deName)
@@ -133,6 +137,7 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 				slog.String("timeout_in", remaining.String()),
 				slog.Int("attempt", i))
 		}
+
 		time.Sleep(time.Second * 3)
 	}
 
@@ -141,6 +146,7 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 
 func CreateDataExporterIfNeeded(ctx context.Context, log *slog.Logger, deName, namespace string, publish bool, ttl string, rtClient ctrlrtclient.Client) (string, error) {
 	var volumeKind, volumeName string
+
 	lowerCaseDeName := strings.ToLower(deName)
 
 	switch {
@@ -192,6 +198,7 @@ func CreateDataExporterIfNeeded(ctx context.Context, log *slog.Logger, deName, n
 	if err != nil {
 		return deName, err
 	}
+
 	log.Info("DataExport creating", slog.String("name", deName), slog.String("namespace", namespace))
 
 	return deName, nil
@@ -221,6 +228,7 @@ func CreateDataExport(ctx context.Context, deName, namespace, ttl, volumeKind, v
 			Publish: publish,
 		},
 	}
+
 	err := rtClient.Create(ctx, deCfg)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("DataExporter create error: %s", err.Error())
@@ -236,6 +244,7 @@ func DeleteDataExport(ctx context.Context, deName, namespace string, rtClient ct
 			Namespace: namespace,
 		},
 	}
+
 	err := rtClient.Delete(ctx, deObj)
 	if err != nil {
 		return err
@@ -249,6 +258,7 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
 	deObj := new(v1alpha1.DataExport)
+
 	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: deName}, deObj)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to get dataExport: %w", err)
@@ -262,6 +272,7 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 	}
 
 	log.Info("Waiting for DataExport to be ready", slog.String("name", deName), slog.String("namespace", namespace))
+
 	deObj, err = GetDataExportWithRestart(ctx, deName, namespace, rtClient, log)
 	if err != nil {
 		return "", "", "", err
@@ -292,9 +303,11 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 }
 
 func PrepareDownload(ctx context.Context, log *slog.Logger, deName, namespace string, publish bool, sClient *safeClient.SafeClient) (string, string, *safeClient.SafeClient, error) {
-	var url, volumeMode string
-	var subClient *safeClient.SafeClient
-	var decodedBytes []byte
+	var (
+		url, volumeMode string
+		subClient       *safeClient.SafeClient
+		decodedBytes    []byte
+	)
 
 	rtClient, err := sClient.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {

--- a/internal/data/dataimport/api/v1alpha1/register.go
+++ b/internal/data/dataimport/api/v1alpha1/register.go
@@ -44,5 +44,6 @@ func AddKnownTypes(scheme *runtime.Scheme) error {
 		&DataImportList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
 	return nil
 }

--- a/internal/data/dataimport/cmd/create/create.go
+++ b/internal/data/dataimport/cmd/create/create.go
@@ -42,6 +42,7 @@ func cmdExamples() string {
 		"  # Create DataImport",
 		fmt.Sprintf("    ... %s my-import -n d8-storage-volume-data-manager -f - --ttl 2m --publish --wffc", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -57,6 +58,7 @@ func NewCommand(ctx context.Context, log *slog.Logger) *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("invalid arguments")
 			}
+
 			return nil
 		},
 	}
@@ -81,6 +83,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	wffc, _ := cmd.Flags().GetBool("wffc")
 
 	flags := cmd.PersistentFlags()
+
 	sc, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
@@ -105,6 +108,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		if pvcSpec.Namespace == "" {
 			return fmt.Errorf("namespace is required")
 		}
+
 		namespace = pvcSpec.Namespace
 	}
 
@@ -121,6 +125,8 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	if err := util.CreateDataImport(ctx, name, namespace, ttl, publish, wffc, pvcSpec, rtClient); err != nil {
 		return err
 	}
+
 	log.Info("DataImport created", slog.String("name", name), slog.String("namespace", namespace))
+
 	return nil
 }

--- a/internal/data/dataimport/cmd/delete/delete.go
+++ b/internal/data/dataimport/cmd/delete/delete.go
@@ -22,6 +22,7 @@ func cmdExamples() string {
 	resp := []string{
 		fmt.Sprintf("  ... -n NAMESPACE %s DATAIMPORT_NAME", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -55,6 +56,7 @@ func parseArgs(args []string) ( /*diName*/ string, error) {
 func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(ctx, 25*time.Second)
 	defer cancel()
+
 	namespace, _ := cmd.Flags().GetString("namespace")
 
 	diName, err := parseArgs(args)
@@ -63,10 +65,12 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	flags := cmd.PersistentFlags()
+
 	safeClient, err := safeClient.NewSafeClient(flags)
 	if err != nil {
 		return err
 	}
+
 	rtClient, err := safeClient.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {
 		return err
@@ -78,5 +82,6 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	}
 
 	log.Info("Deleted DataImport", slog.String("name", diName), slog.String("namespace", namespace))
+
 	return nil
 }

--- a/internal/data/dataimport/cmd/upload/upload.go
+++ b/internal/data/dataimport/cmd/upload/upload.go
@@ -39,6 +39,7 @@ func NewCommand(ctx context.Context, log *slog.Logger) *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("invalid arguments")
 			}
+
 			return nil
 		},
 	}
@@ -60,6 +61,7 @@ func cmdExamples() string {
 		"  # Upload without resume, split into 4 chunks",
 		fmt.Sprintf("    ... %s NAME -n NAMESPACE -P -d /dst/path -f ./file -c 4", cmdName),
 	}
+
 	return strings.Join(resp, "\n")
 }
 
@@ -71,6 +73,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	resume, _ := cmd.Flags().GetBool("resume")
 
 	flags := cmd.PersistentFlags()
+
 	httpClient, err := client.NewSafeClient(flags)
 	if err != nil {
 		return err
@@ -102,6 +105,7 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 	permOctal := defaultFilePermissions
 	uid := os.Getuid()
 	gid := os.Getgid()
+
 	if pathToFile != "" && pathToFile != "-" {
 		if fi, statErr := os.Stat(pathToFile); statErr == nil {
 			permOctal = fmt.Sprintf("%04o", fi.Mode().Perm())
@@ -131,11 +135,13 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 
 func upload(ctx context.Context, _ *slog.Logger, httpClient *client.SafeClient, url string, filePath string, chunks int, permOctal string, uid, gid int, resume bool) error {
 	var offset int64
+
 	if resume {
 		off, err := util.CheckUploadProgress(ctx, httpClient, url)
 		if err != nil {
 			return err
 		}
+
 		offset = off
 	}
 
@@ -162,16 +168,19 @@ func upload(ctx context.Context, _ *slog.Logger, httpClient *client.SafeClient, 
 
 	for offset < totalSize {
 		remaining := totalSize - offset
+
 		sendLen := chunkSize
 		if sendLen > remaining {
 			sendLen = remaining
 		}
 
 		section := io.NewSectionReader(file, offset, sendLen)
+
 		req, err := http.NewRequest(http.MethodPut, url, io.NopCloser(section))
 		if err != nil {
 			return err
 		}
+
 		req = req.WithContext(ctx)
 
 		req.Header.Set("X-Content-Length", strconv.FormatInt(totalSize, 10))
@@ -185,6 +194,7 @@ func upload(ctx context.Context, _ *slog.Logger, httpClient *client.SafeClient, 
 			if err != nil {
 				return err
 			}
+
 			defer func() {
 				_, _ = io.Copy(io.Discard, resp.Body)
 				_ = resp.Body.Close()
@@ -199,14 +209,18 @@ func upload(ctx context.Context, _ *slog.Logger, httpClient *client.SafeClient, 
 				offset += sendLen
 				return nil
 			}
+
 			nextOffset, err := strconv.ParseInt(nextOffsetStr, 10, 64)
 			if err != nil {
 				return fmt.Errorf("invalid X-Next-Offset: %s: %w", nextOffsetStr, err)
 			}
+
 			if nextOffset < offset {
 				return fmt.Errorf("server returned X-Next-Offset (%d) smaller than current offset (%d)", nextOffset, offset)
 			}
+
 			offset = nextOffset
+
 			return nil
 		}(); err != nil {
 			return err

--- a/internal/data/dataimport/util/util.go
+++ b/internal/data/dataimport/util/util.go
@@ -26,6 +26,7 @@ const (
 
 func GetDataImport(ctx context.Context, diName, namespace string, rtClient ctrlrtclient.Client) (*v1alpha1.DataImport, error) {
 	diObj := &v1alpha1.DataImport{}
+
 	err := rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: diName}, diObj)
 	if err != nil {
 		return nil, fmt.Errorf("kube Get dataimport: %s", err.Error())
@@ -38,6 +39,7 @@ func GetDataImport(ctx context.Context, diName, namespace string, rtClient ctrlr
 					diObj.ObjectMeta.Namespace, diObj.ObjectMeta.Name,
 					condition.Message, condition.Reason)
 			}
+
 			break
 		}
 	}
@@ -53,6 +55,7 @@ func DeleteDataImport(ctx context.Context, diName, namespace string, rtClient ct
 		},
 	}
 	err := rtClient.Delete(ctx, diObj)
+
 	return err
 }
 
@@ -90,6 +93,7 @@ func CreateDataImport(
 	if err := rtClient.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("DataImport create error: %s", err.Error())
 	}
+
 	return nil
 }
 
@@ -110,15 +114,18 @@ func GetDataImportWithRestart(
 		}
 
 		var notReadyErr error
+
 		for _, condition := range diObj.Status.Conditions {
 			if condition.Type == "Expired" && condition.Status == "True" {
 				if err := DeleteDataImport(ctx, diName, namespace, rtClient); err != nil {
 					return nil, err
 				}
+
 				pvcTemplate := &v1alpha1.PersistentVolumeClaimTemplateSpec{}
 				if diObj.Spec.TargetRef.PvcTemplate != nil {
 					pvcTemplate = diObj.Spec.TargetRef.PvcTemplate
 				}
+
 				if err := CreateDataImport(
 					ctx,
 					diName,
@@ -132,6 +139,7 @@ func GetDataImportWithRestart(
 					return nil, err
 				}
 			}
+
 			if condition.Type == "Ready" {
 				if condition.Status != "True" {
 					notReadyErr = fmt.Errorf("DataImport %s/%s is not Ready: %s (%s)",
@@ -158,6 +166,7 @@ func GetDataImportWithRestart(
 		if notReadyErr == nil {
 			return diObj, nil
 		}
+
 		if i > maxRetryAttempts {
 			return nil, notReadyErr
 		}
@@ -168,6 +177,7 @@ func GetDataImportWithRestart(
 				slog.String("status", notReadyErr.Error()),
 				slog.Int("attempt", i))
 		}
+
 		time.Sleep(retryInterval * time.Second)
 	}
 }
@@ -179,9 +189,11 @@ func PrepareUpload(
 	sClient *safeClient.SafeClient,
 	log *slog.Logger,
 ) ( /*url*/ string /*volumeMode*/, string /*subClient*/, *safeClient.SafeClient, error) {
-	var url, volumeMode string
-	var subClient *safeClient.SafeClient
-	var decodedBytes []byte
+	var (
+		url, volumeMode string
+		subClient       *safeClient.SafeClient
+		decodedBytes    []byte
+	)
 
 	rtClient, err := sClient.NewRTClient(v1alpha1.AddToScheme)
 	if err != nil {
@@ -190,6 +202,7 @@ func PrepareUpload(
 
 	// Fetch the current state so we can reconcile Spec.Publish before waiting.
 	diObj := new(v1alpha1.DataImport)
+
 	err = rtClient.Get(ctx, ctrlrtclient.ObjectKey{Namespace: namespace, Name: diName}, diObj)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to get dataImport: %w", err)
@@ -209,11 +222,13 @@ func PrepareUpload(
 	}
 
 	var podURL string
+
 	switch {
 	case publish:
 		if diObj.Status.PublicURL == "" {
 			return "", "", nil, fmt.Errorf("empty PublicURL")
 		}
+
 		podURL = diObj.Status.PublicURL
 	case diObj.Status.URL != "":
 		podURL = diObj.Status.URL
@@ -288,6 +303,7 @@ func CheckUploadProgress(ctx context.Context, httpClient *safeClient.SafeClient,
 	if err != nil {
 		return 0, err
 	}
+
 	resp, err := httpClient.HTTPDo(req.WithContext(ctx))
 	if err != nil {
 		return 0, err
@@ -300,8 +316,10 @@ func CheckUploadProgress(ctx context.Context, httpClient *safeClient.SafeClient,
 			if serverOffset, perr := strconv.ParseInt(next, 10, 64); perr == nil && serverOffset >= 0 {
 				return serverOffset, nil
 			}
+
 			return 0, fmt.Errorf("invalid X-Next-Offset header")
 		}
+
 		return 0, nil
 	case http.StatusNotFound:
 		return 0, nil

--- a/internal/data/publish_detect.go
+++ b/internal/data/publish_detect.go
@@ -63,6 +63,7 @@ func ResolvePublish(
 
 	// User didn't set the flag, run autodetection.
 	log.Info("Auto-detecting publish mode")
+
 	return DetectPublish(ctx, rtClient, sClient, log)
 }
 
@@ -105,8 +106,8 @@ func DetectPublish(
 	// which also covers TLS handshake and DNS resolve. Without it the HTTP client inherits
 	// the default kubeconfig timeout (typically 30s).
 	probeClient.SetProbeEndpoint(ProbeTimeout, targetURL, kubeServiceServerName)
-	probeRtClient, err := probeClient.NewRTClient()
 
+	probeRtClient, err := probeClient.NewRTClient()
 	if err != nil {
 		return false, ErrAutoDetectWithHint
 	}
@@ -153,6 +154,7 @@ func DetectPublish(
 
 	// Same service identity via both paths -> internal endpoint is reachable.
 	log.Info("Publish autodetect: internal endpoint is reachable, selecting publish=false")
+
 	return false, nil
 }
 

--- a/internal/iam/access/cmd/completion.go
+++ b/internal/iam/access/cmd/completion.go
@@ -46,6 +46,7 @@ func completeSubjectAndName(cmd *cobra.Command, args []string, toComplete string
 			return utilk8s.CompleteResourceNames(cmd, iamtypes.GroupGVR, "", toComplete)
 		}
 	}
+
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -78,6 +79,7 @@ func completeRuleRef(cmd *cobra.Command, _ []string, toComplete string) ([]strin
 	// Pick which branch to fetch by the committed prefix. Short prefixes
 	// like "C"/"CA" still query both — cobra filters the result.
 	wantCAR, wantAR := true, true
+
 	switch {
 	case strings.HasPrefix(toComplete, "CAR/"),
 		strings.HasPrefix(toComplete, "ClusterAuthorizationRule/"):
@@ -97,6 +99,7 @@ func completeRuleRef(cmd *cobra.Command, _ []string, toComplete string) ([]strin
 			}
 		}
 	}
+
 	if wantAR {
 		list, err := dyn.Resource(iamtypes.AuthorizationRuleGVR).Namespace("").List(cmd.Context(), metav1.ListOptions{})
 		if err == nil {

--- a/internal/iam/access/cmd/grant.go
+++ b/internal/iam/access/cmd/grant.go
@@ -140,6 +140,7 @@ func runGrant(cmd *cobra.Command, args []string) error {
 	}
 
 	var subjectPrincipal string
+
 	switch subjectKind {
 	case iamtypes.KindUser:
 		subjectPrincipal, err = resolveUserEmail(cmd.Context(), dyn, subjectName)
@@ -174,6 +175,7 @@ func runGrant(cmd *cobra.Command, args []string) error {
 		dryRun:           dryRun,
 		outputFmt:        outputFmt,
 	}
+
 	return applyGrants(cmd, dyn, opts)
 }
 
@@ -215,11 +217,13 @@ func applyGrants(cmd *cobra.Command, dyn dynamic.Interface, opts grantOpts) erro
 	}
 
 	var errs *multierror.Error
+
 	for _, spec := range specs {
 		client, err := grantClient(dyn, spec)
 		if err != nil {
 			return err
 		}
+
 		obj, err := buildGrantObject(spec)
 		if err != nil {
 			return err
@@ -229,6 +233,7 @@ func applyGrants(cmd *cobra.Command, dyn dynamic.Interface, opts grantOpts) erro
 			if err := utilk8s.PrintObject(cmd.OutOrStdout(), obj, opts.outputFmt); err != nil {
 				return err
 			}
+
 			continue
 		}
 
@@ -236,12 +241,15 @@ func applyGrants(cmd *cobra.Command, dyn dynamic.Interface, opts grantOpts) erro
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to create grant for %s: %v\n", grantHumanScope(spec), err)
 			errs = multierror.Append(errs, fmt.Errorf("%s: %w", grantHumanScope(spec), err))
+
 			continue
 		}
+
 		if err := utilk8s.PrintObject(cmd.OutOrStdout(), result, opts.outputFmt); err != nil {
 			return err
 		}
 	}
+
 	return errs.ErrorOrNil()
 }
 
@@ -267,15 +275,18 @@ func canonicalGrantSpecs(in canonicalGrantInput) ([]*canonicalGrantSpec, error) 
 		if len(in.Namespaces) == 0 {
 			return nil, errors.New("namespaced grant requires at least one namespace")
 		}
+
 		specs := make([]*canonicalGrantSpec, 0, len(in.Namespaces))
 		for _, ns := range in.Namespaces {
 			if ns == "" {
 				return nil, errors.New("namespace name must not be empty")
 			}
+
 			s := *base
 			s.Namespaces = []string{ns}
 			specs = append(specs, &s)
 		}
+
 		return specs, nil
 	case iamtypes.ScopeCluster, iamtypes.ScopeAllNamespaces:
 		return []*canonicalGrantSpec{base}, nil
@@ -283,12 +294,14 @@ func canonicalGrantSpecs(in canonicalGrantInput) ([]*canonicalGrantSpec, error) 
 		if len(in.LabelMatch) == 0 {
 			return nil, errors.New("labels scope requires at least one K=V pair")
 		}
+
 		s := *base
 		// copy to avoid sharing the caller's map
 		s.LabelMatch = make(map[string]string, len(in.LabelMatch))
 		for k, v := range in.LabelMatch {
 			s.LabelMatch[k] = v
 		}
+
 		return []*canonicalGrantSpec{&s}, nil
 	default:
 		return nil, fmt.Errorf("unsupported scope %q", in.ScopeType)
@@ -304,6 +317,7 @@ func grantClient(dyn dynamic.Interface, spec *canonicalGrantSpec) (dynamic.Resou
 		if len(spec.Namespaces) != 1 {
 			return nil, fmt.Errorf("namespaced grant must target exactly one namespace, got %d", len(spec.Namespaces))
 		}
+
 		return dyn.Resource(iamtypes.AuthorizationRuleGVR).Namespace(spec.Namespaces[0]), nil
 	case iamtypes.ScopeCluster, iamtypes.ScopeAllNamespaces, iamtypes.ScopeLabels:
 		return dyn.Resource(iamtypes.ClusterAuthorizationRuleGVR), nil
@@ -320,7 +334,9 @@ func buildGrantObject(spec *canonicalGrantSpec) (*unstructured.Unstructured, err
 	if err != nil {
 		return nil, err
 	}
+
 	labels := grantLabels(spec)
+
 	annotations, err := grantAnnotations(spec)
 	if err != nil {
 		return nil, err
@@ -345,6 +361,7 @@ func buildGrantObject(spec *canonicalGrantSpec) (*unstructured.Unstructured, err
 	}
 
 	var apiVersion, kind string
+
 	switch spec.ScopeType {
 	case iamtypes.ScopeNamespace:
 		// canonicalGrantSpecs guarantees exactly one namespace per spec for
@@ -353,9 +370,11 @@ func buildGrantObject(spec *canonicalGrantSpec) (*unstructured.Unstructured, err
 		if len(spec.Namespaces) != 1 {
 			return nil, fmt.Errorf("namespaced grant must target exactly one namespace, got %d", len(spec.Namespaces))
 		}
+
 		if spec.Namespaces[0] == "" {
 			return nil, errors.New("namespaced grant has empty namespace")
 		}
+
 		apiVersion = iamtypes.APIVersionDeckhouseV1Alpha1
 		kind = iamtypes.KindAuthorizationRule
 		metadata["namespace"] = spec.Namespaces[0]
@@ -370,12 +389,15 @@ func buildGrantObject(spec *canonicalGrantSpec) (*unstructured.Unstructured, err
 		if len(spec.LabelMatch) == 0 {
 			return nil, errors.New("labels scope requires at least one label pair")
 		}
+
 		apiVersion = iamtypes.APIVersionDeckhouseV1
 		kind = iamtypes.KindClusterAuthorizationRule
+
 		matchLabels := make(map[string]any, len(spec.LabelMatch))
 		for k, v := range spec.LabelMatch {
 			matchLabels[k] = v
 		}
+
 		ruleSpec["namespaceSelector"] = map[string]any{
 			"labelSelector": map[string]any{
 				"matchLabels": matchLabels,
@@ -412,12 +434,15 @@ func createOrUpdateGrant(cmd *cobra.Command, client dynamic.ResourceInterface,
 	switch {
 	case err == nil:
 		existingAnnot := existing.GetAnnotations()
+
 		newAnnot := obj.GetAnnotations()
 		if existingAnnot[iamtypes.AnnotationAccessCanonicalSpec] == newAnnot[iamtypes.AnnotationAccessCanonicalSpec] {
 			cmd.PrintErrf("%s/%s unchanged\n", scope, name)
 			return existing, nil
 		}
+
 		obj.SetResourceVersion(existing.GetResourceVersion())
+
 		return client.Update(cmd.Context(), obj, metav1.UpdateOptions{})
 	case apierrors.IsNotFound(err):
 		return client.Create(cmd.Context(), obj, metav1.CreateOptions{})
@@ -432,6 +457,7 @@ func grantHumanScope(spec *canonicalGrantSpec) string {
 	if spec.ScopeType == iamtypes.ScopeNamespace && len(spec.Namespaces) == 1 {
 		return iamtypes.KindAuthorizationRule + "/" + spec.Namespaces[0]
 	}
+
 	return iamtypes.KindClusterAuthorizationRule
 }
 
@@ -472,6 +498,7 @@ func parseScope(scope string, namespaces []string) (iamtypes.Scope, []string, ma
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("--scope: %w", err)
 		}
+
 		return iamtypes.ScopeLabels, nil, labels, nil
 	default:
 		return "", nil, nil, fmt.Errorf("invalid --scope %q: expected one of cluster, all-namespaces, labels=K=V[,K2=V2,...]", scope)
@@ -485,21 +512,27 @@ func parseLabelMatch(s string) (map[string]string, error) {
 	if s == "" {
 		return nil, errors.New("labels=... must contain at least one K=V pair")
 	}
+
 	out := make(map[string]string)
+
 	for _, pair := range strings.Split(s, ",") {
 		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("invalid label pair %q: expected key=value", pair)
 		}
+
 		k, v := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
 		if k == "" || v == "" {
 			return nil, fmt.Errorf("invalid label pair %q: key and value must be non-empty", pair)
 		}
+
 		if _, dup := out[k]; dup {
 			return nil, fmt.Errorf("duplicate label key %q", k)
 		}
+
 		out[k] = v
 	}
+
 	return out, nil
 }
 
@@ -508,5 +541,6 @@ func toAnyMap(m map[string]string) map[string]any {
 	for k, v := range m {
 		result[k] = v
 	}
+
 	return result
 }

--- a/internal/iam/access/cmd/list.go
+++ b/internal/iam/access/cmd/list.go
@@ -38,11 +38,14 @@ func runInventory(cmd *cobra.Command, fn func(inv *accessInventory, outputFmt st
 	if err != nil {
 		return err
 	}
+
 	inv, err := buildInventory(cmd.Context(), dyn)
 	if err != nil {
 		return err
 	}
+
 	outputFmt, _ := cmd.Flags().GetString("output")
+
 	return fn(inv, outputFmt)
 }
 
@@ -61,11 +64,13 @@ func NewListUsersCommand() *cobra.Command {
 				if outputFmt == "json" {
 					return printStructured(cmd.OutOrStdout(), buildUsersJSON(inv), outputFmt)
 				}
+
 				return printUsersTable(cmd, inv)
 			})
 		},
 	}
 	utilk8s.AddOutputFlag(cmd, "table", "table", "json")
+
 	return cmd
 }
 
@@ -83,11 +88,13 @@ func NewListGroupsCommand() *cobra.Command {
 				if outputFmt == "json" {
 					return printStructured(cmd.OutOrStdout(), buildGroupsJSON(inv), outputFmt)
 				}
+
 				return printGroupsTable(cmd, inv)
 			})
 		},
 	}
 	utilk8s.AddOutputFlag(cmd, "table", "table", "json")
+
 	return cmd
 }
 
@@ -108,15 +115,19 @@ func NewGetUserCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			userName := args[0]
+
 			return runInventory(cmd, func(inv *accessInventory, outputFmt string) error {
 				if _, ok := inv.Users[userName]; !ok {
 					return fmt.Errorf("user %q not found", userName)
 				}
+
 				warnings := userWarnings(inv, userName)
+
 				switch outputFmt {
 				case "json", "yaml":
 					payload := buildUserAccessJSON(inv, userName)
 					payload.Warnings = denil(warnings)
+
 					return printStructured(cmd.OutOrStdout(), payload, outputFmt)
 				case "table", "":
 					return printUserDetail(cmd, inv, userName, warnings)
@@ -127,6 +138,7 @@ func NewGetUserCommand() *cobra.Command {
 		},
 	}
 	utilk8s.AddOutputFlag(cmd, "table", "table", "json", "yaml")
+
 	return cmd
 }
 
@@ -144,15 +156,19 @@ func NewGetGroupCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			groupName := args[0]
+
 			return runInventory(cmd, func(inv *accessInventory, outputFmt string) error {
 				if _, ok := inv.GroupMembers[groupName]; !ok {
 					return fmt.Errorf("group %q not found", groupName)
 				}
+
 				warnings := groupWarnings(inv, groupName)
+
 				switch outputFmt {
 				case "json", "yaml":
 					payload := buildGroupDetailJSON(inv, groupName)
 					payload.Warnings = denil(warnings)
+
 					return printStructured(cmd.OutOrStdout(), payload, outputFmt)
 				case "table", "":
 					return printGroupDetail(cmd, inv, groupName, warnings)
@@ -163,6 +179,7 @@ func NewGetGroupCommand() *cobra.Command {
 		},
 	}
 	utilk8s.AddOutputFlag(cmd, "table", "table", "json", "yaml")
+
 	return cmd
 }
 
@@ -176,6 +193,7 @@ func printUsersTable(cmd *cobra.Command, inv *accessInventory) error {
 	for u := range inv.Users {
 		users = append(users, u)
 	}
+
 	sort.Strings(users)
 
 	for _, userName := range users {
@@ -197,6 +215,7 @@ func printUsersTable(cmd *cobra.Command, inv *accessInventory) error {
 			len(directGrants), len(inheritedGrants),
 			summary.String())
 	}
+
 	return tw.Flush()
 }
 
@@ -208,11 +227,13 @@ func printGroupsTable(cmd *cobra.Command, inv *accessInventory) error {
 	for g := range inv.GroupMembers {
 		groups = append(groups, g)
 	}
+
 	sort.Strings(groups)
 
 	for _, groupName := range groups {
 		members := inv.GroupMembers[groupName]
 		userCount, nestedCount := 0, 0
+
 		for _, m := range members {
 			if m.Kind == iamtypes.KindGroup {
 				nestedCount++
@@ -227,6 +248,7 @@ func printGroupsTable(cmd *cobra.Command, inv *accessInventory) error {
 		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%s\n",
 			groupName, userCount, nestedCount, len(grants), summary.String())
 	}
+
 	return tw.Flush()
 }
 
@@ -252,17 +274,21 @@ func printUserDetail(cmd *cobra.Command, inv *accessInventory, userName string, 
 	}
 
 	fmt.Fprintf(w, "\nDirect access:\n")
+
 	if len(directGrants) == 0 {
 		fmt.Fprintln(w, "  <none>")
 	}
+
 	for _, g := range directGrants {
 		printGrantToWriter(w, &g, "")
 	}
 
 	fmt.Fprintf(w, "\nInherited access:\n")
+
 	if len(inheritedGrants) == 0 {
 		fmt.Fprintln(w, "  <none>")
 	}
+
 	idx := buildUserGroupIndex(inv, userName)
 	for _, g := range inheritedGrants {
 		printGrantToWriter(w, &g, idx.findVia(g.SubjectPrincipal))
@@ -292,9 +318,11 @@ func printGroupDetail(cmd *cobra.Command, inv *accessInventory, groupName string
 	printBulletList(w, groupMembers)
 
 	fmt.Fprintf(w, "\nGrants (%d):\n", len(grants))
+
 	if len(grants) == 0 {
 		fmt.Fprintln(w, "  <none>")
 	}
+
 	for _, g := range grants {
 		printGrantToWriter(w, &g, "")
 	}
@@ -311,6 +339,7 @@ func printGrantToWriter(w io.Writer, g *normalizedGrant, via string) {
 	if g.ScopeType == iamtypes.ScopeNamespace && len(g.ScopeNamespaces) > 0 {
 		scope = fmt.Sprintf("namespaces %s", strings.Join(g.ScopeNamespaces, ", "))
 	}
+
 	managed := ""
 	if g.ManagedByD8 {
 		managed = " [d8-managed]"
@@ -319,12 +348,15 @@ func printGrantToWriter(w io.Writer, g *normalizedGrant, via string) {
 	fmt.Fprintf(w, "  - %s\n", g.AccessLevel)
 	fmt.Fprintf(w, "    Scope: %s\n", scope)
 	fmt.Fprintf(w, "    Source: %s%s\n", formatGrantSource(g), managed)
+
 	if via != "" {
 		fmt.Fprintf(w, "    Via: group %s\n", via)
 	}
+
 	if g.AllowScale {
 		fmt.Fprintln(w, "    allow-scale: true")
 	}
+
 	if g.PortForwarding {
 		fmt.Fprintln(w, "    port-forwarding: true")
 	}
@@ -341,9 +373,11 @@ func printEffectiveSummary(w io.Writer, summary *effectiveSummary) {
 	if summary.ClusterLevel != "" {
 		fmt.Fprintf(w, "  cluster scope: %s\n", summary.ClusterLevel)
 	}
+
 	for ns, level := range summary.Namespaced {
 		fmt.Fprintf(w, "  namespaced scope: %s(%s)\n", level, ns)
 	}
+
 	fmt.Fprintf(w, "  port-forwarding: %v%s\n", summary.PortForwarding, capabilityNote(summary.PortForwardingImplicit))
 	fmt.Fprintf(w, "  allow-scale: %v%s\n", summary.AllowScale, capabilityNote(summary.AllowScaleImplicit))
 }
@@ -352,7 +386,9 @@ func printWarnings(w io.Writer, warnings []string) {
 	if len(warnings) == 0 {
 		return
 	}
+
 	fmt.Fprintln(w, "\nWarnings:")
+
 	for _, warn := range warnings {
 		fmt.Fprintf(w, "  ! %s\n", warn)
 	}
@@ -360,6 +396,7 @@ func printWarnings(w io.Writer, warnings []string) {
 
 func partitionMembersByKind(members []memberRef) ([]string, []string) {
 	var users, groups []string
+
 	for _, m := range members {
 		if m.Kind == iamtypes.KindGroup {
 			groups = append(groups, m.Name)
@@ -367,6 +404,7 @@ func partitionMembersByKind(members []memberRef) ([]string, []string) {
 			users = append(users, m.Name)
 		}
 	}
+
 	return users, groups
 }
 
@@ -375,6 +413,7 @@ func printBulletList(w io.Writer, items []string) {
 		fmt.Fprintln(w, "  <none>")
 		return
 	}
+
 	for _, item := range items {
 		fmt.Fprintf(w, "  - %s\n", item)
 	}
@@ -391,6 +430,7 @@ type userGroupIndex struct {
 
 func buildUserGroupIndex(inv *accessInventory, userName string) userGroupIndex {
 	directGroups, transitiveGroups := inv.ResolveUserGroups(userName)
+
 	idx := userGroupIndex{
 		direct:     make(map[string]bool, len(directGroups)),
 		transitive: make(map[string]bool, len(transitiveGroups)),
@@ -398,9 +438,11 @@ func buildUserGroupIndex(inv *accessInventory, userName string) userGroupIndex {
 	for _, g := range directGroups {
 		idx.direct[g] = true
 	}
+
 	for _, g := range transitiveGroups {
 		idx.transitive[g] = true
 	}
+
 	return idx
 }
 
@@ -425,27 +467,32 @@ func userWarnings(inv *accessInventory, userName string) []string {
 	if _, ok := inv.Users[userName]; !ok {
 		return nil
 	}
+
 	cycles := inv.DetectGroupCycles()
 	_, transitiveGroups := inv.ResolveUserGroups(userName)
 	directGrants, inheritedGrants := inv.UserGrants(userName)
 
 	var out []string
+
 	for _, g := range transitiveGroups {
 		if cycle, ok := cycles[g]; ok {
 			out = append(out, fmt.Sprintf("group cycle detected: %s", strings.Join(cycle, " -> ")))
 		}
 	}
+
 	for _, g := range directGrants {
 		if !g.ManagedByD8 {
 			out = append(out, fmt.Sprintf("direct grant from manual object: %s", formatGrantSource(&g)))
 		}
 	}
+
 	for _, g := range inheritedGrants {
 		if !g.ManagedByD8 {
 			out = append(out, fmt.Sprintf("inherited grant from manual object: %s (via group %s)",
 				formatGrantSource(&g), g.SubjectPrincipal))
 		}
 	}
+
 	return out
 }
 
@@ -455,12 +502,14 @@ func groupWarnings(inv *accessInventory, groupName string) []string {
 	if _, ok := inv.GroupMembers[groupName]; !ok {
 		return nil
 	}
+
 	cycles := inv.DetectGroupCycles()
 
 	var out []string
 	if cycle, ok := cycles[groupName]; ok {
 		out = append(out, fmt.Sprintf("group cycle detected: %s", strings.Join(cycle, " -> ")))
 	}
+
 	for _, m := range inv.GroupMembers[groupName] {
 		switch m.Kind {
 		case iamtypes.KindUser:
@@ -473,6 +522,7 @@ func groupWarnings(inv *accessInventory, groupName string) []string {
 			}
 		}
 	}
+
 	return out
 }
 
@@ -593,6 +643,7 @@ func summaryToJSON(s *effectiveSummary) effectiveJSON {
 	for ns, level := range s.Namespaced {
 		levelNS[level] = append(levelNS[level], ns)
 	}
+
 	for level, nss := range levelNS {
 		sort.Strings(nss)
 		ej.Namespaces = append(ej.Namespaces, nsLevelJSON{AccessLevel: level, Namespaces: nss})
@@ -606,12 +657,14 @@ func buildUsersJSON(inv *accessInventory) []userAccessJSON {
 	for u := range inv.Users {
 		users = append(users, u)
 	}
+
 	sort.Strings(users)
 
 	items := make([]userAccessJSON, 0, len(users))
 	for _, userName := range users {
 		items = append(items, buildUserAccessJSON(inv, userName))
 	}
+
 	return items
 }
 
@@ -628,7 +681,9 @@ func buildUserAccessJSON(inv *accessInventory, userName string) userAccessJSON {
 	for _, g := range directGrants {
 		directGrantsJSON = append(directGrantsJSON, grantToJSON(&g, ""))
 	}
+
 	idx := buildUserGroupIndex(inv, userName)
+
 	inheritedGrantsJSON := make([]grantJSON, 0, len(inheritedGrants))
 	for _, g := range inheritedGrants {
 		inheritedGrantsJSON = append(inheritedGrantsJSON, grantToJSON(&g, idx.findVia(g.SubjectPrincipal)))
@@ -657,12 +712,14 @@ func buildGroupsJSON(inv *accessInventory) []groupSummaryJSON {
 	for g := range inv.GroupMembers {
 		groups = append(groups, g)
 	}
+
 	sort.Strings(groups)
 
 	items := make([]groupSummaryJSON, 0, len(groups))
 	for _, gName := range groups {
 		members := inv.GroupMembers[gName]
 		userCount, nestedCount := 0, 0
+
 		for _, m := range members {
 			if m.Kind == iamtypes.KindGroup {
 				nestedCount++
@@ -670,6 +727,7 @@ func buildGroupsJSON(inv *accessInventory) []groupSummaryJSON {
 				userCount++
 			}
 		}
+
 		grants := inv.GroupGrants(gName)
 		summary := computeEffectiveSummary(grants)
 		items = append(items, groupSummaryJSON{
@@ -680,6 +738,7 @@ func buildGroupsJSON(inv *accessInventory) []groupSummaryJSON {
 			Effective: summaryToJSON(summary),
 		})
 	}
+
 	return items
 }
 
@@ -692,6 +751,7 @@ func buildGroupDetailJSON(inv *accessInventory, groupName string) groupDetailJSO
 	for _, m := range members {
 		memberItems = append(memberItems, memberJSON{Kind: string(m.Kind), Name: m.Name})
 	}
+
 	grantItems := make([]grantJSON, 0, len(grants))
 	for _, g := range grants {
 		grantItems = append(grantItems, grantToJSON(&g, ""))

--- a/internal/iam/access/cmd/naming.go
+++ b/internal/iam/access/cmd/naming.go
@@ -79,6 +79,7 @@ func grantAnnotations(spec *canonicalGrantSpec) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return map[string]string{
 		iamtypes.AnnotationAccessSubjectRef:       spec.SubjectRef,
 		iamtypes.AnnotationAccessSubjectPrincipal: spec.SubjectPrincipal,
@@ -91,11 +92,14 @@ func sanitizeNamePart(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, "@", "-at-")
 	s = strings.ReplaceAll(s, ".", "-")
+
 	s = strings.ReplaceAll(s, "_", "-")
 	if len(s) > 40 {
 		s = s[:40]
 	}
+
 	s = strings.TrimRight(s, "-")
+
 	return s
 }
 
@@ -105,6 +109,7 @@ func scopeNamePart(spec *canonicalGrantSpec) string {
 		if len(spec.Namespaces) == 1 {
 			return spec.Namespaces[0]
 		}
+
 		return "multi-ns"
 	case iamtypes.ScopeCluster:
 		return "cluster"
@@ -118,7 +123,9 @@ func scopeNamePart(spec *canonicalGrantSpec) string {
 		for k := range spec.LabelMatch {
 			keys = append(keys, k)
 		}
+
 		sort.Strings(keys)
+
 		var b strings.Builder
 		for _, k := range keys {
 			b.WriteString(k)
@@ -126,7 +133,9 @@ func scopeNamePart(spec *canonicalGrantSpec) string {
 			b.WriteString(spec.LabelMatch[k])
 			b.WriteByte(',')
 		}
+
 		h := sha256.Sum256([]byte(b.String()))
+
 		return fmt.Sprintf("labels-%x", h[:3])
 	default:
 		return "unknown"

--- a/internal/iam/access/cmd/print.go
+++ b/internal/iam/access/cmd/print.go
@@ -40,18 +40,23 @@ func printStructured(w io.Writer, v any, format string) error {
 		if err != nil {
 			return fmt.Errorf("marshalling JSON: %w", err)
 		}
+
 		_, err = fmt.Fprintln(w, string(data))
+
 		return err
 	case "yaml":
 		jsonData, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Errorf("marshalling JSON for YAML conversion: %w", err)
 		}
+
 		yamlData, err := sigsyaml.JSONToYAML(jsonData)
 		if err != nil {
 			return fmt.Errorf("converting JSON to YAML: %w", err)
 		}
+
 		_, err = fmt.Fprint(w, string(yamlData))
+
 		return err
 	default:
 		return fmt.Errorf("%w %q", errUnsupportedFormat, format)
@@ -64,5 +69,6 @@ func denil[T any](s []T) []T {
 	if s == nil {
 		return []T{}
 	}
+
 	return s
 }

--- a/internal/iam/access/cmd/resolve.go
+++ b/internal/iam/access/cmd/resolve.go
@@ -35,10 +35,12 @@ func resolveUserEmail(ctx context.Context, dyn dynamic.Interface, userName strin
 	if err != nil {
 		return "", fmt.Errorf("getting User %q to resolve email: %w", userName, err)
 	}
+
 	email, found, _ := unstructured.NestedString(obj.Object, "spec", "email")
 	if !found || email == "" {
 		return "", fmt.Errorf("User %q has no spec.email", userName)
 	}
+
 	return email, nil
 }
 
@@ -73,8 +75,10 @@ func buildInventory(ctx context.Context, dyn dynamic.Interface) (*accessInventor
 	if err != nil {
 		return nil, fmt.Errorf("listing Users: %w", err)
 	}
+
 	for _, u := range userList.Items {
 		name := u.GetName()
+
 		email, _, _ := unstructured.NestedString(u.Object, "spec", "email")
 		if email != "" {
 			inv.Users[name] = email
@@ -87,20 +91,25 @@ func buildInventory(ctx context.Context, dyn dynamic.Interface) (*accessInventor
 	if err != nil {
 		return nil, fmt.Errorf("listing Groups: %w", err)
 	}
+
 	for _, g := range groupList.Items {
 		gName := g.GetName()
 		rawMembers, _, _ := unstructured.NestedSlice(g.Object, "spec", "members")
+
 		var members []memberRef
+
 		for _, item := range rawMembers {
 			m, ok := item.(map[string]any)
 			if !ok {
 				continue
 			}
+
 			members = append(members, memberRef{
 				Kind: iamtypes.SubjectKind(fmt.Sprint(m["kind"])),
 				Name: fmt.Sprint(m["name"]),
 			})
 		}
+
 		inv.GroupMembers[gName] = members
 	}
 
@@ -109,6 +118,7 @@ func buildInventory(ctx context.Context, dyn dynamic.Interface) (*accessInventor
 	if err != nil {
 		return nil, fmt.Errorf("listing ClusterAuthorizationRules: %w", err)
 	}
+
 	for _, car := range carList.Items {
 		inv.Grants = append(inv.Grants, normalizeAuthRule(&car)...)
 	}
@@ -118,6 +128,7 @@ func buildInventory(ctx context.Context, dyn dynamic.Interface) (*accessInventor
 	if err != nil {
 		return nil, fmt.Errorf("listing AuthorizationRules: %w", err)
 	}
+
 	for _, ar := range arList.Items {
 		inv.Grants = append(inv.Grants, normalizeAuthRule(&ar)...)
 	}
@@ -147,6 +158,7 @@ func normalizeAuthRule(obj *unstructured.Unstructured) []normalizedGrant {
 	switch obj.GetKind() {
 	case iamtypes.KindClusterAuthorizationRule:
 		base.SourceKind = iamtypes.KindClusterAuthorizationRule
+
 		base.ScopeType = iamtypes.ScopeCluster
 		if matchAny, found, _ := unstructured.NestedBool(obj.Object, "spec", "namespaceSelector", "matchAny"); found && matchAny {
 			base.ScopeType = iamtypes.ScopeAllNamespaces
@@ -163,21 +175,25 @@ func normalizeAuthRule(obj *unstructured.Unstructured) []normalizedGrant {
 	}
 
 	var grants []normalizedGrant
+
 	for _, sub := range readSubjectRefs(obj) {
 		if sub.Kind == iamtypes.KindServiceAccount {
 			continue
 		}
+
 		g := base
 		g.SubjectKind = sub.Kind
 		g.SubjectPrincipal = sub.Name
 		grants = append(grants, g)
 	}
+
 	return grants
 }
 
 // ResolveUserGroups computes direct and transitive group memberships for a user.
 func (inv *accessInventory) ResolveUserGroups(userName string) ([]string, []string) {
 	directSet := make(map[string]bool)
+
 	for gName, members := range inv.GroupMembers {
 		for _, m := range members {
 			if m.Kind == iamtypes.KindUser && m.Name == userName {
@@ -187,12 +203,16 @@ func (inv *accessInventory) ResolveUserGroups(userName string) ([]string, []stri
 	}
 
 	visited := make(map[string]bool)
+
 	var walk func(string)
+
 	walk = func(g string) {
 		if visited[g] {
 			return
 		}
+
 		visited[g] = true
+
 		for parentGroup, members := range inv.GroupMembers {
 			for _, m := range members {
 				if m.Kind == iamtypes.KindGroup && m.Name == g {
@@ -210,13 +230,16 @@ func (inv *accessInventory) ResolveUserGroups(userName string) ([]string, []stri
 	for g := range directSet {
 		direct = append(direct, g)
 	}
+
 	sort.Strings(direct)
 
 	transitive := make([]string, 0, len(visited))
 	for g := range visited {
 		transitive = append(transitive, g)
 	}
+
 	sort.Strings(transitive)
+
 	return direct, transitive
 }
 
@@ -231,6 +254,7 @@ func (inv *accessInventory) UserGrants(userName string) ([]normalizedGrant, []no
 	}
 
 	var directGrants, inheritedGrants []normalizedGrant
+
 	for _, grant := range inv.Grants {
 		if grant.SubjectKind == iamtypes.KindUser && grant.SubjectPrincipal == email {
 			directGrants = append(directGrants, grant)
@@ -238,17 +262,20 @@ func (inv *accessInventory) UserGrants(userName string) ([]normalizedGrant, []no
 			inheritedGrants = append(inheritedGrants, grant)
 		}
 	}
+
 	return directGrants, inheritedGrants
 }
 
 // GroupGrants returns grants assigned directly to a group.
 func (inv *accessInventory) GroupGrants(groupName string) []normalizedGrant {
 	var grants []normalizedGrant
+
 	for _, grant := range inv.Grants {
 		if grant.SubjectKind == iamtypes.KindGroup && grant.SubjectPrincipal == groupName {
 			grants = append(grants, grant)
 		}
 	}
+
 	return grants
 }
 
@@ -272,15 +299,18 @@ func computeEffectiveSummary(grants []normalizedGrant) *effectiveSummary {
 	}
 
 	var clusterLevels []string
+
 	nsLevels := make(map[string][]string)
 
 	for _, g := range grants {
 		if g.AllowScale {
 			summary.AllowScale = true
 		}
+
 		if g.PortForwarding {
 			summary.PortForwarding = true
 		}
+
 		switch g.ScopeType {
 		case iamtypes.ScopeCluster, iamtypes.ScopeAllNamespaces, iamtypes.ScopeLabels:
 			// ScopeLabels still creates a CAR; without resolving the
@@ -309,6 +339,7 @@ func computeEffectiveSummary(grants []normalizedGrant) *effectiveSummary {
 			summary.PortForwarding = true
 			summary.PortForwardingImplicit = true
 		}
+
 		if !summary.AllowScale {
 			summary.AllowScale = true
 			summary.AllowScaleImplicit = true
@@ -324,6 +355,7 @@ func capabilityNote(implicit bool) string {
 	if implicit {
 		return " (implicit via SuperAdmin wildcard)"
 	}
+
 	return ""
 }
 
@@ -338,6 +370,7 @@ func (s *effectiveSummary) String() string {
 	for ns, level := range s.Namespaced {
 		levelNS[level] = append(levelNS[level], ns)
 	}
+
 	for level, nss := range levelNS {
 		sort.Strings(nss)
 		parts = append(parts, fmt.Sprintf("%s[%s]", level, strings.Join(nss, ",")))
@@ -346,7 +379,9 @@ func (s *effectiveSummary) String() string {
 	if len(parts) == 0 {
 		return "<none>"
 	}
+
 	sort.Strings(parts)
+
 	return strings.Join(parts, ", ")
 }
 
@@ -354,29 +389,36 @@ func (s *effectiveSummary) String() string {
 func (inv *accessInventory) DetectGroupCycles() map[string][]string {
 	cycles := make(map[string][]string)
 	visited := make(map[string]int) // 0=unvisited, 1=visiting, 2=done
+
 	var path []string
 
 	var dfs func(string)
+
 	dfs = func(g string) {
 		if visited[g] == 2 {
 			return
 		}
+
 		if visited[g] == 1 {
 			// Found cycle
 			cycleStart := -1
+
 			for i, p := range path {
 				if p == g {
 					cycleStart = i
 					break
 				}
 			}
+
 			if cycleStart >= 0 {
 				cycle := append([]string{}, path[cycleStart:]...)
 				cycle = append(cycle, g)
 				cycles[g] = cycle
 			}
+
 			return
 		}
+
 		visited[g] = 1
 		path = append(path, g)
 

--- a/internal/iam/access/cmd/revoke.go
+++ b/internal/iam/access/cmd/revoke.go
@@ -115,6 +115,7 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 	}
 
 	var subjectPrincipal string
+
 	switch subjectKind {
 	case iamtypes.KindUser:
 		subjectPrincipal, err = resolveUserEmail(cmd.Context(), dyn, subjectName)
@@ -138,6 +139,7 @@ func runRevoke(cmd *cobra.Command, args []string) error {
 		dryRun:           dryRun,
 		outputFmt:        outputFmt,
 	}
+
 	return revokeManagedGrants(cmd, dyn, opts)
 }
 
@@ -177,15 +179,18 @@ func revokeManagedGrants(cmd *cobra.Command, dyn dynamic.Interface, opts revokeO
 	}
 
 	var errs *multierror.Error
+
 	for _, spec := range specs {
 		client, kind, ns, err := revokeClient(dyn, spec)
 		if err != nil {
 			return err
 		}
+
 		if err := deleteManagedGrant(cmd, client, spec, kind, ns, opts.dryRun, opts.outputFmt); err != nil {
 			errs = multierror.Append(errs, err)
 		}
 	}
+
 	return errs.ErrorOrNil()
 }
 
@@ -197,7 +202,9 @@ func revokeClient(dyn dynamic.Interface, spec *canonicalGrantSpec) (dynamic.Reso
 		if len(spec.Namespaces) != 1 {
 			return nil, "", "", fmt.Errorf("namespaced revoke must target exactly one namespace, got %d", len(spec.Namespaces))
 		}
+
 		ns := spec.Namespaces[0]
+
 		return dyn.Resource(iamtypes.AuthorizationRuleGVR).Namespace(ns), iamtypes.KindAuthorizationRule, ns, nil
 	case iamtypes.ScopeCluster, iamtypes.ScopeAllNamespaces, iamtypes.ScopeLabels:
 		return dyn.Resource(iamtypes.ClusterAuthorizationRuleGVR), iamtypes.KindClusterAuthorizationRule, "", nil
@@ -225,6 +232,7 @@ func deleteManagedGrant(cmd *cobra.Command, client dynamic.ResourceInterface,
 	if err != nil {
 		ref := formatRuleRef(kind, ns, name)
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: d8-managed %s not found\n", ref)
+
 		return fmt.Errorf("%s: %w", ref, err)
 	}
 
@@ -243,10 +251,12 @@ func deleteManagedGrant(cmd *cobra.Command, client dynamic.ResourceInterface,
 	if err := client.Delete(cmd.Context(), name, metav1.DeleteOptions{}); err != nil {
 		ref := formatRuleRef(kind, ns, name)
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to delete %s: %v\n", ref, err)
+
 		return fmt.Errorf("%s: %w", ref, err)
 	}
 
 	cmd.Printf("Revoked: %s\n", formatRuleRef(kind, ns, name))
+
 	return nil
 }
 
@@ -257,5 +267,6 @@ func formatRuleRef(kind, ns, name string) string {
 	if ns == "" {
 		return fmt.Sprintf("%s/%s", kind, name)
 	}
+
 	return fmt.Sprintf("%s/%s/%s", kind, ns, name)
 }

--- a/internal/iam/access/cmd/rules.go
+++ b/internal/iam/access/cmd/rules.go
@@ -72,17 +72,20 @@ func (r ruleRow) ref() string {
 // shape — e.g. rules get — see exactly what is on the object).
 func readSubjectRefs(obj *unstructured.Unstructured) []subjectRef {
 	raw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "subjects")
+
 	out := make([]subjectRef, 0, len(raw))
 	for _, s := range raw {
 		m, ok := s.(map[string]any)
 		if !ok {
 			continue
 		}
+
 		out = append(out, subjectRef{
 			Kind: iamtypes.SubjectKind(fmt.Sprint(m["kind"])),
 			Name: fmt.Sprint(m["name"]),
 		})
 	}
+
 	return out
 }
 
@@ -208,6 +211,7 @@ func NewGetRuleCommand() *cobra.Command {
 		RunE:              runRulesGet,
 	}
 	utilk8s.AddOutputFlag(cmd, "text", "text", "json", "yaml")
+
 	return cmd
 }
 
@@ -216,6 +220,7 @@ func runRulesGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	outputFmt, _ := cmd.Flags().GetString("output")
 
 	dyn, err := utilk8s.NewDynamicClient(cmd)
@@ -224,12 +229,14 @@ func runRulesGet(cmd *cobra.Command, args []string) error {
 	}
 
 	var obj *unstructured.Unstructured
+
 	switch refKind {
 	case iamtypes.KindClusterAuthorizationRule:
 		obj, err = dyn.Resource(iamtypes.ClusterAuthorizationRuleGVR).Get(cmd.Context(), refName, metav1.GetOptions{})
 	case iamtypes.KindAuthorizationRule:
 		obj, err = dyn.Resource(iamtypes.AuthorizationRuleGVR).Namespace(refNS).Get(cmd.Context(), refName, metav1.GetOptions{})
 	}
+
 	if err != nil {
 		return fmt.Errorf("getting %s: %w", args[0], err)
 	}
@@ -243,11 +250,13 @@ func runRulesGet(cmd *cobra.Command, args []string) error {
 		return utilk8s.PrintObject(cmd.OutOrStdout(), obj, outputFmt)
 	case "text", "":
 		row := ruleRowFromObject(obj)
+
 		reverse, err := reverseSubjectLookup(cmd.Context(), dyn, row.Subjects)
 		if err != nil {
 			// Reverse lookup is a best-effort nicety; degrade rather than fail.
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: reverse lookup of subjects failed: %v\n", err)
 		}
+
 		return printRuleRowText(cmd.OutOrStdout(), row, reverse)
 	default:
 		return fmt.Errorf("%w %q; use text|json|yaml", errUnsupportedFormat, outputFmt)
@@ -264,6 +273,7 @@ func collectRuleRows(ctx context.Context, dyn dynamic.Interface, includeCARs, in
 		if err != nil {
 			return nil, fmt.Errorf("listing ClusterAuthorizationRules: %w", err)
 		}
+
 		for i := range list.Items {
 			rows = append(rows, ruleRowFromObject(&list.Items[i]))
 		}
@@ -274,11 +284,13 @@ func collectRuleRows(ctx context.Context, dyn dynamic.Interface, includeCARs, in
 		if len(nsFilter) > 0 {
 			nsToList = nsFilter
 		}
+
 		for _, ns := range nsToList {
 			list, err := dyn.Resource(iamtypes.AuthorizationRuleGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("listing AuthorizationRules in %q: %w", ns, err)
 			}
+
 			for i := range list.Items {
 				rows = append(rows, ruleRowFromObject(&list.Items[i]))
 			}
@@ -297,8 +309,12 @@ func ruleRowFromObject(obj *unstructured.Unstructured) ruleRow {
 
 	kind := obj.GetKind()
 	ns := obj.GetNamespace()
-	var scopeType iamtypes.Scope
-	var scopeNamespaces []string
+
+	var (
+		scopeType       iamtypes.Scope
+		scopeNamespaces []string
+	)
+
 	switch kind {
 	case iamtypes.KindClusterAuthorizationRule:
 		scopeType = iamtypes.ScopeCluster
@@ -345,6 +361,7 @@ func filterByManagement(rows []ruleRow, managedOnly, manualOnly bool) []ruleRow 
 			out = append(out, r)
 		}
 	}
+
 	return out
 }
 
@@ -356,9 +373,11 @@ func sortRuleRows(rows []ruleRow) {
 			// namespaced ones, matching operator mental model.
 			return rows[i].Kind < rows[j].Kind
 		}
+
 		if rows[i].Namespace != rows[j].Namespace {
 			return rows[i].Namespace < rows[j].Namespace
 		}
+
 		return rows[i].Name < rows[j].Name
 	})
 }
@@ -381,6 +400,7 @@ func managedByColumn(r ruleRow) string {
 	if r.ManagedByD8 {
 		return iamtypes.ManagedByValueCLI
 	}
+
 	return "manual"
 }
 
@@ -389,12 +409,15 @@ func capsColumn(r ruleRow) string {
 	if r.AllowScale {
 		caps = append(caps, "scale")
 	}
+
 	if r.PortForwarding {
 		caps = append(caps, "pfwd")
 	}
+
 	if len(caps) == 0 {
 		return "-"
 	}
+
 	return strings.Join(caps, ",")
 }
 
@@ -412,6 +435,7 @@ func printRuleRowsTable(w io.Writer, rows []ruleRow) error {
 		if ns == "" {
 			ns = "-"
 		}
+
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\t%s\n",
 			shortKind(r.Kind),
 			ns,
@@ -424,6 +448,7 @@ func printRuleRowsTable(w io.Writer, rows []ruleRow) error {
 			humanAge(r.CreationTime),
 		)
 	}
+
 	return tw.Flush()
 }
 
@@ -431,9 +456,11 @@ func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
+
 	if max <= 1 {
 		return s[:max]
 	}
+
 	return s[:max-1] + "…"
 }
 
@@ -444,6 +471,7 @@ func humanAge(t time.Time) string {
 	if t.IsZero() {
 		return "-"
 	}
+
 	return duration.HumanDuration(time.Since(t))
 }
 
@@ -453,28 +481,34 @@ func printRuleRowText(w io.Writer, r ruleRow, reverse map[string]string) error {
 	fmt.Fprintf(w, "=== %s ===\n", r.ref())
 	fmt.Fprintf(w, "  Kind:         %s\n", r.Kind)
 	fmt.Fprintf(w, "  Name:         %s\n", r.Name)
+
 	if r.Namespace != "" {
 		fmt.Fprintf(w, "  Namespace:    %s\n", r.Namespace)
 	}
+
 	accessLevel := r.AccessLevel
 	if accessLevel == "" {
 		accessLevel = "<unset>"
 	}
+
 	fmt.Fprintf(w, "  Access level: %s\n", accessLevel)
 	fmt.Fprintf(w, "  Scope:        %s\n", r.ScopeType)
 	fmt.Fprintf(w, "  Allow scale:  %v\n", r.AllowScale)
 	fmt.Fprintf(w, "  Port forward: %v\n", r.PortForwarding)
 	fmt.Fprintf(w, "  Managed by:   %s\n", managedByColumn(r))
+
 	if !r.CreationTime.IsZero() {
 		fmt.Fprintf(w, "  Age:          %s (%s)\n", humanAge(r.CreationTime), r.CreationTime.UTC().Format(time.RFC3339))
 	}
 
 	fmt.Fprintf(w, "\n=== Subjects (%d) ===\n", len(r.Subjects))
+
 	if len(r.Subjects) == 0 {
 		fmt.Fprintln(w, "  <none>")
 	} else {
 		for _, s := range r.Subjects {
 			key := string(s.Kind) + "/" + s.Name
+
 			local := reverse[key]
 			switch local {
 			case "":
@@ -531,6 +565,7 @@ func ruleRowToJSON(r ruleRow) ruleJSON {
 	for _, s := range r.Subjects {
 		subjects = append(subjects, subjectJSON{Kind: string(s.Kind), Name: s.Name})
 	}
+
 	return ruleJSON{
 		Kind:           r.Kind,
 		Name:           r.Name,
@@ -550,6 +585,7 @@ func buildRuleRowsJSON(rows []ruleRow) []ruleJSON {
 	for _, r := range rows {
 		items = append(items, ruleRowToJSON(r))
 	}
+
 	return items
 }
 
@@ -574,11 +610,13 @@ func parseRuleRef(ref string) (string, string, string, error) {
 		if len(parts) != 2 {
 			return "", "", "", fmt.Errorf("%w %q: ClusterAuthorizationRule reference must be of the form ClusterAuthorizationRule/NAME", ErrInvalidRuleRef, ref)
 		}
+
 		return iamtypes.KindClusterAuthorizationRule, "", parts[1], nil
 	case iamtypes.KindAuthorizationRule, "AR", "ar":
 		if len(parts) != 3 {
 			return "", "", "", fmt.Errorf("%w %q: AuthorizationRule reference must be of the form AuthorizationRule/NAMESPACE/NAME", ErrInvalidRuleRef, ref)
 		}
+
 		return iamtypes.KindAuthorizationRule, parts[1], parts[2], nil
 	default:
 		return "", "", "", fmt.Errorf("%w %q: unknown rule kind %q (use ClusterAuthorizationRule, AuthorizationRule, CAR or AR)", ErrInvalidRuleRef, ref, parts[0])
@@ -596,6 +634,7 @@ func reverseSubjectLookup(ctx context.Context, dyn dynamic.Interface, subjects [
 	result := make(map[string]string)
 	needUsers := false
 	needGroups := false
+
 	for _, s := range subjects {
 		switch s.Kind {
 		case iamtypes.KindUser:
@@ -610,18 +649,22 @@ func reverseSubjectLookup(ctx context.Context, dyn dynamic.Interface, subjects [
 		if err != nil {
 			return nil, fmt.Errorf("listing Users: %w", err)
 		}
+
 		emailToCR := make(map[string]string, len(userList.Items))
 		for i := range userList.Items {
 			u := &userList.Items[i]
+
 			email, _, _ := unstructured.NestedString(u.Object, "spec", "email")
 			if email != "" {
 				emailToCR[email] = u.GetName()
 			}
 		}
+
 		for _, s := range subjects {
 			if s.Kind != iamtypes.KindUser {
 				continue
 			}
+
 			if cr, ok := emailToCR[s.Name]; ok {
 				result[string(iamtypes.KindUser)+"/"+s.Name] = cr
 			}
@@ -633,14 +676,17 @@ func reverseSubjectLookup(ctx context.Context, dyn dynamic.Interface, subjects [
 		if err != nil {
 			return nil, fmt.Errorf("listing Groups: %w", err)
 		}
+
 		present := make(map[string]bool, len(groupList.Items))
 		for i := range groupList.Items {
 			present[groupList.Items[i].GetName()] = true
 		}
+
 		for _, s := range subjects {
 			if s.Kind != iamtypes.KindGroup {
 				continue
 			}
+
 			if present[s.Name] {
 				result[string(iamtypes.KindGroup)+"/"+s.Name] = s.Name
 			}

--- a/internal/iam/access/cmd/types.go
+++ b/internal/iam/access/cmd/types.go
@@ -46,6 +46,7 @@ var accessLevelOrder = func() map[string]int {
 	for i, l := range allAccessLevelsOrdered {
 		m[l] = i
 	}
+
 	return m
 }()
 
@@ -57,6 +58,7 @@ func sliceToSet(s []string) map[string]bool {
 	for _, v := range s {
 		m[v] = true
 	}
+
 	return m
 }
 
@@ -90,6 +92,7 @@ func (c *canonicalGrantSpec) JSON() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(data), nil
 }
 
@@ -118,17 +121,21 @@ func validateAccessLevel(level string, namespaced bool) error {
 			return fmt.Errorf("access level %q is not valid for namespaced scope; valid levels: %s",
 				level, strings.Join(namespacedAccessLevelsOrdered, ", "))
 		}
+
 		return nil
 	}
+
 	if !allAccessLevels[level] {
 		return fmt.Errorf("invalid access level %q; valid levels: %s",
 			level, strings.Join(allAccessLevelsOrdered, ", "))
 	}
+
 	return nil
 }
 
 func maxAccessLevel(levels []string) string {
 	best := ""
+
 	bestOrder := -1
 	for _, l := range levels {
 		if ord, ok := accessLevelOrder[l]; ok && ord > bestOrder {
@@ -136,6 +143,7 @@ func maxAccessLevel(levels []string) string {
 			bestOrder = ord
 		}
 	}
+
 	return best
 }
 

--- a/internal/iam/group/cmd/add_member.go
+++ b/internal/iam/group/cmd/add_member.go
@@ -55,6 +55,7 @@ func newAddMemberCommand() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("create-group", false, "Create the target group if it does not exist")
+
 	return cmd
 }
 
@@ -63,6 +64,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	createGroup, _ := cmd.Flags().GetBool("create-group")
 
 	memberKind, err := normalizeMemberKind(kindStr)
@@ -86,6 +88,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 		if !createGroup && apierrors.IsNotFound(err) {
 			return fmt.Errorf("%w (use --create-group to create it)", err)
 		}
+
 		return err
 	}
 
@@ -98,6 +101,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 	case res.Added:
 		cmd.Printf("Added %s %q to group %q\n", strings.ToLower(string(memberKind)), memberName, groupName)
 	}
+
 	return nil
 }
 

--- a/internal/iam/group/cmd/completion.go
+++ b/internal/iam/group/cmd/completion.go
@@ -32,6 +32,7 @@ func completeGroupOnly(cmd *cobra.Command, args []string, toComplete string) ([]
 	if len(args) >= 1 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+
 	return utilk8s.CompleteResourceNames(cmd, iamtypes.GroupGVR, "", toComplete)
 }
 
@@ -51,5 +52,6 @@ func completeMemberArgs(cmd *cobra.Command, args []string, toComplete string) ([
 			return utilk8s.CompleteResourceNames(cmd, iamtypes.GroupGVR, "", toComplete)
 		}
 	}
+
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/iam/group/cmd/create.go
+++ b/internal/iam/group/cmd/create.go
@@ -70,6 +70,7 @@ func newCreateCommand() *cobra.Command {
 
 	cmd.Flags().Bool("dry-run", false, "Print the resource that would be created without applying")
 	utilk8s.AddOutputFlag(cmd, "name", "name", "yaml", "json")
+
 	return cmd
 }
 

--- a/internal/iam/group/cmd/delete.go
+++ b/internal/iam/group/cmd/delete.go
@@ -48,6 +48,7 @@ func newDeleteCommand() *cobra.Command {
 			}
 
 			cmd.Printf("Group %s deleted\n", name)
+
 			return nil
 		},
 	}

--- a/internal/iam/group/cmd/membership.go
+++ b/internal/iam/group/cmd/membership.go
@@ -61,13 +61,16 @@ func EnsureMember(ctx context.Context, dyn dynamic.Interface,
 			if !opts.CreateGroupIfMissing {
 				return EnsureMemberResult{}, fmt.Errorf("group %q not found: %w", groupName, err)
 			}
+
 			newObj := buildGroupObject(groupName)
 			setSpecMembers(newObj, []any{
 				map[string]any{"kind": memberKindStr, "name": memberName},
 			})
+
 			if _, err := groupClient.Create(ctx, newObj, metav1.CreateOptions{}); err != nil {
 				return EnsureMemberResult{}, fmt.Errorf("creating group %q: %w", groupName, err)
 			}
+
 			return EnsureMemberResult{GroupCreated: true, Added: true}, nil
 		default:
 			// Any other Get failure (Forbidden, Timeout, transient API error)
@@ -79,6 +82,7 @@ func EnsureMember(ctx context.Context, dyn dynamic.Interface,
 	}
 
 	var result EnsureMemberResult
+
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		obj, err := groupClient.Get(ctx, groupName, metav1.GetOptions{})
 		if err != nil {
@@ -93,6 +97,7 @@ func EnsureMember(ctx context.Context, dyn dynamic.Interface,
 			if err != nil {
 				return fmt.Errorf("cycle detection failed: %w", err)
 			}
+
 			if hasCycle {
 				return fmt.Errorf("adding group %q to %q would create a cycle: %s",
 					memberName, groupName, strings.Join(cyclePath, " -> "))
@@ -105,6 +110,7 @@ func EnsureMember(ctx context.Context, dyn dynamic.Interface,
 			if !ok {
 				continue
 			}
+
 			if fmt.Sprint(member["kind"]) == memberKindStr && fmt.Sprint(member["name"]) == memberName {
 				result = EnsureMemberResult{AlreadyMember: true}
 				return nil
@@ -121,12 +127,15 @@ func EnsureMember(ctx context.Context, dyn dynamic.Interface,
 		if _, err := groupClient.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
+
 		result = EnsureMemberResult{Added: true}
+
 		return nil
 	})
 	if err != nil {
 		return EnsureMemberResult{}, err
 	}
+
 	return result, nil
 }
 
@@ -149,9 +158,11 @@ func detectCycleCtx(ctx context.Context, dyn dynamic.Interface, parentGroup, chi
 
 	groupKindStr := string(iamtypes.KindGroup)
 	adj := make(map[string][]string)
+
 	for i := range allGroups.Items {
 		g := &allGroups.Items[i]
 		gName := g.GetName()
+
 		members, _ := getGroupMembers(g)
 		for _, m := range members {
 			if fmt.Sprint(m["kind"]) == groupKindStr {
@@ -159,32 +170,43 @@ func detectCycleCtx(ctx context.Context, dyn dynamic.Interface, parentGroup, chi
 			}
 		}
 	}
+
 	adj[parentGroup] = append(adj[parentGroup], childGroup)
 
 	visited := make(map[string]bool)
-	var path []string
-	var dfs func(string) bool
+
+	var (
+		path []string
+		dfs  func(string) bool
+	)
+
 	dfs = func(node string) bool {
 		if node == parentGroup {
 			path = append(path, node)
 			return true
 		}
+
 		if visited[node] {
 			return false
 		}
+
 		visited[node] = true
+
 		path = append(path, node)
 		for _, next := range adj[node] {
 			if dfs(next) {
 				return true
 			}
 		}
+
 		path = path[:len(path)-1]
+
 		return false
 	}
 	if dfs(childGroup) {
 		return true, path, nil
 	}
+
 	return false, nil, nil
 }
 

--- a/internal/iam/group/cmd/remove_member.go
+++ b/internal/iam/group/cmd/remove_member.go
@@ -77,7 +77,9 @@ func newRemoveMemberCommand() *cobra.Command {
 				cmd.Printf("Nothing to do: %s %q is not a member of group %q\n", memberKindStr, memberName, groupName)
 				return nil
 			}
+
 			cmd.Printf("Removed %s %q from group %q\n", memberKindStr, memberName, groupName)
+
 			return nil
 		},
 	}
@@ -107,17 +109,21 @@ func RemoveMember(ctx context.Context, dyn dynamic.Interface,
 
 		rawMembers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "members")
 		found := false
+
 		var newMembers []any
+
 		for _, item := range rawMembers {
 			m, ok := item.(map[string]any)
 			if !ok {
 				newMembers = append(newMembers, item)
 				continue
 			}
+
 			if fmt.Sprint(m["kind"]) == memberKindStr && fmt.Sprint(m["name"]) == memberName {
 				found = true
 				continue
 			}
+
 			newMembers = append(newMembers, item)
 		}
 
@@ -134,11 +140,14 @@ func RemoveMember(ctx context.Context, dyn dynamic.Interface,
 		if _, err := groupClient.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
+
 		removed = true
+
 		return nil
 	})
 	if err != nil {
 		return false, err
 	}
+
 	return removed, nil
 }

--- a/internal/iam/group/cmd/types.go
+++ b/internal/iam/group/cmd/types.go
@@ -24,16 +24,20 @@ func getGroupMembers(obj *unstructured.Unstructured) ([]map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if !found {
 		return nil, nil
 	}
+
 	result := make([]map[string]any, 0, len(raw))
 	for _, item := range raw {
 		m, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
+
 		result = append(result, m)
 	}
+
 	return result, nil
 }

--- a/internal/iam/user/cmd/completion.go
+++ b/internal/iam/user/cmd/completion.go
@@ -30,5 +30,6 @@ func completeUserNames(cmd *cobra.Command, args []string, toComplete string) ([]
 	if len(args) >= 1 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+
 	return utilk8s.CompleteResourceNames(cmd, iamtypes.UserGVR, "", toComplete)
 }

--- a/internal/iam/user/cmd/create.go
+++ b/internal/iam/user/cmd/create.go
@@ -110,9 +110,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if err := validateUserName(name); err != nil {
 		return err
 	}
+
 	if err := validateEmail(email); err != nil {
 		return err
 	}
+
 	if ttl != "" {
 		if err := validateTTL(ttl); err != nil {
 			return err
@@ -165,6 +167,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if len(memberOf) > 0 {
 		var errs *multierror.Error
+
 		for _, groupName := range memberOf {
 			if _, err := group.EnsureMember(cmd.Context(), dyn, groupName, iamtypes.KindUser, name, group.EnsureMemberOpts{
 				CreateGroupIfMissing: createGroups,
@@ -173,6 +176,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 				errs = multierror.Append(errs, err)
 			}
 		}
+
 		if errs.ErrorOrNil() != nil {
 			return fmt.Errorf("User %s created, but failed to update %d group(s): %w",
 				name, errs.Len(), errs)
@@ -209,6 +213,7 @@ func validateUserName(name string) error {
 	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
 		return fmt.Errorf("invalid user name %q: %s", name, strings.Join(errs, "; "))
 	}
+
 	return nil
 }
 
@@ -216,12 +221,15 @@ func validateEmail(email string) error {
 	if email == "" {
 		return errors.New("--email is required")
 	}
+
 	if email != strings.ToLower(email) {
 		return fmt.Errorf("email must be lowercase, got %q", email)
 	}
+
 	if !strings.Contains(email, "@") {
 		return fmt.Errorf("email %q does not look like a valid email address", email)
 	}
+
 	return nil
 }
 
@@ -230,8 +238,10 @@ func validateTTL(ttl string) error {
 	if err != nil {
 		return fmt.Errorf("invalid --ttl %q: %w (expected like 24h, 30m, 1h30m)", ttl, err)
 	}
+
 	if d <= 0 {
 		return fmt.Errorf("invalid --ttl %q: must be positive", ttl)
 	}
+
 	return nil
 }

--- a/internal/iam/user/cmd/delete.go
+++ b/internal/iam/user/cmd/delete.go
@@ -83,11 +83,14 @@ func newDeleteCommand() *cobra.Command {
 			if keepMemberships {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: --keep-memberships set; user %q may still be referenced in Group memberships. Use \"d8 iam group remove-member\" to clean up.\n", name)
 			}
+
 			cmd.Printf("User %s deleted\n", name)
+
 			return nil
 		},
 	}
 	cmd.Flags().Bool("keep-memberships", false, "Do not remove the user from local Group spec.members; only delete the User CR")
+
 	return cmd
 }
 
@@ -105,7 +108,9 @@ func cleanupUserFromGroups(ctx context.Context, cmd *cobra.Command, dyn dynamic.
 	}
 
 	cleaned := 0
+
 	var errs *multierror.Error
+
 	userKindStr := string(iamtypes.KindUser)
 
 	for i := range groups.Items {
@@ -123,8 +128,10 @@ func cleanupUserFromGroups(ctx context.Context, cmd *cobra.Command, dyn dynamic.
 			errs = multierror.Append(errs, fmt.Errorf("group %q: %w", groupName, err))
 			continue
 		}
+
 		if removed {
 			cleaned++
+
 			fmt.Fprintf(cmd.ErrOrStderr(), "Removed user %q from group %q\n", userName, groupName)
 		}
 	}
@@ -133,9 +140,11 @@ func cleanupUserFromGroups(ctx context.Context, cmd *cobra.Command, dyn dynamic.
 		return fmt.Errorf("failed to clean up user %q from %d group(s): %w",
 			userName, errs.Len(), errs)
 	}
+
 	if cleaned > 0 {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Cleaned %d group membership(s) of user %q\n", cleaned, userName)
 	}
+
 	return nil
 }
 
@@ -156,16 +165,19 @@ func removeUserFromGroup(ctx context.Context, groupClient dynamic.NamespaceableR
 		raw, _, _ := unstructured.NestedSlice(obj.Object, "spec", "members")
 		filtered := make([]any, 0, len(raw))
 		found := false
+
 		for _, item := range raw {
 			m, ok := item.(map[string]any)
 			if !ok {
 				filtered = append(filtered, item)
 				continue
 			}
+
 			if fmt.Sprint(m["kind"]) == userKindStr && fmt.Sprint(m["name"]) == userName {
 				found = true
 				continue
 			}
+
 			filtered = append(filtered, item)
 		}
 
@@ -182,9 +194,12 @@ func removeUserFromGroup(ctx context.Context, groupClient dynamic.NamespaceableR
 		if _, err := groupClient.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
+
 		removed = true
+
 		return nil
 	})
+
 	return removed, err
 }
 
@@ -195,9 +210,11 @@ func groupContainsMember(obj *unstructured.Unstructured, kindStr, name string) b
 		if !ok {
 			continue
 		}
+
 		if fmt.Sprint(m["kind"]) == kindStr && fmt.Sprint(m["name"]) == name {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/iam/user/cmd/deprecated.go
+++ b/internal/iam/user/cmd/deprecated.go
@@ -103,6 +103,7 @@ func newDeprecatedResetPasswordCommand() *cobra.Command {
 			fmt.Fprintln(cmd.ErrOrStderr(),
 				"Warning: 'd8 user reset-password <user> <hash>' is deprecated; "+
 					"please use 'd8 iam user reset-password <user> --password-hash <hash>' instead.")
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -126,6 +127,7 @@ func newDeprecatedResetPasswordCommand() *cobra.Command {
 		},
 	}
 	addWaitFlags(cmd)
+
 	return cmd
 }
 
@@ -141,10 +143,13 @@ func deprecateForward(sub *cobra.Command, newPath string) *cobra.Command {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"Warning: 'd8 user %s' is deprecated; please use '%s' instead.\n",
 			cmd.Name(), newPath)
+
 		if origPre != nil {
 			return origPre(cmd, args)
 		}
+
 		return nil
 	}
+
 	return sub
 }

--- a/internal/iam/user/cmd/password.go
+++ b/internal/iam/user/cmd/password.go
@@ -71,15 +71,19 @@ func resolvePasswordMode(prompt, stdin, generate bool, hash string) (passwordMod
 	if prompt {
 		count++
 	}
+
 	if stdin {
 		count++
 	}
+
 	if generate {
 		count++
 	}
+
 	if hash != "" {
 		count++
 	}
+
 	if count > 1 {
 		return passwordModeNone, fmt.Errorf(
 			"only one of --%s, --%s, --%s, --%s may be specified",
@@ -101,6 +105,7 @@ func resolvePasswordMode(prompt, stdin, generate bool, hash string) (passwordMod
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		return passwordModePrompt, nil
 	}
+
 	return passwordModeNone, fmt.Errorf(
 		"stdin is not a terminal; use --%s, --%s or --%s",
 		flagPasswordStdin, flagPasswordGenerate, flagPasswordHash,
@@ -136,6 +141,7 @@ func resolvePasswordInput(cmd *cobra.Command) (passwordResult, passwordMode, err
 		if err := validateBcryptHash(hashFlag); err != nil {
 			return passwordResult{}, mode, err
 		}
+
 		return passwordResult{Hash: hashFlag}, mode, nil
 	case passwordModePrompt:
 		p, err := readPasswordPrompt(int(os.Stdin.Fd()), cmd.ErrOrStderr())
@@ -147,6 +153,7 @@ func resolvePasswordInput(cmd *cobra.Command) (passwordResult, passwordMode, err
 		p, err := generatePassword()
 		return passwordResult{Plain: p}, mode, err
 	}
+
 	return passwordResult{}, mode, errors.New("no password source configured")
 }
 
@@ -157,10 +164,12 @@ func (r passwordResult) rawBcryptHash() (string, error) {
 	if r.Hash != "" {
 		return r.Hash, nil
 	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(r.Plain), bcryptCost)
 	if err != nil {
 		return "", fmt.Errorf("hashing password: %w", err)
 	}
+
 	return string(hash), nil
 }
 
@@ -168,15 +177,21 @@ func (r passwordResult) rawBcryptHash() (string, error) {
 // stdinFd is the file descriptor to read from; out receives prompts.
 func readPasswordPrompt(stdinFd int, out io.Writer) (string, error) {
 	fmt.Fprint(out, "Enter password: ")
+
 	pw1, err := term.ReadPassword(stdinFd)
+
 	fmt.Fprintln(out)
+
 	if err != nil {
 		return "", fmt.Errorf("reading password: %w", err)
 	}
 
 	fmt.Fprint(out, "Confirm password: ")
+
 	pw2, err := term.ReadPassword(stdinFd)
+
 	fmt.Fprintln(out)
+
 	if err != nil {
 		return "", fmt.Errorf("reading password confirmation: %w", err)
 	}
@@ -184,9 +199,11 @@ func readPasswordPrompt(stdinFd int, out io.Writer) (string, error) {
 	if string(pw1) != string(pw2) {
 		return "", errors.New("passwords do not match")
 	}
+
 	if len(pw1) == 0 {
 		return "", errors.New("password must not be empty")
 	}
+
 	return string(pw1), nil
 }
 
@@ -197,12 +214,15 @@ func readPasswordStdin(r io.Reader) (string, error) {
 		if err := scanner.Err(); err != nil {
 			return "", fmt.Errorf("reading password from stdin: %w", err)
 		}
+
 		return "", errors.New("no password provided on stdin")
 	}
+
 	pw := strings.TrimRight(scanner.Text(), "\r\n")
 	if pw == "" {
 		return "", errors.New("password must not be empty")
 	}
+
 	return pw, nil
 }
 
@@ -212,6 +232,7 @@ func generatePassword() (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", fmt.Errorf("generating random password: %w", err)
 	}
+
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b), nil
 }
 
@@ -231,6 +252,7 @@ func encodePasswordForDeckhouse(plain string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("hashing password: %w", err)
 	}
+
 	return encodePasswordForUserCR(string(hash)), nil
 }
 
@@ -242,8 +264,10 @@ func validateBcryptHash(s string) error {
 	if !strings.HasPrefix(s, "$2") {
 		return fmt.Errorf("--%s value does not look like a bcrypt hash (expected to start with $2a$ or $2y$)", flagPasswordHash)
 	}
+
 	if _, err := bcrypt.Cost([]byte(s)); err != nil {
 		return fmt.Errorf("--%s value is not a valid bcrypt hash: %w", flagPasswordHash, err)
 	}
+
 	return nil
 }

--- a/internal/iam/user/cmd/reset_password.go
+++ b/internal/iam/user/cmd/reset_password.go
@@ -74,6 +74,7 @@ func newResetPasswordCommand() *cobra.Command {
 
 	addPasswordFlags(cmd)
 	addWaitFlags(cmd)
+
 	return cmd
 }
 
@@ -115,5 +116,6 @@ func runResetPassword(cmd *cobra.Command, args []string) error {
 	if mode == passwordModeGenerate {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Generated new password (shown once): %s\n", res.Plain)
 	}
+
 	return nil
 }

--- a/internal/iam/user/cmd/types.go
+++ b/internal/iam/user/cmd/types.go
@@ -50,10 +50,12 @@ func getWaitFlags(cmd *cobra.Command) (waitFlags, error) {
 	if err != nil {
 		return waitFlags{}, err
 	}
+
 	timeoutVal, err := cmd.Flags().GetDuration("timeout")
 	if err != nil {
 		return waitFlags{}, err
 	}
+
 	return waitFlags{wait: waitVal, timeout: timeoutVal}, nil
 }
 
@@ -87,6 +89,7 @@ func runUserOperation(cmd *cobra.Command, dyn dynamic.Interface, req userOpReque
 	// Nano-second precision avoids collisions when several UserOperation
 	// commands are issued within the same wall-clock second (CI, retries, etc.).
 	name := fmt.Sprintf("%s%d", req.NamePrefix, time.Now().UnixNano())
+
 	spec := map[string]any{
 		"user":          req.User,
 		"type":          req.OpType,
@@ -120,11 +123,14 @@ func runUserOperation(cmd *cobra.Command, dyn dynamic.Interface, req userOpReque
 	}
 
 	phase, _, _ := unstructured.NestedString(result.Object, "status", "phase")
+
 	message, _, _ := unstructured.NestedString(result.Object, "status", "message")
 	if phase == "Failed" {
 		return fmt.Errorf("%s failed: %s", req.OpType, message)
 	}
+
 	cmd.Printf("Succeeded: %s\n", name)
+
 	return nil
 }
 
@@ -157,5 +163,6 @@ func waitUserOperation(ctx context.Context, dyn dynamic.Interface, name string, 
 	if err != nil {
 		return nil, err
 	}
+
 	return obj, nil
 }

--- a/internal/iam/user/cmd/user.go
+++ b/internal/iam/user/cmd/user.go
@@ -55,6 +55,7 @@ func NewCommand() *cobra.Command {
 		newDeleteCommand(),
 		newResetPasswordCommand(),
 	)
+
 	for _, def := range userOpDefs {
 		cmd.AddCommand(newUserOpCommand(def))
 	}

--- a/internal/iam/user/cmd/user_ops.go
+++ b/internal/iam/user/cmd/user_ops.go
@@ -61,6 +61,7 @@ var userOpDefs = []userOpDef{
 			if _, err := time.ParseDuration(args[1]); err != nil {
 				return nil, fmt.Errorf("invalid lockDuration %q: %w", args[1], err)
 			}
+
 			return map[string]any{
 				"lock": map[string]any{"for": args[1]},
 			}, nil
@@ -96,17 +97,21 @@ func newUserOpCommand(def userOpDef) *cobra.Command {
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var extra map[string]any
+
 			if def.BuildExtraSpec != nil {
 				e, err := def.BuildExtraSpec(args)
 				if err != nil {
 					return err
 				}
+
 				extra = e
 			}
+
 			dyn, err := utilk8s.NewDynamicClient(cmd)
 			if err != nil {
 				return err
 			}
+
 			return runUserOperation(cmd, dyn, userOpRequest{
 				NamePrefix: def.NamePrefix,
 				OpType:     def.OpType,
@@ -116,5 +121,6 @@ func newUserOpCommand(def userOpDef) *cobra.Command {
 		},
 	}
 	addWaitFlags(cmd)
+
 	return cmd
 }

--- a/internal/mirror/api/v1alpha1/deckhouse_release.go
+++ b/internal/mirror/api/v1alpha1/deckhouse_release.go
@@ -109,16 +109,19 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
+
 	switch value := v.(type) {
 	case float64:
 		d.Duration = time.Duration(value)
 		return nil
 	case string:
 		var err error
+
 		d.Duration, err = time.ParseDuration(value)
 		if err != nil {
 			return err
 		}
+
 		return nil
 	default:
 		return errors.New("invalid duration")

--- a/internal/mirror/chunked/chunk_reader.go
+++ b/internal/mirror/chunked/chunk_reader.go
@@ -35,8 +35,10 @@ type FileReader struct {
 func Open(baseDir, baseFileName string) (*FileReader, error) {
 	chunkIndex := 0
 	chunks := make([]*os.File, 0)
+
 	for {
 		chunkName := fmt.Sprintf("%s.%04d.chunk", baseFileName, chunkIndex)
+
 		chunk, err := os.Open(filepath.Join(baseDir, chunkName))
 		switch {
 		case errors.Is(err, os.ErrNotExist) && chunkIndex == 0:
@@ -61,10 +63,12 @@ func (f *FileReader) Read(p []byte) (int, error) {
 
 func (f *FileReader) Close() error {
 	err := &multierror.Error{}
+
 	for _, chunk := range f.chunks {
 		if chErr := chunk.Close(); chErr != nil {
 			err = multierror.Append(err, fmt.Errorf("closing chunk %s: %w", chunk.Name(), chErr))
 		}
 	}
+
 	return err.ErrorOrNil()
 }

--- a/internal/mirror/chunked/chunk_writer.go
+++ b/internal/mirror/chunked/chunk_writer.go
@@ -71,6 +71,7 @@ func (c *FileWriter) Write(p []byte) (int, error) {
 
 	buf := bytes.NewBuffer(p)
 	bytesWritten := 0
+
 	for {
 		for c.chunkSize-chunkStat.Size() > 0 {
 			s := buf.Next(512 * 1024)
@@ -80,6 +81,7 @@ func (c *FileWriter) Write(p []byte) (int, error) {
 
 			written, err := c.activeChunk.Write(s)
 			bytesWritten += written
+
 			if err != nil {
 				return 0, fmt.Errorf("Write to chunk: %w", err)
 			}
@@ -93,6 +95,7 @@ func (c *FileWriter) Write(p []byte) (int, error) {
 		if err = c.swapActiveChunk(); err != nil {
 			return 0, fmt.Errorf("Swap active chunk: %w", err)
 		}
+
 		chunkStat, err = c.activeChunk.Stat()
 		if err != nil {
 			return 0, fmt.Errorf("Read chunk size: %w", err)
@@ -115,14 +118,18 @@ func (c *FileWriter) Close() error {
 // called only after Close and only on a successful pack.
 func (c *FileWriter) Finalize() error {
 	var errs []error
+
 	for _, tmpRelPath := range c.writtenChunks {
 		tmp := filepath.Join(c.workingDir, tmpRelPath)
+
 		final := filepath.Join(c.workingDir, finalChunkName(tmpRelPath))
 		if err := os.Rename(tmp, final); err != nil {
 			errs = append(errs, fmt.Errorf("rename %s -> %s: %w", tmp, final, err))
 		}
 	}
+
 	c.writtenChunks = nil
+
 	return errors.Join(errs...)
 }
 
@@ -134,9 +141,11 @@ func (c *FileWriter) Cleanup() {
 		_ = c.activeChunk.Close()
 		c.activeChunk = nil
 	}
+
 	for _, tmpRelPath := range c.writtenChunks {
 		_ = os.Remove(filepath.Join(c.workingDir, tmpRelPath))
 	}
+
 	c.writtenChunks = nil
 }
 
@@ -145,10 +154,12 @@ func (c *FileWriter) swapActiveChunk() error {
 		if err := c.closeActiveChunk(); err != nil {
 			return fmt.Errorf("Close active chunk file: %w", err)
 		}
+
 		c.chunkIndex++
 	}
 
 	tmpName := fmt.Sprintf("%s.%04d.chunk%s", c.baseFileName, c.chunkIndex, tmpChunkSuffix)
+
 	newChunk, err := os.Create(filepath.Join(c.workingDir, tmpName))
 	if err != nil {
 		return fmt.Errorf("Create new chunk file: %w", err)
@@ -156,6 +167,7 @@ func (c *FileWriter) swapActiveChunk() error {
 
 	c.activeChunk = newChunk
 	c.writtenChunks = append(c.writtenChunks, tmpName)
+
 	return nil
 }
 
@@ -164,11 +176,14 @@ func (c *FileWriter) closeActiveChunk() error {
 		if err := c.activeChunk.Sync(); err != nil {
 			return fmt.Errorf("Flush chunk: %w", err)
 		}
+
 		if err := c.activeChunk.Close(); err != nil {
 			return fmt.Errorf("Close chunk: %w", err)
 		}
+
 		c.activeChunk = nil
 	}
+
 	return nil
 }
 
@@ -177,5 +192,6 @@ func finalChunkName(tmpName string) string {
 	if len(tmpName) > len(tmpChunkSuffix) && tmpName[len(tmpName)-len(tmpChunkSuffix):] == tmpChunkSuffix {
 		return tmpName[:len(tmpName)-len(tmpChunkSuffix)]
 	}
+
 	return tmpName
 }

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -401,6 +401,7 @@ func authStatusCode(err error) int {
 	if errors.As(err, &transportErr) {
 		return transportErr.StatusCode
 	}
+
 	return 0
 }
 
@@ -451,6 +452,7 @@ func serverStatusCode(err error) int {
 	if errors.As(err, &transportErr) {
 		return transportErr.StatusCode
 	}
+
 	return 0
 }
 
@@ -464,6 +466,7 @@ func dnsHostname(err error) string {
 	if errors.As(err, &dnsErr) {
 		return dnsErr.Name
 	}
+
 	return ""
 }
 
@@ -506,6 +509,7 @@ func networkAddr(err error) string {
 	if errors.As(err, &opErr) && opErr.Addr != nil {
 		return opErr.Addr.String()
 	}
+
 	return ""
 }
 

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -312,6 +312,7 @@ func ParseEnvironmentVariables() {
 			// TODO: Add logger
 			fmt.Println("Failed to parse timeout duration from environment variable D8_MIRROR_TIMEOUT: ", err)
 		}
+
 		if err == nil && timeout >= 0 {
 			MirrorTimeout = timeout
 		}

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -114,6 +114,7 @@ func pull(cmd *cobra.Command, _ []string) error {
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
+
 	ctx, cancel := signal.NotifyContext(parentCtx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -126,9 +127,11 @@ func pull(cmd *cobra.Command, _ []string) error {
 			puller.logger.WarnLn("Operation cancelled by user")
 			return nil
 		}
+
 		if diag := errdetect.Diagnose(err); diag != nil {
 			return diag
 		}
+
 		return fmt.Errorf("pull failed: %w", err)
 	}
 
@@ -140,6 +143,7 @@ func setupLogger() *log.SLogger {
 	if log.DebugLogLevel() >= 3 {
 		logLevel = slog.LevelDebug
 	}
+
 	return log.NewSLogger(logLevel)
 }
 
@@ -173,6 +177,7 @@ func buildPullParams(logger params.Logger) *params.PullParams {
 		DeckhouseTag:          pullflags.DeckhouseTag,
 		SinceVersion:          pullflags.SinceVersion,
 	}
+
 	return mirrorCtx
 }
 
@@ -312,6 +317,7 @@ func (p *Puller) Execute(ctx context.Context) error {
 			p.logger.WarnLn("Operation cancelled by user")
 			return nil
 		}
+
 		return fmt.Errorf("pull from registry: %w", err)
 	}
 
@@ -334,6 +340,7 @@ func (p *Puller) cleanupWorkingDirectory() error {
 			return fmt.Errorf("Cleanup last unfinished pull data: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -349,6 +356,7 @@ func (p *Puller) validatePlatformAccess() error {
 	targetTags = append(targetTags, internal.StableChannel, internal.LTSChannel)
 
 	var accessErr error
+
 	for _, targetTag := range targetTags {
 		imageRef := p.params.DeckhouseRegistryRepo + ":" + targetTag
 
@@ -371,12 +379,14 @@ func (p *Puller) validatePlatformAccess() error {
 // validateModulesAccess validates access to the modules registry
 func (p *Puller) validateModulesAccess() error {
 	modulesRepo := path.Join(p.params.DeckhouseRegistryRepo, p.params.ModulesPathSuffix)
+
 	ctx, cancel := context.WithTimeout(p.cmd.Context(), 15*time.Second)
 	defer cancel()
 
 	if err := p.accessValidator.ValidateListAccessForRepo(ctx, modulesRepo, p.validationOpts...); err != nil {
 		return fmt.Errorf("Source registry is not accessible: %w", err)
 	}
+
 	return nil
 }
 
@@ -390,6 +400,7 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Prepare module filter: %w", err)
 		}
+
 		return filter, nil
 	}
 
@@ -397,6 +408,7 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Prepare module filter: %w", err)
 	}
+
 	return filter, nil
 }
 
@@ -418,6 +430,7 @@ func (p *Puller) computeGOSTDigests() error {
 		})
 
 		merr := &multierror.Error{}
+
 		parallel.ForEach(bundlePackages, func(bundlePackage os.DirEntry, _ int) {
 			file, err := os.Open(filepath.Join(p.params.BundleDir, bundlePackage.Name()))
 			if err != nil {
@@ -437,6 +450,7 @@ func (p *Puller) computeGOSTDigests() error {
 				merr = multierror.Append(merr, fmt.Errorf("Could not write digest to .gostsum file: %w", err))
 			}
 		})
+
 		return merr.ErrorOrNil()
 	})
 }
@@ -451,6 +465,7 @@ func (p *Puller) finalCleanup() error {
 
 	pullDirExists := false
 	otherEntries := 0
+
 	for _, entry := range entries {
 		if entry.Name() == mirror.TmpMirrorFolderName && entry.IsDir() {
 			pullDirExists = true

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -37,18 +37,23 @@ func parseAndValidateParameters(_ *cobra.Command, args []string) error {
 	if err = validateSourceRegistry(); err != nil {
 		return err
 	}
+
 	if err = parseAndValidateVersionFlags(); err != nil {
 		return err
 	}
+
 	if err = validateProxyRegistryFlag(); err != nil {
 		return err
 	}
+
 	if err = validateImagesBundlePathArg(args); err != nil {
 		return err
 	}
+
 	if err = validateTmpPath(args); err != nil {
 		return err
 	}
+
 	if err = validateChunkSizeFlag(); err != nil {
 		return err
 	}
@@ -71,9 +76,11 @@ func validateSourceRegistry() error {
 	if err != nil {
 		return fmt.Errorf("Validate source registry parameter: %w", err)
 	}
+
 	if registryURL.Host == "" {
 		return errors.New("--source you provided contains no registry host. Please specify source registry host address correctly")
 	}
+
 	if registryURL.Path == "" {
 		return errors.New("--source you provided contains no registry path. Please specify source registry repo path correctly")
 	}
@@ -87,12 +94,14 @@ func validateImagesBundlePathArg(args []string) error {
 	}
 
 	pullflags.ImagesBundlePath = filepath.Clean(args[0])
+
 	pathInfo, err := os.Stat(pullflags.ImagesBundlePath)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		if err = os.MkdirAll(pullflags.ImagesBundlePath, 0755); err != nil {
 			return fmt.Errorf("Create bundle directory at %s: %w", pullflags.ImagesBundlePath, err)
 		}
+
 		return validateImagesBundlePathArg(args)
 	case err != nil:
 		return err
@@ -122,9 +131,11 @@ func parseAndValidateVersionFlags() error {
 	if pullflags.SinceVersionString != "" && pullflags.DeckhouseTag != "" {
 		return errors.New("Using both --deckhouse-tag and --since-version at the same time is ambiguous")
 	}
+
 	if pullflags.PlatformConstraintString != "" && pullflags.DeckhouseTag != "" {
 		return errors.New("Using both --deckhouse-tag and --include-platform at the same time is ambiguous")
 	}
+
 	if pullflags.PlatformConstraintString != "" && pullflags.SinceVersionString != "" {
 		return errors.New("Using both --since-version and --include-platform at the same time is ambiguous: --include-platform already expresses a lower bound (e.g. \">=1.64\")")
 	}
@@ -171,6 +182,7 @@ func validateProxyRegistryFlag() error {
 	if pullflags.DeckhouseTag != "" {
 		return errors.New("--proxy-registry cannot be combined with --deckhouse-tag: pulling a single tag does not need a list-based discovery and uses the direct check-tag-exists path already")
 	}
+
 	if pullflags.SinceVersionString != "" {
 		return errors.New("--proxy-registry cannot be combined with --since-version: --since-version has no upper bound, so the probe cannot terminate. Use --include-platform with an explicit lower bound (and optional upper bound) instead")
 	}
@@ -188,6 +200,7 @@ func validateProxyRegistryFlag() error {
 	if needPlatform && pullflags.PlatformConstraintString == "" {
 		return errors.New("--proxy-registry requires --include-platform (or --no-platform to skip platform mirroring): the probe needs an explicit lower bound to start incrementing from")
 	}
+
 	if needModules {
 		if len(pullflags.ModulesWhitelist) == 0 {
 			return errors.New("--proxy-registry requires --include-module (or --no-modules to skip module mirroring): the probe needs explicit module names and version anchors to start incrementing from")
@@ -220,8 +233,10 @@ func validateTmpPath(_ []string) error {
 	if pullflags.TempDir == "" {
 		pullflags.TempDir = filepath.Join(pullflags.ImagesBundlePath, ".tmp")
 	}
+
 	if err := os.MkdirAll(pullflags.TempDir, 0755); err != nil {
 		return fmt.Errorf("Error creating temp directory at %s: %w", pullflags.TempDir, err)
 	}
+
 	return nil
 }

--- a/internal/mirror/cmd/push/errdetect/diagnose.go
+++ b/internal/mirror/cmd/push/errdetect/diagnose.go
@@ -394,6 +394,7 @@ func authStatusCode(err error) int {
 	if errors.As(err, &transportErr) {
 		return transportErr.StatusCode
 	}
+
 	return 0
 }
 
@@ -444,6 +445,7 @@ func serverStatusCode(err error) int {
 	if errors.As(err, &transportErr) {
 		return transportErr.StatusCode
 	}
+
 	return 0
 }
 
@@ -457,6 +459,7 @@ func dnsHostname(err error) string {
 	if errors.As(err, &dnsErr) {
 		return dnsErr.Name
 	}
+
 	return ""
 }
 
@@ -499,6 +502,7 @@ func networkAddr(err error) string {
 	if errors.As(err, &opErr) && opErr.Addr != nil {
 		return opErr.Addr.String()
 	}
+
 	return ""
 }
 

--- a/internal/mirror/cmd/push/flags.go
+++ b/internal/mirror/cmd/push/flags.go
@@ -72,6 +72,7 @@ func ParseEnvironmentVariables() {
 			// TODO: Add logger
 			fmt.Println("Failed to parse timeout duration from environment variable D8_MIRROR_TIMEOUT: ", err)
 		}
+
 		if err == nil && timeout >= 0 {
 			MirrorTimeout = timeout
 		}

--- a/internal/mirror/cmd/push/push.go
+++ b/internal/mirror/cmd/push/push.go
@@ -106,6 +106,7 @@ func NewCommand() *cobra.Command {
 
 	addFlags(pushCmd.Flags())
 	ParseEnvironmentVariables()
+
 	return pushCmd
 }
 
@@ -114,6 +115,7 @@ func setupLogger() *log.SLogger {
 	if log.DebugLogLevel() >= 3 {
 		logLevel = slog.LevelDebug
 	}
+
 	return log.NewSLogger(logLevel)
 }
 
@@ -135,6 +137,7 @@ func buildPushParams(logger params.Logger) *params.PushParams {
 			Images: 1,
 		},
 	}
+
 	return pushParams
 }
 
@@ -146,6 +149,7 @@ func validateRegistryAccess(ctx context.Context, pushParams *params.PushParams) 
 	}
 
 	accessValidator := validation.NewRemoteRegistryAccessValidator()
+
 	err := accessValidator.ValidateWriteAccessForRepo(ctx, path.Join(pushParams.RegistryHost, pushParams.RegistryPath), opts...)
 	if err != nil {
 		return fmt.Errorf("validate write access to registry %s: %w", path.Join(pushParams.RegistryHost, pushParams.RegistryPath), err)
@@ -164,6 +168,7 @@ type Pusher struct {
 func NewPusher() *Pusher {
 	logger := setupLogger()
 	pushParams := buildPushParams(logger)
+
 	return &Pusher{
 		logger:     logger,
 		pushParams: pushParams,
@@ -182,6 +187,7 @@ func (p *Pusher) Execute() error {
 		if diag := errdetect.Diagnose(err); diag != nil {
 			return diag
 		}
+
 		return err
 	}
 
@@ -189,6 +195,7 @@ func (p *Pusher) Execute() error {
 		if diag := errdetect.Diagnose(err); diag != nil {
 			return diag
 		}
+
 		return err
 	}
 
@@ -245,6 +252,7 @@ func (p *Pusher) executeNewPush() error {
 			p.logger.WarnLn("Operation cancelled by user")
 			return nil
 		}
+
 		return fmt.Errorf("push to registry: %w", err)
 	}
 

--- a/internal/mirror/cmd/push/validation.go
+++ b/internal/mirror/cmd/push/validation.go
@@ -40,9 +40,11 @@ func parseAndValidateParameters(_ *cobra.Command, args []string) error {
 	if err = parseAndValidateRegistryURLArg(args); err != nil {
 		return err
 	}
+
 	if err = validateRegistryCredentials(); err != nil {
 		return err
 	}
+
 	if err = validateImagesBundlePathArg(args); err != nil {
 		return err
 	}
@@ -52,6 +54,7 @@ func parseAndValidateParameters(_ *cobra.Command, args []string) error {
 
 func validateImagesBundlePathArg(args []string) error {
 	ImagesBundlePath = filepath.Clean(args[0])
+
 	s, err := os.Stat(ImagesBundlePath)
 	if err != nil {
 		return fmt.Errorf("could not read images bundle: %w", err)
@@ -62,6 +65,7 @@ func validateImagesBundlePathArg(args []string) error {
 		if err != nil {
 			return fmt.Errorf("could not list files in bundle directory: %w", err)
 		}
+
 		dirEntries = lo.Filter(dirEntries, func(item os.DirEntry, _ int) bool {
 			ext := filepath.Ext(item.Name())
 			return ext == ".tar" || ext == ".chunk"
@@ -81,6 +85,7 @@ func validateImagesBundlePathArg(args []string) error {
 		if TempDir == "" {
 			TempDir = filepath.Join(filepath.Dir(ImagesBundlePath), ".tmp", mirror.TmpMirrorFolderName)
 		}
+
 		return nil
 	}
 
@@ -91,6 +96,7 @@ func validateRegistryCredentials() error {
 	if RegistryPassword != "" && RegistryUsername == "" {
 		return errors.New("registry username not specified")
 	}
+
 	return nil
 }
 
@@ -110,11 +116,14 @@ func parseAndValidateRegistryURLArg(args []string) error {
 	if err != nil {
 		return fmt.Errorf("Validate registry address: %w", err)
 	}
+
 	RegistryHost = registryURL.Host
 	RegistryPath = registryURL.Path
+
 	if RegistryHost == "" {
 		return errors.New("<registry> you provided contains no registry host. Please specify registry address correctly")
 	}
+
 	if len(RegistryPath) < 2 || len(RegistryPath) > 255 {
 		return errors.New("repository part must be between 2 and 255 characters in length. Please specify registry repo path correctly")
 	}

--- a/internal/mirror/errmatch/errmatch.go
+++ b/internal/mirror/errmatch/errmatch.go
@@ -40,6 +40,7 @@ func IsImageNotFound(err error) bool {
 	// String fallback: HEAD responses have no body per HTTP spec, so transport.Error.Errors
 	// is empty. Also covers registries that return plain text instead of structured JSON.
 	errMsg := err.Error()
+
 	return strings.Contains(errMsg, "MANIFEST_UNKNOWN") || strings.Contains(errMsg, "404 Not Found")
 }
 

--- a/internal/mirror/installer/installer.go
+++ b/internal/mirror/installer/installer.go
@@ -118,9 +118,11 @@ func (svc *Service) PullInstaller(ctx context.Context) error {
 
 	if svc.options.DryRun {
 		svc.userLogger.InfoLn("[dry-run] Installer images that would be pulled:")
+
 		for ref := range svc.downloadList.Installer {
 			svc.userLogger.InfoLn("  " + ref)
 		}
+
 		return nil
 	}
 

--- a/internal/mirror/installer/layout.go
+++ b/internal/mirror/installer/layout.go
@@ -57,6 +57,7 @@ type ImageLayouts struct {
 
 func NewImageLayouts(rootFolder string) (*ImageLayouts, error) {
 	layoutPath := filepath.Join(rootFolder, "installer")
+
 	image, err := regimage.NewImageLayout(layoutPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create image layout: %w", err)

--- a/internal/mirror/modules/constraints.go
+++ b/internal/mirror/modules/constraints.go
@@ -142,6 +142,7 @@ func extractLowerBound(constraintStr string) (*semver.Version, error) {
 	}
 
 	var lowest *semver.Version
+
 	for _, raw := range matches {
 		v, err := semver.NewVersion(raw)
 		if err != nil {
@@ -150,6 +151,7 @@ func extractLowerBound(constraintStr string) (*semver.Version, error) {
 			// instead of silently dropping the literal.
 			return nil, fmt.Errorf("version literal %q not parseable: %w", raw, err)
 		}
+
 		if lowest == nil || v.LessThan(lowest) {
 			lowest = v
 		}
@@ -158,6 +160,7 @@ func extractLowerBound(constraintStr string) (*semver.Version, error) {
 	if lowest == nil {
 		return nil, fmt.Errorf("no parseable version literal in constraint")
 	}
+
 	return lowest, nil
 }
 
@@ -171,15 +174,18 @@ func extractInclusiveAnchors(constraintStr string) ([]*semver.Version, error) {
 	}
 
 	seen := make(map[string]struct{}, len(matches))
+
 	out := make([]*semver.Version, 0, len(matches))
 	for _, m := range matches {
 		if len(m) < 2 {
 			continue
 		}
+
 		raw := m[1]
 		if _, dup := seen[raw]; dup {
 			continue
 		}
+
 		seen[raw] = struct{}{}
 
 		v, err := semver.NewVersion(raw)
@@ -190,8 +196,10 @@ func extractInclusiveAnchors(constraintStr string) ([]*semver.Version, error) {
 			// version parser hadn't). Surface it as a real error.
 			return nil, fmt.Errorf("anchor %q not a valid semver: %w", raw, err)
 		}
+
 		out = append(out, v)
 	}
+
 	return out, nil
 }
 

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -59,16 +59,20 @@ func NewFilter(filterExpressions []string, filterType FilterType) (*Filter, erro
 
 	for _, filterExpr := range filterExpressions {
 		moduleName, versionStr, hasVersion := strings.Cut(strings.TrimSpace(filterExpr), "@")
+
 		moduleName = strings.TrimSpace(moduleName)
 		if moduleName == "" {
 			return nil, fmt.Errorf("Malformed filter expression %q: empty module name", filterExpr)
 		}
+
 		if _, moduleRedeclared := filter.modules[moduleName]; moduleRedeclared {
 			return nil, fmt.Errorf("Malformed filter expression: module %s is declared multiple times", moduleName)
 		}
+
 		if !hasVersion {
 			constraint, _ := NewSemanticVersionConstraint(">=0.0.0")
 			filter.modules[moduleName] = constraint
+
 			continue
 		}
 
@@ -124,7 +128,9 @@ func (f *Filter) ModuleNames() []string {
 	for name := range f.modules {
 		names = append(names, name)
 	}
+
 	sort.Strings(names)
+
 	return names
 }
 
@@ -150,6 +156,7 @@ func parseVersionConstraint(v string) (VersionConstraint, error) {
 	if v == "" {
 		return nil, fmt.Errorf("empty constraint")
 	}
+
 	switch v[0] {
 	// has user defined constraint (nothing to do)
 	case '=', '>', '<', '~', '^':
@@ -172,11 +179,13 @@ func parseExact(body string) (VersionConstraint, error) {
 	if tag == "" {
 		return nil, fmt.Errorf("empty tag in %q", body)
 	}
+
 	if ch != "" {
 		if internal.ChannelIsValid(ch) {
 			return NewExactTagConstraintWithChannel(tag, ch), nil
 		}
 	}
+
 	return NewExactTagConstraint(tag), nil
 }
 
@@ -186,6 +195,7 @@ func parseSemver(v string) (VersionConstraint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid semver %q: %w", v, err)
 	}
+
 	return c, nil
 }
 
@@ -194,6 +204,7 @@ func (f *Filter) ShouldMirrorReleaseChannels(moduleName string) bool {
 	if hasConstraint && constraint.IsExact() {
 		return false
 	}
+
 	return true
 }
 
@@ -231,6 +242,7 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 		if !isExactTag {
 			return nil
 		}
+
 		return []string{exact.Tag()}
 	}
 
@@ -240,6 +252,7 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 	}
 
 	matched := make([]*semver.Version, 0)
+
 	for _, v := range mod.Versions() {
 		if semverConstraint.Match(v) {
 			matched = append(matched, v)
@@ -253,6 +266,7 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 	for _, v := range selected {
 		tags = append(tags, "v"+v.String())
 	}
+
 	return tags
 }
 
@@ -278,6 +292,7 @@ func restoreInclusiveAnchors(selected, available []*semver.Version, anchors []*s
 		if v == nil {
 			continue
 		}
+
 		availableByKey[v.String()] = v
 	}
 
@@ -291,13 +306,16 @@ func restoreInclusiveAnchors(selected, available []*semver.Version, anchors []*s
 		if _, already := selectedKeys[key]; already {
 			continue
 		}
+
 		registryVersion, isAvailable := availableByKey[key]
 		if !isAvailable {
 			continue
 		}
+
 		selected = append(selected, registryVersion)
 		selectedKeys[key] = struct{}{}
 	}
+
 	return selected
 }
 
@@ -316,7 +334,9 @@ func filterOnlyLatestPatches(versions []*semver.Version) []*semver.Version {
 		if v == nil {
 			continue
 		}
+
 		key := majorMinor{major: v.Major(), minor: v.Minor()}
+
 		current, ok := latest[key]
 		if !ok || v.GreaterThan(current) {
 			latest[key] = v
@@ -327,5 +347,6 @@ func filterOnlyLatestPatches(versions []*semver.Version) []*semver.Version {
 	for _, v := range latest {
 		result = append(result, v)
 	}
+
 	return result
 }

--- a/internal/mirror/modules/layout.go
+++ b/internal/mirror/modules/layout.go
@@ -105,11 +105,13 @@ func (l *ModulesImageLayouts) Module(moduleName string) *ImageLayouts {
 // AsList returns a list of layout.Path's from all modules. Undefined path's are not included in the list.
 func (l *ModulesImageLayouts) AsList() []layout.Path {
 	var paths []layout.Path
+
 	for _, imgLayout := range l.list {
 		if imgLayout != nil {
 			paths = append(paths, imgLayout.AsList()...)
 		}
 	}
+
 	return paths
 }
 
@@ -165,12 +167,14 @@ func (l *ImageLayouts) GetOrCreateExtraLayout(extraName string) (*regimage.Image
 
 	// Create layout at modules/<module-name>/extra/<extra-name>/
 	layoutPath := filepath.Join(l.workingDir, "extra", extraName)
+
 	layout, err := regimage.NewImageLayout(layoutPath)
 	if err != nil {
 		return nil, fmt.Errorf("create extra image layout for %s: %w", extraName, err)
 	}
 
 	l.ExtraImages[extraName] = layout
+
 	return layout, nil
 }
 
@@ -180,6 +184,7 @@ func (l *ImageLayouts) AsList() []layout.Path {
 	if l.Modules != nil {
 		paths = append(paths, l.Modules.Path())
 	}
+
 	if l.ModulesReleaseChannels != nil {
 		paths = append(paths, l.ModulesReleaseChannels.Path())
 	}
@@ -189,6 +194,7 @@ func (l *ImageLayouts) AsList() []layout.Path {
 			paths = append(paths, extraLayout.Path())
 		}
 	}
+
 	return paths
 }
 
@@ -201,13 +207,16 @@ func (l *ImageLayouts) HasImages() bool {
 		if err != nil {
 			continue
 		}
+
 		manifest, err := index.IndexManifest()
 		if err != nil {
 			continue
 		}
+
 		if len(manifest.Manifests) > 0 {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/mirror/modules/modules.go
+++ b/internal/mirror/modules/modules.go
@@ -50,12 +50,14 @@ type Module struct {
 
 func (m *Module) Versions() []*semver.Version {
 	versions := make([]*semver.Version, 0)
+
 	for _, release := range m.Releases {
 		v, err := semver.NewVersion(release)
 		if err == nil {
 			versions = append(versions, v)
 		}
 	}
+
 	return versions
 }
 
@@ -226,6 +228,7 @@ func (svc *Service) pullModules(ctx context.Context) error {
 
 	// Filter-out modules that are not allowed by the filter (blacklist or whitelist)
 	filteredModules := make([]moduleData, 0)
+
 	for _, moduleName := range moduleNames {
 		mod := &Module{
 			Name:         moduleName,
@@ -254,6 +257,7 @@ func (svc *Service) pullModules(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create OCI image layouts for modules: %w", err)
 	}
+
 	svc.layout = moduleImagesLayout
 
 	processName := "Pull Modules"
@@ -266,11 +270,14 @@ func (svc *Service) pullModules(ctx context.Context) error {
 	// successfully downloaded so far, rather than throw it all away and leave
 	// the user with nothing for a multi-hour pull.
 	pullCancelled := false
+
 	err = logger.Process(processName, func() error {
 		for i, module := range filteredModules {
 			if err := ctx.Err(); err != nil {
 				logger.Warnf("Pull cancelled; %d/%d modules attempted, will pack already-downloaded modules", i, len(filteredModules))
+
 				pullCancelled = true
+
 				return nil
 			}
 
@@ -279,12 +286,16 @@ func (svc *Service) pullModules(ctx context.Context) error {
 			if err := svc.pullSingleModule(ctx, module); err != nil {
 				if isContextErr(err) {
 					logger.Warnf("Pull of module %s cancelled, will pack already-downloaded modules", module.name)
+
 					pullCancelled = true
+
 					return nil
 				}
+
 				return fmt.Errorf("pull module %s: %w", module.name, err)
 			}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -313,6 +324,7 @@ func (svc *Service) pullModules(ctx context.Context) error {
 				return fmt.Errorf("sorting index manifests of %s: %w", l, err)
 			}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -367,6 +379,7 @@ func (svc *Service) pullSingleModule(ctx context.Context, module moduleData) err
 		if err := svc.pullModuleImages(ctx, module.name, moduleVersions, downloadList); err != nil {
 			return err
 		}
+
 		svc.pullReleaseVersionImages(ctx, module.name, moduleVersions, downloadList)
 		svc.pullInternalDigestImages(ctx, module.name, moduleVersions, downloadList)
 	}
@@ -441,6 +454,7 @@ func (svc *Service) discoverModuleNames(ctx context.Context) ([]string, error) {
 			// degrade into a no-op pull.
 			return nil, fmt.Errorf("--proxy-registry requires a whitelist of modules (--include-module)")
 		}
+
 		return svc.options.Filter.ModuleNames(), nil
 	}
 
@@ -448,6 +462,7 @@ func (svc *Service) discoverModuleNames(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list modules: %w", err)
 	}
+
 	return moduleNames, nil
 }
 
@@ -480,6 +495,7 @@ func (svc *Service) listTagsIfConstrained(ctx context.Context, moduleName string
 	case err != nil:
 		return nil, fmt.Errorf("list tags for module %s: %w", moduleName, err)
 	}
+
 	return tags, nil
 }
 
@@ -503,13 +519,16 @@ func (svc *Service) probeModuleTags(ctx context.Context, moduleName string, cons
 
 	check := func(ctx context.Context, v *semver.Version) (bool, error) {
 		tag := "v" + v.String()
+
 		err := svc.modulesService.Module(moduleName).CheckImageExists(ctx, tag)
 		if err == nil {
 			return true, nil
 		}
+
 		if errors.Is(err, client.ErrImageNotFound) {
 			return false, nil
 		}
+
 		return false, fmt.Errorf("check module %s tag %q: %w", moduleName, tag, err)
 	}
 
@@ -522,6 +541,7 @@ func (svc *Service) probeModuleTags(ctx context.Context, moduleName string, cons
 	for _, v := range versions {
 		tags = append(tags, "v"+v.String())
 	}
+
 	return tags, nil
 }
 
@@ -543,12 +563,15 @@ func (svc *Service) mergeAndDedupeVersions(moduleName, registryPath string, chan
 // printDryRunPlan prints the set of refs that would be pulled, without downloading.
 func (svc *Service) printDryRunPlan(moduleName string, downloadList *ImageDownloadList, versions []string) {
 	svc.userLogger.InfoLn("[dry-run] Module '" + moduleName + "' images that would be pulled:")
+
 	for ref := range downloadList.ModuleReleaseChannels {
 		svc.userLogger.InfoLn("  " + ref)
 	}
+
 	for _, version := range versions {
 		svc.userLogger.InfoLn("  " + svc.rootURL + "/modules/" + moduleName + ":" + version)
 	}
+
 	if len(versions) > 0 {
 		svc.userLogger.InfoLn("  (extra images discovery requires a real pull)")
 	}
@@ -577,6 +600,7 @@ func (svc *Service) pullModuleImages(ctx context.Context, moduleName string, ver
 	if err := svc.pullerService.PullImages(ctx, config); err != nil {
 		return fmt.Errorf("pull module images: %w", err)
 	}
+
 	return nil
 }
 
@@ -668,6 +692,7 @@ func (svc *Service) pullExtraImages(ctx context.Context, moduleName string, vers
 			return fmt.Errorf("pull extra image %s: %w", extraName, err)
 		}
 	}
+
 	return nil
 }
 
@@ -678,18 +703,21 @@ func (svc *Service) pullVexImages(ctx context.Context, moduleName string, downlo
 	for img := range downloadList.Module {
 		allImages = append(allImages, img)
 	}
+
 	for img := range downloadList.ModuleExtra {
 		allImages = append(allImages, img)
 	}
 
 	// Find VEX images and add to a separate set for pulling
 	vexImageSet := make(map[string]*puller.ImageMeta)
+
 	for _, img := range allImages {
 		vexImageName, err := svc.findVexImage(ctx, moduleName, img)
 		if err != nil {
 			svc.logger.Debug(fmt.Sprintf("Failed to find VEX image for %s: %v", img, err))
 			continue
 		}
+
 		if vexImageName != "" {
 			svc.logger.Debug(fmt.Sprintf("Found VEX image: %s", vexImageName))
 			vexImageSet[vexImageName] = nil
@@ -724,12 +752,14 @@ func (svc *Service) findVexImage(ctx context.Context, moduleName string, imageRe
 	if splitIndex == -1 {
 		return "", nil
 	}
+
 	tag := vexImageName[splitIndex+1:]
 
 	err := svc.modulesService.Module(moduleName).CheckImageExists(ctx, tag)
 	if errors.Is(err, client.ErrImageNotFound) {
 		return "", nil
 	}
+
 	if err != nil {
 		return "", err
 	}
@@ -761,12 +791,14 @@ func (svc *Service) extractVersionsFromReleaseChannels(ctx context.Context, modu
 			svc.logger.Debug(fmt.Sprintf("Failed to extract version.json for %s/%s: %v", moduleName, channel, err))
 			continue
 		}
+
 		if versionJSON.Version != "" {
 			version := versionJSON.Version
 			// Ensure version has "v" prefix (some may already have it)
 			if !strings.HasPrefix(version, "v") {
 				version = "v" + version
 			}
+
 			versions = append(versions, version)
 		}
 	}
@@ -789,6 +821,7 @@ func extractVersionJSON(img interface{ Extract() io.ReadCloser }) (*versionJSON,
 		if err == io.EOF {
 			return nil, fmt.Errorf("version.json not found in image")
 		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -798,6 +831,7 @@ func extractVersionJSON(img interface{ Extract() io.ReadCloser }) (*versionJSON,
 			if err := json.NewDecoder(tr).Decode(&version); err != nil {
 				return nil, fmt.Errorf("parse version.json: %w", err)
 			}
+
 			return &version, nil
 		}
 	}
@@ -846,6 +880,7 @@ func (svc *Service) findExtraImages(ctx context.Context, moduleName string, vers
 
 		for imageName, tagValue := range extraImagesJSON {
 			var imageTag string
+
 			switch v := tagValue.(type) {
 			case float64:
 				imageTag = fmt.Sprintf("%.0f", v)
@@ -882,6 +917,7 @@ func extractExtraImagesJSON(img interface{ Extract() io.ReadCloser }) (map[strin
 		if err == io.EOF {
 			return nil, fmt.Errorf("extra_images.json not found in image")
 		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -891,6 +927,7 @@ func extractExtraImagesJSON(img interface{ Extract() io.ReadCloser }) (map[strin
 			if err := json.NewDecoder(tr).Decode(&extraImages); err != nil {
 				return nil, fmt.Errorf("parse extra_images.json: %w", err)
 			}
+
 			return extraImages, nil
 		}
 	}
@@ -902,6 +939,7 @@ func extractExtraImagesJSON(img interface{ Extract() io.ReadCloser }) (map[strin
 // and stored with tag = hex part of digest.
 func (svc *Service) extractInternalDigestImages(ctx context.Context, moduleName string, versions []string) []string {
 	seenDigests := make(map[string]struct{})
+
 	var digestRefs []string
 
 	moduleRepo := svc.rootURL + "/modules/" + moduleName
@@ -937,6 +975,7 @@ func (svc *Service) extractInternalDigestImages(ctx context.Context, moduleName 
 			if _, seen := seenDigests[digest]; seen {
 				continue
 			}
+
 			seenDigests[digest] = struct{}{}
 
 			// Create reference in format repo@sha256:...
@@ -964,6 +1003,7 @@ func extractImagesDigestsJSON(img interface{ Extract() io.ReadCloser }) ([]strin
 		if err == io.EOF {
 			return nil, fmt.Errorf("images_digests.json not found in image")
 		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -975,6 +1015,7 @@ func extractImagesDigestsJSON(img interface{ Extract() io.ReadCloser }) ([]strin
 			}
 			// Extract all sha256:... digests from JSON file
 			digests := digestRegex.FindAllString(string(data), -1)
+
 			return digests, nil
 		}
 	}
@@ -1002,6 +1043,7 @@ func (svc *Service) applyChannelAliases(moduleName string) error {
 		if errors.Is(err, layouts.ErrImageNotFound) {
 			return nil
 		}
+
 		return err
 	}
 
@@ -1069,11 +1111,13 @@ func getModuleNames(modules []moduleData) []string {
 	for i, m := range modules {
 		names[i] = m.name
 	}
+
 	return names
 }
 
 func deduplicateStrings(items []string) []string {
 	seen := make(map[string]struct{})
+
 	result := make([]string, 0, len(items))
 	for _, item := range items {
 		if _, ok := seen[item]; !ok {
@@ -1081,6 +1125,7 @@ func deduplicateStrings(items []string) []string {
 			result = append(result, item)
 		}
 	}
+
 	return result
 }
 
@@ -1097,6 +1142,7 @@ func createOCIImageLayoutsForModules(
 		if err != nil {
 			return nil, fmt.Errorf("create OCI image layouts for module %s: %w", moduleName, err)
 		}
+
 		layouts.list[moduleName] = moduleLayouts
 	}
 

--- a/internal/mirror/modules/probe.go
+++ b/internal/mirror/modules/probe.go
@@ -77,6 +77,7 @@ func ProbeAvailableVersions(
 	if constraint == nil {
 		return nil, errors.New("probe requires a non-nil constraint")
 	}
+
 	if check == nil {
 		return nil, errors.New("probe requires a non-nil checker")
 	}
@@ -107,12 +108,14 @@ func ProbeAvailableVersions(
 		if err != nil {
 			return false, err
 		}
+
 		if !exists {
 			return false, nil
 		}
 
 		found = append(found, v)
 		patch++
+
 		return true, nil
 	}
 
@@ -123,6 +126,7 @@ func ProbeAvailableVersions(
 			if err != nil {
 				return nil, err
 			}
+
 			if !advanced {
 				break
 			}
@@ -133,10 +137,12 @@ func ProbeAvailableVersions(
 		// patch right after it.
 		minor++
 		patch = 0
+
 		advanced, err := probeOne()
 		if err != nil {
 			return nil, err
 		}
+
 		if advanced {
 			continue
 		}
@@ -145,10 +151,12 @@ func ProbeAvailableVersions(
 		major++
 		minor = 0
 		patch = 0
+
 		advanced, err = probeOne()
 		if err != nil {
 			return nil, err
 		}
+
 		if advanced {
 			continue
 		}

--- a/internal/mirror/pack/pack.go
+++ b/internal/mirror/pack/pack.go
@@ -50,6 +50,7 @@ func Bundle(
 	if bundleChunkSize > 0 {
 		return bundleChunked(ctx, bundleDir, pkgName, bundleChunkSize, pack)
 	}
+
 	return bundleSingle(ctx, bundleDir, pkgName, pack)
 }
 
@@ -65,6 +66,7 @@ func bundleChunked(
 		cw.Cleanup()
 		return fmt.Errorf("pack %s: %w", pkgName, err)
 	}
+
 	if err := cw.Close(); err != nil {
 		cw.Cleanup()
 		return fmt.Errorf("close %s: %w", pkgName, err)
@@ -75,9 +77,11 @@ func bundleChunked(
 		cw.Cleanup()
 		return cerr
 	}
+
 	if err := cw.Finalize(); err != nil {
 		return fmt.Errorf("finalize %s: %w", pkgName, err)
 	}
+
 	return nil
 }
 
@@ -100,19 +104,24 @@ func bundleSingle(
 	if err = pack(f); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmpPath)
+
 		return fmt.Errorf("pack %s: %w", pkgName, err)
 	}
+
 	if err = f.Close(); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close %s: %w", pkgName, err)
 	}
+
 	if cerr := ctx.Err(); cerr != nil {
 		_ = os.Remove(tmpPath)
 		return cerr
 	}
+
 	if err = os.Rename(tmpPath, finalPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename %s: %w", pkgName, err)
 	}
+
 	return nil
 }

--- a/internal/mirror/platform/deckhouse_releases.go
+++ b/internal/mirror/platform/deckhouse_releases.go
@@ -39,6 +39,7 @@ func (svc *Service) writeDeckhouseReleaseManifests(
 	releaseChannelsImagesLayout *image.ImageLayout,
 ) error {
 	manifests := &bytes.Buffer{}
+
 	for _, version := range versionTagsToMirror {
 		versionReleaseImage, err := releaseChannelsImagesLayout.GetImage(version)
 		if err != nil {
@@ -62,6 +63,7 @@ func (svc *Service) writeDeckhouseReleaseManifests(
 	if err := os.MkdirAll(filepath.Dir(pathToManifestYAML), 0o775); err != nil {
 		return fmt.Errorf("Create DeckhouseReleases manifest file: %w", err)
 	}
+
 	manifestFile, err := os.Create(pathToManifestYAML)
 	if err != nil {
 		return fmt.Errorf("Create DeckhouseReleases manifest file: %w", err)
@@ -74,6 +76,7 @@ func (svc *Service) writeDeckhouseReleaseManifests(
 	if err = manifestFile.Sync(); err != nil {
 		return fmt.Errorf("Write DeckhouseReleases manifest file: %w", err)
 	}
+
 	if err = manifestFile.Close(); err != nil {
 		return fmt.Errorf("Write DeckhouseReleases manifest file: %w", err)
 	}
@@ -83,12 +86,14 @@ func (svc *Service) writeDeckhouseReleaseManifests(
 
 func generateDeckhouseRelease(versionTag string, releaseInfo *releaseInfo) ([]byte, error) {
 	const githubReleaseChangelogLinkBase = "https://github.com/deckhouse/deckhouse/releases/tag"
+
 	version, err := semver.NewVersion(versionTag)
 	if err != nil {
 		return nil, fmt.Errorf("Parse version tag %q: %w", versionTag, err)
 	}
 
 	var disruptions []string
+
 	if len(releaseInfo.Disruptions) > 0 {
 		disruptionsVersion := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 		disruptions = releaseInfo.Disruptions[disruptionsVersion]
@@ -128,6 +133,7 @@ func extractReleaseInfoForDeckhouseRelease(versionReleaseImage v1.Image) (*relea
 	if err != nil {
 		return nil, fmt.Errorf("Extract changelog from release image: %w", err)
 	}
+
 	rawReleaseData, err := images.ExtractFileFromImage(versionReleaseImage, "version.json")
 	if err != nil {
 		return nil, fmt.Errorf("Extract release data from release image: %w", err)
@@ -139,6 +145,7 @@ func extractReleaseInfoForDeckhouseRelease(versionReleaseImage v1.Image) (*relea
 	if err = yaml.Unmarshal(rawReleaseData.Bytes(), release); err != nil {
 		return nil, fmt.Errorf("Extract release data from release image: %w", err)
 	}
+
 	if err = yaml.Unmarshal(rawChangelog.Bytes(), &release.Changelog); err != nil {
 		return nil, fmt.Errorf("Extract release data from release image: %w", err)
 	}

--- a/internal/mirror/platform/layout.go
+++ b/internal/mirror/platform/layout.go
@@ -130,6 +130,7 @@ func (l *ImageLayouts) AsList() []layout.Path {
 	layoutPathType := reflect.TypeOf(layout.Path(""))
 
 	paths := make([]layout.Path, 0)
+
 	for i := 0; i < layoutsValue.NumField(); i++ {
 		if layoutsValue.Field(i).Type() != layoutPathType {
 			continue

--- a/internal/mirror/platform/platform.go
+++ b/internal/mirror/platform/platform.go
@@ -128,8 +128,10 @@ func NewService(
 
 	// layout is nil in dry-run mode; pullDeckhousePlatformDryRun does not use it.
 	var layout *ImageLayouts
+
 	if !options.DryRun {
 		var err error
+
 		layout, err = createOCIImageLayoutsForPlatform(tmpDir)
 		if err != nil {
 			//TODO: handle error
@@ -343,6 +345,7 @@ func (svc *Service) versionsToMirror(ctx context.Context, tagsToMirror []string)
 	// When IncludeConstraint is active the channel set was already constrained above;
 	// keep the lower-bound filter so SinceVersion still works in combination.
 	minVersion := svc.determineMinimumVersion(channelVersions)
+
 	filteredChannels := make([]string, 0, len(matchedChannels))
 	for _, ch := range matchedChannels {
 		if minVersion != nil {
@@ -350,6 +353,7 @@ func (svc *Service) versionsToMirror(ctx context.Context, tagsToMirror []string)
 				continue
 			}
 		}
+
 		filteredChannels = append(filteredChannels, ch)
 	}
 
@@ -374,8 +378,10 @@ func (svc *Service) parseInputTags(tags []string) parsedTags {
 			if !internal.ChannelIsValid(tag) {
 				result.customTags = append(result.customTags, tag)
 			}
+
 			continue
 		}
+
 		result.semverVersions = append(result.semverVersions, version)
 	}
 
@@ -413,6 +419,7 @@ func (svc *Service) fetchReleaseChannelVersions(ctx context.Context) (channelVer
 		if hasLTS && errors.Is(err, client.ErrImageNotFound) {
 			continue
 		}
+
 		channelResults[channel] = releaseChannelVersionResult{ver: version, err: err}
 	}
 
@@ -460,6 +467,7 @@ func (svc *Service) matchChannelsToTags(requestedTags []string, channelVersions 
 			versions = append(versions, version)
 			matchedChannels[channel] = struct{}{}
 		}
+
 		return versions, mapKeysToSlice(matchedChannels)
 	}
 
@@ -469,6 +477,7 @@ func (svc *Service) matchChannelsToTags(requestedTags []string, channelVersions 
 			if svc.tagMatchesChannel(tag, channel, version) {
 				versions = append(versions, version)
 				matchedChannels[channel] = struct{}{}
+
 				break
 			}
 		}
@@ -515,8 +524,10 @@ func (svc *Service) expandVersionRange(ctx context.Context, channelVersions chan
 				if v == nil || v.LessThan(minVersion) {
 					continue
 				}
+
 				nb = append(nb, v)
 			}
+
 			filteredBase = nb
 		}
 
@@ -538,8 +549,10 @@ func (svc *Service) expandVersionRange(ctx context.Context, channelVersions chan
 			if v.LessThan(since) {
 				continue
 			}
+
 			nb = append(nb, v)
 		}
+
 		matched = nb
 	}
 
@@ -566,10 +579,12 @@ func (svc *Service) expandVersionRange(ctx context.Context, channelVersions chan
 func (svc *Service) discoverConstrainedPlatformVersions(ctx context.Context, semverConstraint *modules.SemanticVersionConstraint) ([]*semver.Version, error) {
 	if svc.options.ProxyRegistry {
 		svc.userLogger.Debugf("probing deckhouse releases for --include-platform via --proxy-registry")
+
 		matched, err := modules.ProbeAvailableVersions(ctx, semverConstraint, svc.releaseTagExists)
 		if err != nil {
 			return nil, fmt.Errorf("probe deckhouse releases: %w", err)
 		}
+
 		return matched, nil
 	}
 
@@ -590,13 +605,16 @@ func (svc *Service) discoverConstrainedPlatformVersions(ctx context.Context, sem
 // (network, auth, unexpected status) propagates out to fail the pull.
 func (svc *Service) releaseTagExists(ctx context.Context, v *semver.Version) (bool, error) {
 	tag := "v" + v.String()
+
 	err := svc.deckhouseService.ReleaseChannels().CheckImageExists(ctx, tag)
 	if err == nil {
 		return true, nil
 	}
+
 	if errors.Is(err, client.ErrImageNotFound) {
 		return false, nil
 	}
+
 	return false, fmt.Errorf("check release tag %q: %w", tag, err)
 }
 
@@ -612,10 +630,12 @@ func parseTagsMatchingConstraint(tags []string, constraint *modules.SemanticVers
 		if err != nil {
 			continue
 		}
+
 		if constraint.Match(v) {
 			matched = append(matched, v)
 		}
 	}
+
 	return matched
 }
 
@@ -628,10 +648,12 @@ func filterVersionsByConstraint(versions []*semver.Version, constraint *modules.
 		if v == nil {
 			continue
 		}
+
 		if constraint.Match(v) {
 			out = append(out, v)
 		}
 	}
+
 	return out
 }
 
@@ -648,10 +670,12 @@ func filterChannelsByConstraint(channels []string, channelVersions channelVersio
 			out = append(out, ch)
 			continue
 		}
+
 		if constraint.Match(v) {
 			out = append(out, ch)
 		}
 	}
+
 	return out
 }
 
@@ -670,6 +694,7 @@ func restoreInclusiveAnchors(selected, available []*semver.Version, anchors []*s
 		if v == nil {
 			continue
 		}
+
 		availableByKey[v.String()] = v
 	}
 
@@ -683,13 +708,16 @@ func restoreInclusiveAnchors(selected, available []*semver.Version, anchors []*s
 		if _, already := selectedKeys[key]; already {
 			continue
 		}
+
 		registryVersion, isAvailable := availableByKey[key]
 		if !isAvailable {
 			continue
 		}
+
 		selected = append(selected, registryVersion)
 		selectedKeys[key] = struct{}{}
 	}
+
 	return selected
 }
 
@@ -718,6 +746,7 @@ func mapKeysToSlice(m map[string]struct{}) []string {
 	for key := range m {
 		keys = append(keys, key)
 	}
+
 	return keys
 }
 
@@ -812,6 +841,7 @@ func (svc *Service) pullDeckhousePlatform(ctx context.Context, tagsToMirror []st
 	}
 
 	var prevDigests = make(map[string]struct{}, 0)
+
 	for _, tag := range uniqueImages {
 		svc.userLogger.Infof("Extracting images digests from Deckhouse installer %s", tag)
 
@@ -868,6 +898,7 @@ func (svc *Service) pullDeckhousePlatform(ctx context.Context, tagsToMirror []st
 				return fmt.Errorf("Sorting index manifests of %s: %w", l, err)
 			}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -976,6 +1007,7 @@ func (svc *Service) ExtractImageDigestsFromDeckhouseInstallerNew(
 	result := make(map[string]*puller.ImageMeta, len(images))
 
 	const scanPrintInterval = 20
+
 	counter := 0
 
 	if svc.options.SkipVexImages {
@@ -1000,6 +1032,7 @@ func (svc *Service) ExtractImageDigestsFromDeckhouseInstallerNew(
 	}
 
 	logger.Infof("Searching for VEX images")
+
 	for image := range images {
 		counter++
 		if counter%scanPrintInterval == 0 {
@@ -1177,6 +1210,7 @@ func deduplicateVersions(versions []*semver.Version) []semver.Version {
 		if v == nil {
 			continue
 		}
+
 		m[v.String()] = struct{}{}
 	}
 

--- a/internal/mirror/platform/platform_dryrun.go
+++ b/internal/mirror/platform/platform_dryrun.go
@@ -36,6 +36,7 @@ func (svc *Service) pullDeckhousePlatformDryRun(ctx context.Context, tagsToMirro
 	logger.Infof("Searching for Deckhouse built-in modules digests")
 
 	var prevDigests = make(map[string]struct{})
+
 	for _, tag := range tagsToMirror {
 		logger.Infof("[dry-run] Streaming installer metadata for %s from registry", tag)
 
@@ -56,26 +57,31 @@ func (svc *Service) pullDeckhousePlatformDryRun(ctx context.Context, tagsToMirro
 	svc.userLogger.InfoLn("[dry-run] Platform images that would be pulled:")
 
 	svc.userLogger.Infof("  Deckhouse components: %d images", len(svc.downloadList.Deckhouse))
+
 	for _, ref := range slices.Sorted(maps.Keys(svc.downloadList.Deckhouse)) {
 		svc.userLogger.InfoLn("    " + ref)
 	}
 
 	svc.userLogger.Infof("  Release channels: %d", len(svc.downloadList.DeckhouseReleaseChannel))
+
 	for _, ref := range slices.Sorted(maps.Keys(svc.downloadList.DeckhouseReleaseChannel)) {
 		svc.userLogger.InfoLn("    " + ref)
 	}
 
 	svc.userLogger.Infof("  Installer: %d", len(svc.downloadList.DeckhouseInstall))
+
 	for _, ref := range slices.Sorted(maps.Keys(svc.downloadList.DeckhouseInstall)) {
 		svc.userLogger.InfoLn("    " + ref)
 	}
 
 	svc.userLogger.Infof("  Standalone installer: %d", len(svc.downloadList.DeckhouseInstallStandalone))
+
 	for _, ref := range slices.Sorted(maps.Keys(svc.downloadList.DeckhouseInstallStandalone)) {
 		svc.userLogger.InfoLn("    " + ref)
 	}
 
 	svc.userLogger.Infof("  Total: %d platform images", totalImages)
+
 	return nil
 }
 
@@ -102,6 +108,7 @@ func (svc *Service) extractImageDigestsFromRemote(
 		if err := json.NewDecoder(tagsFile).Decode(&tags); err != nil {
 			return nil, fmt.Errorf("decode %s: %w", imagesTagsFile, err)
 		}
+
 		for _, nameTagTuple := range tags {
 			for _, imageID := range nameTagTuple {
 				ref := rootURL + ":" + imageID
@@ -111,7 +118,9 @@ func (svc *Service) extractImageDigestsFromRemote(
 				}
 			}
 		}
+
 		svc.userLogger.Infof("Deckhouse digests found: %d", len(result))
+
 		return result, nil
 	}
 
@@ -120,10 +129,12 @@ func (svc *Service) extractImageDigestsFromRemote(
 	if err != nil {
 		return nil, fmt.Errorf("extract %s from installer %q: %w", imagesDigestsFile, tag, err)
 	}
+
 	var digests map[string]map[string]string
 	if err := json.NewDecoder(digestsFile).Decode(&digests); err != nil {
 		return nil, fmt.Errorf("decode %s: %w", imagesDigestsFile, err)
 	}
+
 	for _, nameDigestTuple := range digests {
 		for _, imageID := range nameDigestTuple {
 			ref := rootURL + "@" + imageID
@@ -135,5 +146,6 @@ func (svc *Service) extractImageDigestsFromRemote(
 	}
 
 	svc.userLogger.Infof("Deckhouse digests found: %d", len(result))
+
 	return result, nil
 }

--- a/internal/mirror/platform/worker.go
+++ b/internal/mirror/platform/worker.go
@@ -55,6 +55,7 @@ func (cw *ConcurrentWorker[T, R]) Do(inputs []T, handler func(input T) (R, error
 
 	for _, input := range inputs {
 		semaphore <- struct{}{}
+
 		wg.Add(1)
 
 		go func(input T) {

--- a/internal/mirror/puller/puller.go
+++ b/internal/mirror/puller/puller.go
@@ -65,6 +65,7 @@ func (ps *PullerService) PullImages(ctx context.Context, config PullConfig) erro
 	ps.userLogger.InfoLn("Beginning to pull " + config.Name)
 
 	ps.userLogger.InfoLn("Pull " + config.Name + " meta")
+
 	for image, meta := range config.ImageSet {
 		// Bail out fast on cancellation. Without this check, a Ctrl+C in the
 		// middle of a large pull would cause every subsequent GetDigest call
@@ -110,6 +111,7 @@ func (ps *PullerService) PullImages(ctx context.Context, config PullConfig) erro
 			if isContextErr(err) {
 				return err
 			}
+
 			if config.AllowMissingTags {
 				continue
 			}
@@ -189,6 +191,7 @@ func (ps *PullerService) PullImageSet(
 			if imageMeta != nil {
 				ref = imageMeta.TagReference
 			}
+
 			return fmt.Errorf("pull image %q: %w", ref, err)
 		}
 

--- a/internal/mirror/push.go
+++ b/internal/mirror/push.go
@@ -116,6 +116,7 @@ func (svc *PushService) Push(ctx context.Context) error {
 	if err := os.MkdirAll(dirPath, dirPermissions); err != nil {
 		return fmt.Errorf("create unified directory: %w", err)
 	}
+
 	defer func() {
 		if err := os.RemoveAll(dirPath); err != nil {
 			svc.logger.Warn("Failed to cleanup unified directory",
@@ -180,6 +181,7 @@ func (svc *PushService) findPackages(entries []os.DirEntry) []string {
 		if strings.HasSuffix(name, ".tar") {
 			pkgName := strings.TrimSuffix(name, ".tar")
 			packagesSet[pkgName] = struct{}{}
+
 			continue
 		}
 
@@ -194,6 +196,7 @@ func (svc *PushService) findPackages(entries []os.DirEntry) []string {
 	for pkg := range packagesSet {
 		packages = append(packages, pkg)
 	}
+
 	slices.Sort(packages)
 
 	return packages
@@ -270,10 +273,13 @@ func (svc *PushService) findLayouts(rootDir string) ([]string, error) {
 		if err != nil {
 			return err
 		}
+
 		if d.IsDir() || d.Name() != "index.json" {
 			return nil
 		}
+
 		layouts = append(layouts, filepath.Dir(path))
+
 		return nil
 	})
 	if err != nil {
@@ -281,6 +287,7 @@ func (svc *PushService) findLayouts(rootDir string) ([]string, error) {
 	}
 
 	slices.Sort(layouts)
+
 	return layouts, nil
 }
 
@@ -292,14 +299,17 @@ func (svc *PushService) pushSingleLayout(ctx context.Context, rootDir, layoutDir
 		svc.logger.Warn("Failed to check layout",
 			slog.String("path", layoutDir),
 			slog.Any("error", err))
+
 		return nil
 	}
+
 	if !hasImages {
 		return nil
 	}
 
 	// Build registry segment from relative path
 	relPath, _ := filepath.Rel(rootDir, layoutDir)
+
 	segment := ""
 	if relPath != "." {
 		segment = relPath
@@ -311,6 +321,7 @@ func (svc *PushService) pushSingleLayout(ctx context.Context, rootDir, layoutDir
 
 	// Create client with appropriate segments
 	targetClient := svc.client
+
 	if segment != "" {
 		// Apply each path component as a segment
 		for _, seg := range strings.Split(segment, string(os.PathSeparator)) {
@@ -330,6 +341,7 @@ func (svc *PushService) pushSingleLayout(ctx context.Context, rootDir, layoutDir
 // layoutHasImages checks if an OCI layout has any images to push.
 func (svc *PushService) layoutHasImages(layoutDir string) (bool, error) {
 	layoutPath := layout.Path(layoutDir)
+
 	index, err := layoutPath.ImageIndex()
 	if err != nil {
 		return false, fmt.Errorf("read index: %w", err)
@@ -356,11 +368,13 @@ func (svc *PushService) createModulesIndex(ctx context.Context, rootDir string) 
 			svc.userLogger.InfoLn("No modules directory found, skipping modules index")
 			return nil
 		}
+
 		return fmt.Errorf("read modules directory %q: %w", modulesDir, err)
 	}
 
 	// Find all module directories
 	var moduleNames []string
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			moduleNames = append(moduleNames, entry.Name())
@@ -399,5 +413,6 @@ func (svc *PushService) createModulesIndex(ctx context.Context, rootDir string) 
 	}
 
 	svc.userLogger.Infof("Modules index created successfully")
+
 	return nil
 }

--- a/internal/mirror/pusher/pusher.go
+++ b/internal/mirror/pusher/pusher.go
@@ -67,6 +67,7 @@ func (s *Service) PackageExists(bundleDir, pkgName string) bool {
 	if _, err := os.Stat(packagePath + ".chunk000"); err == nil {
 		return true
 	}
+
 	return false
 }
 
@@ -102,6 +103,7 @@ func (s *Service) PushLayout(ctx context.Context, layoutPath layout.Path, client
 		}
 
 		imageReferenceString := fmt.Sprintf("%s:%s", client.GetRegistry(), tag)
+
 		err = retry.RunTask(
 			ctx,
 			s.userLogger,
@@ -110,6 +112,7 @@ func (s *Service) PushLayout(ctx context.Context, layoutPath layout.Path, client
 				if err := client.PushImage(ctx, tag, img); err != nil {
 					return fmt.Errorf("write %s:%s to registry: %w", client.GetRegistry(), tag, err)
 				}
+
 				return nil
 			}))
 		if err != nil {
@@ -143,6 +146,7 @@ func dedupManifestsByShortTag(descriptors []v1.Descriptor, logger *dkplog.Logger
 		if tag == "" {
 			logger.Warn("Skipping image without short_tag annotation",
 				slog.String("digest", manifest.Digest.String()))
+
 			continue
 		}
 
@@ -152,6 +156,7 @@ func dedupManifestsByShortTag(descriptors []v1.Descriptor, logger *dkplog.Logger
 				slog.String("previous_digest", result[idx].Digest.String()),
 				slog.String("current_digest", manifest.Digest.String()))
 			result[idx] = manifest
+
 			continue
 		}
 
@@ -165,6 +170,7 @@ func dedupManifestsByShortTag(descriptors []v1.Descriptor, logger *dkplog.Logger
 // OpenPackage opens a package file, trying .tar first, then chunked
 func (s *Service) OpenPackage(bundleDir, pkgName string) (io.ReadCloser, error) {
 	p := filepath.Join(bundleDir, pkgName+".tar")
+
 	pkg, err := os.Open(p)
 	switch {
 	case os.IsNotExist(err):

--- a/internal/mirror/security/layout.go
+++ b/internal/mirror/security/layout.go
@@ -106,5 +106,6 @@ func (l *ImageLayouts) AsList() []layout.Path {
 	for _, layout := range l.Security {
 		paths = append(paths, layout.Path())
 	}
+
 	return paths
 }

--- a/internal/mirror/security/security.go
+++ b/internal/mirror/security/security.go
@@ -147,11 +147,13 @@ func (svc *Service) pullSecurityDatabases(ctx context.Context) error {
 
 	if svc.options.DryRun {
 		svc.userLogger.InfoLn("[dry-run] Security database images that would be pulled:")
+
 		for _, imageSet := range svc.downloadList.Security {
 			for ref := range imageSet {
 				svc.userLogger.InfoLn("  " + ref)
 			}
 		}
+
 		return nil
 	}
 
@@ -186,6 +188,7 @@ func (svc *Service) pullSecurityDatabases(ctx context.Context) error {
 				return fmt.Errorf("sorting index manifests of %s: %w", l, err)
 			}
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/internal/mirror/validation/registry_access.go
+++ b/internal/mirror/validation/registry_access.go
@@ -91,6 +91,7 @@ func (v *RemoteRegistryAccessValidator) ValidateReadAccessForImage(ctx context.C
 		if errmatch.IsImageNotFound(err) {
 			return ErrImageUnavailable
 		}
+
 		return err
 	}
 
@@ -116,6 +117,7 @@ func (v *RemoteRegistryAccessValidator) ValidateWriteAccessForRepo(ctx context.C
 	if err = remote.Write(ref, syntheticImage, remoteOpts...); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -127,6 +129,7 @@ func (v *RemoteRegistryAccessValidator) useOptions(opts []Option) *options {
 	for _, opt := range opts {
 		opt(o)
 	}
+
 	return o
 }
 

--- a/internal/network/cnimigration/cmd/cni.go
+++ b/internal/network/cnimigration/cmd/cni.go
@@ -75,6 +75,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(NewCmdCniMigrationSwitch())
 	cmd.AddCommand(NewCmdCniMigrationWatch())
 	cmd.AddCommand(NewCmdCniMigrationCleanup())
+
 	return cmd
 }
 
@@ -90,6 +91,7 @@ func NewCmdCniMigrationSwitch() *cobra.Command {
 					return nil
 				}
 			}
+
 			return fmt.Errorf(
 				"invalid --to-cni value %q. Supported values are: %s",
 				targetCNI,
@@ -104,14 +106,17 @@ func NewCmdCniMigrationSwitch() *cobra.Command {
 				if errors.Is(err, cni.ErrCancelled) {
 					return
 				}
+
 				log.Fatalf("❌ Error running switch command: %v", err)
 			}
 
 			fmt.Println()
+
 			if err := cni.RunWatch(); err != nil {
 				if errors.Is(err, cni.ErrMigrationFailed) {
 					os.Exit(1)
 				}
+
 				log.Fatalf("❌ Error monitoring switch progress: %v", err)
 			}
 		},
@@ -135,10 +140,12 @@ func NewCmdCniMigrationWatch() *cobra.Command {
 				if errors.Is(err, cni.ErrMigrationFailed) {
 					os.Exit(1)
 				}
+
 				log.Fatalf("❌ Error running watch command: %v", err)
 			}
 		},
 	}
+
 	return cmd
 }
 
@@ -153,5 +160,6 @@ func NewCmdCniMigrationCleanup() *cobra.Command {
 			}
 		},
 	}
+
 	return cmd
 }

--- a/internal/plugins/cmd/contract.go
+++ b/internal/plugins/cmd/contract.go
@@ -28,8 +28,10 @@ import (
 )
 
 func (pc *PluginsCommand) pluginsContractCommand() *cobra.Command {
-	var version string
-	var useMajor int
+	var (
+		version  string
+		useMajor int
+	)
 
 	cmd := &cobra.Command{
 		Use:   "contract [plugin-name]",
@@ -56,8 +58,10 @@ func (pc *PluginsCommand) pluginsContractCommand() *cobra.Command {
 					slog.String("plugin", pluginName),
 					slog.String("tag", tag),
 					slog.String("error", err.Error()))
+
 				return fmt.Errorf("failed to get plugin contract: %w", err)
 			}
+
 			contract := service.DomainToContract(plugin)
 
 			// Display contract
@@ -65,10 +69,12 @@ func (pc *PluginsCommand) pluginsContractCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal contract to JSON: %w", err)
 			}
+
 			yamlBytes, err := yaml.JSONToYAML(jsonBytes)
 			if err != nil {
 				return fmt.Errorf("failed to convert JSON to YAML: %w", err)
 			}
+
 			fmt.Println(string(yamlBytes))
 
 			return nil

--- a/internal/plugins/cmd/init.go
+++ b/internal/plugins/cmd/init.go
@@ -90,6 +90,7 @@ func containsSlash(s string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -98,6 +99,7 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 	if d8flags.SourceRegistryLogin != "" {
 		logger.Debug("Using explicit credentials from flags",
 			slog.String("username", d8flags.SourceRegistryLogin))
+
 		return authn.FromConfig(authn.AuthConfig{
 			Username: d8flags.SourceRegistryLogin,
 			Password: d8flags.SourceRegistryPassword,
@@ -107,6 +109,7 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 	// Priority 2: License token from flags
 	if d8flags.DeckhouseLicenseToken != "" {
 		logger.Debug("Using license token from flags")
+
 		return authn.FromConfig(authn.AuthConfig{
 			Username: "license-token",
 			Password: d8flags.DeckhouseLicenseToken,
@@ -115,10 +118,13 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 
 	// Priority 3: Try to get credentials from Docker config (~/.docker/config.json)
 	// Parse the registry hostname to create a Registry object for DefaultKeychain
-	var reg name.Registry
-	var err error
+	var (
+		reg name.Registry
+		err error
+	)
 
 	// If registryHost contains a slash, it might be a full path - extract just the host
+
 	if containsSlash(registryHost) {
 		ref, parseErr := name.ParseReference(registryHost)
 		if parseErr == nil {
@@ -126,12 +132,14 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 		} else {
 			// Fallback: just use the part before the first slash
 			idx := 0
+
 			for i := 0; i < len(registryHost); i++ {
 				if registryHost[i] == '/' {
 					idx = i
 					break
 				}
 			}
+
 			reg, err = name.NewRegistry(registryHost[:idx])
 		}
 	} else {
@@ -147,6 +155,7 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 			if err == nil && (cfg.Username != "" || cfg.Password != "" || cfg.Auth != "" || cfg.IdentityToken != "") {
 				logger.Debug("Using credentials from Docker config",
 					slog.String("registry", reg.String()))
+
 				return auth
 			}
 		}
@@ -155,5 +164,6 @@ func getPluginRegistryAuthProvider(registryHost string, logger *dkplog.Logger) a
 	// Priority 4: Anonymous access
 	logger.Debug("Using anonymous access for registry",
 		slog.String("registry", registryHost))
+
 	return authn.Anonymous
 }

--- a/internal/plugins/cmd/install.go
+++ b/internal/plugins/cmd/install.go
@@ -33,9 +33,11 @@ import (
 )
 
 func (pc *PluginsCommand) pluginsInstallCommand() *cobra.Command {
-	var version string
-	var useMajor int
-	var resolvePluginsConflicts bool
+	var (
+		version                 string
+		useMajor                int
+		resolvePluginsConflicts bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "install [plugin-name]",
@@ -110,6 +112,7 @@ func (pc *PluginsCommand) InstallPlugin(ctx context.Context, pluginName string, 
 
 	if options.version != "" {
 		var err error
+
 		installVersion, err = semver.NewVersion(options.version)
 		if err != nil {
 			return fmt.Errorf("failed to parse version: %w", err)
@@ -191,6 +194,7 @@ func (pc *PluginsCommand) installPlugin(ctx context.Context, pluginName string, 
 	}
 
 	fmt.Printf("✓ Plugin '%s' successfully installed!\n", pluginName)
+
 	return nil
 }
 
@@ -209,6 +213,7 @@ func (pc *PluginsCommand) preparePluginDirs(pluginName string, version *semver.V
 	if err := os.MkdirAll(paths.pluginDir, 0755); err != nil {
 		return pluginPaths{}, fmt.Errorf("failed to create plugin directory: %w", err)
 	}
+
 	if err := os.MkdirAll(paths.versionDir, 0755); err != nil {
 		return pluginPaths{}, fmt.Errorf("failed to create plugin directory: %w", err)
 	}
@@ -234,6 +239,7 @@ func (pc *PluginsCommand) acquireInstallLock(lockFilePath string) (func(), error
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
+
 	lockFile.Close()
 
 	return func() { os.Remove(lockFilePath) }, nil
@@ -268,14 +274,17 @@ func (pc *PluginsCommand) validateAndResolveConflicts(ctx context.Context, plugi
 	if err != nil {
 		return fmt.Errorf("failed to validate requirements: %w", err)
 	}
+
 	if len(failedConstraints) > 0 && !resolvePluginsConflicts {
 		return fmt.Errorf("plugin requirements not satisfied")
 	}
+
 	if len(failedConstraints) > 0 && resolvePluginsConflicts {
 		if err := pc.resolvePluginConflicts(ctx, failedConstraints); err != nil {
 			return fmt.Errorf("failed to resolve conflicts: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -286,9 +295,11 @@ func (pc *PluginsCommand) backupOldBinary(binaryPath string) error {
 	if err != nil || info.IsDir() {
 		return nil
 	}
+
 	if err := os.Rename(binaryPath, binaryPath+".old"); err != nil {
 		return fmt.Errorf("failed to save old version: %w", err)
 	}
+
 	return nil
 }
 
@@ -296,6 +307,7 @@ func (pc *PluginsCommand) backupOldBinary(binaryPath string) error {
 // binary to <binaryPath>.
 func (pc *PluginsCommand) downloadAndExtract(ctx context.Context, pluginName string, version *semver.Version, binaryPath string) error {
 	tag := version.Original()
+
 	fmt.Printf("Installing to: %s\n", binaryPath)
 	fmt.Println("Downloading and extracting plugin...")
 
@@ -305,8 +317,10 @@ func (pc *PluginsCommand) downloadAndExtract(ctx context.Context, pluginName str
 			slog.String("tag", tag),
 			slog.String("destination", binaryPath),
 			slog.String("error", err.Error()))
+
 		return fmt.Errorf("failed to extract plugin: %w", err)
 	}
+
 	return nil
 }
 
@@ -323,6 +337,7 @@ func (pc *PluginsCommand) linkCurrent(paths pluginPaths) error {
 	if err := os.Symlink(absPath, paths.currentLink); err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
+
 	return nil
 }
 
@@ -335,6 +350,7 @@ func (pc *PluginsCommand) cacheContract(pluginName string, plugin *internal.Plug
 	}
 
 	contract := service.DomainToContract(plugin)
+
 	contractFile, err := os.OpenFile(layout.ContractFile(pc.pluginDirectory, pluginName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open contract file: %w", err)
@@ -348,6 +364,7 @@ func (pc *PluginsCommand) cacheContract(pluginName string, plugin *internal.Plug
 	if err := enc.Encode(contract); err != nil {
 		return fmt.Errorf("failed to cache contract: %w", err)
 	}
+
 	return nil
 }
 

--- a/internal/plugins/cmd/layout/layout.go
+++ b/internal/plugins/cmd/layout/layout.go
@@ -95,5 +95,6 @@ func HomeFallbackPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to determine user home directory: %w", err)
 	}
+
 	return path.Join(home, HomeFallbackDir), nil
 }

--- a/internal/plugins/cmd/list.go
+++ b/internal/plugins/cmd/list.go
@@ -42,8 +42,10 @@ type pluginsListData struct {
 }
 
 func (pc *PluginsCommand) pluginsListCommand() *cobra.Command {
-	var showInstalledOnly bool
-	var showAvailableOnly bool
+	var (
+		showInstalledOnly bool
+		showAvailableOnly bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -116,6 +118,7 @@ func (pc *PluginsCommand) fetchInstalledPlugins() ([]pluginDisplayInfo, error) {
 				Version:     "ERROR",
 				Description: err.Error(),
 			})
+
 			continue
 		}
 
@@ -126,6 +129,7 @@ func (pc *PluginsCommand) fetchInstalledPlugins() ([]pluginDisplayInfo, error) {
 				Version:     version.Original(),
 				Description: "failed to get description",
 			})
+
 			continue
 		}
 
@@ -242,6 +246,7 @@ func (pc *PluginsCommand) printAvailableSection(data *pluginsListData) {
 		fmt.Println("You can still use specific plugins if you know their names:")
 		fmt.Println("  - Use 'plugins contract <name>' to view plugin details")
 		fmt.Println("  - Use 'plugins install <name>' to install a plugin")
+
 		return
 	}
 

--- a/internal/plugins/cmd/plugin.go
+++ b/internal/plugins/cmd/plugin.go
@@ -43,6 +43,7 @@ func NewPluginCommand(commandName, description string, aliases []string, logger 
 		logger.Warn("failed to ensure plugin root directory", slog.String("error", err.Error()))
 		return nil
 	}
+
 	if cached := pc.cachedDescription(commandName); cached != "" {
 		description = cached
 	}
@@ -70,11 +71,14 @@ func (pc *PluginsCommand) runInstalledPlugin(ctx context.Context, pluginName str
 	if err != nil {
 		return fmt.Errorf("check installed: %w", err)
 	}
+
 	if !installed {
 		fmt.Println("Not installed, installing...")
+
 		if err := pc.InstallPlugin(ctx, pluginName); err != nil {
 			return fmt.Errorf("install: %w", err)
 		}
+
 		fmt.Println("Installed successfully")
 	}
 
@@ -85,10 +89,12 @@ func (pc *PluginsCommand) runInstalledPlugin(ctx context.Context, pluginName str
 
 	pc.logger.Debug("Executing plugin", slog.String("plugin", pluginName), slog.Any("args", args))
 	cmd := exec.CommandContext(ctx, absPath, args...)
+
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("plugin run: %w", err)
 	}
+
 	return nil
 }
 

--- a/internal/plugins/cmd/plugins.go
+++ b/internal/plugins/cmd/plugins.go
@@ -56,13 +56,17 @@ func (pc *PluginsCommand) ensureInstallRoot() error {
 	if !errors.Is(err, os.ErrPermission) {
 		return err
 	}
+
 	pc.logger.Debug("use homedir instead of default d8 plugins path in '/opt/deckhouse/lib/deckhouse-cli'",
 		slog.String("was", pc.pluginDirectory), dkplog.Err(err))
+
 	fallback, ferr := layout.HomeFallbackPath()
 	if ferr != nil {
 		return fmt.Errorf("home fallback: %w", ferr)
 	}
+
 	pc.pluginDirectory = fallback
+
 	return os.MkdirAll(layout.PluginsRoot(pc.pluginDirectory), 0755)
 }
 
@@ -74,9 +78,11 @@ func (pc *PluginsCommand) cachedDescription(pluginName string) string {
 		pc.logger.Debug("failed to get plugin contract from cache", slog.String("error", err.Error()))
 		return ""
 	}
+
 	if contract == nil {
 		return ""
 	}
+
 	return contract.Description
 }
 
@@ -90,6 +96,7 @@ func NewCommand(logger *dkplog.Logger) *cobra.Command {
 		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			// init plugin services for subcommands after flags are parsed
 			pc.InitPluginServices()
+
 			if err := pc.ensureInstallRoot(); err != nil {
 				pc.logger.Warn("failed to ensure plugin root directory", slog.String("error", err.Error()))
 			}

--- a/internal/plugins/cmd/validators.go
+++ b/internal/plugins/cmd/validators.go
@@ -46,6 +46,7 @@ func (pc *PluginsCommand) getInstalledPluginContract(pluginName string) (*intern
 
 	contract := new(service.PluginContract)
 	dec := json.NewDecoder(file)
+
 	err = dec.Decode(contract)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal contract: %w", err)
@@ -127,6 +128,7 @@ func (pc *PluginsCommand) fetchLatestVersion(ctx context.Context, pluginName str
 		pc.logger.Warn("Failed to fetch latest version", slog.String("plugin", pluginName), slog.String("error", err.Error()))
 		return nil, fmt.Errorf("failed to fetch latest version: %w", err)
 	}
+
 	return latestVersion, nil
 }
 
@@ -156,11 +158,13 @@ func (pc *PluginsCommand) validateRequirements(plugin *internal.Plugin) (FailedC
 	if err := pc.validateKubernetesRequirement(plugin); err != nil {
 		return nil, fmt.Errorf("kubernetes requirement: %w", err)
 	}
+
 	if err := pc.validateDeckhouseRequirement(plugin); err != nil {
 		return nil, fmt.Errorf("deckhouse requirement: %w", err)
 	}
 
 	pc.logger.Debug("validating module requirements", slog.String("plugin", plugin.Name))
+
 	if err := pc.validateModuleRequirement(plugin); err != nil {
 		return nil, fmt.Errorf("module requirements: %w", err)
 	}
@@ -176,6 +180,7 @@ func (pc *PluginsCommand) validatePluginConflicts(plugin *internal.Plugin) error
 		pc.logger.Debug("failed to read contract directory", slog.String("error", err.Error()))
 		return nil
 	}
+
 	if err != nil {
 		return fmt.Errorf("failed to read contract directory: %w", err)
 	}
@@ -213,6 +218,7 @@ func validatePluginConflict(plugin *internal.Plugin, installedPlugin *internal.P
 		if requirement.Name != plugin.Name {
 			continue
 		}
+
 		constraint, err := semver.NewConstraint(requirement.Constraint)
 		if err != nil {
 			return fmt.Errorf("failed to parse constraint: %w", err)
@@ -223,6 +229,7 @@ func validatePluginConflict(plugin *internal.Plugin, installedPlugin *internal.P
 		if err != nil {
 			return fmt.Errorf("failed to parse version: %w", err)
 		}
+
 		if !constraint.Check(version) {
 			return fmt.Errorf("installing plugin %s %s conflicts with existing plugin %s which requires %s %s",
 				plugin.Name,
@@ -252,24 +259,30 @@ func (pc *PluginsCommand) validatePluginRequirementMandatory(plugin *internal.Pl
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if plugin is installed: %w", err)
 		}
+
 		if !installed {
 			pc.logger.Warn("plugin requirement not installed",
 				slog.String("plugin", plugin.Name),
 				slog.String("requirement", pluginRequirement.Name))
 			result[pluginRequirement.Name] = nil
+
 			continue
 		}
+
 		if pluginRequirement.Constraint == "" {
 			continue
 		}
+
 		installedVersion, err := pc.getInstalledPluginVersion(pluginRequirement.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get installed version: %w", err)
 		}
+
 		constraint, err := semver.NewConstraint(pluginRequirement.Constraint)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse constraint: %w", err)
 		}
+
 		if !constraint.Check(installedVersion) {
 			pc.logger.Warn("plugin requirement not satisfied",
 				slog.String("plugin", plugin.Name),
@@ -294,20 +307,25 @@ func (pc *PluginsCommand) validatePluginRequirementConditional(plugin *internal.
 		if err != nil {
 			return fmt.Errorf("failed to check if plugin is installed: %w", err)
 		}
+
 		if !installed {
 			continue
 		}
+
 		if pluginRequirement.Constraint == "" {
 			continue
 		}
+
 		installedVersion, err := pc.getInstalledPluginVersion(pluginRequirement.Name)
 		if err != nil {
 			return fmt.Errorf("failed to get installed version: %w", err)
 		}
+
 		constraint, err := semver.NewConstraint(pluginRequirement.Constraint)
 		if err != nil {
 			return fmt.Errorf("failed to parse constraint: %w", err)
 		}
+
 		if !constraint.Check(installedVersion) {
 			return fmt.Errorf("conditional plugin requirement not satisfied: plugin %s %s installed but %s requires %s",
 				pluginRequirement.Name,
@@ -316,6 +334,7 @@ func (pc *PluginsCommand) validatePluginRequirementConditional(plugin *internal.
 				pluginRequirement.Constraint)
 		}
 	}
+
 	return nil
 }
 
@@ -331,6 +350,7 @@ func (pc *PluginsCommand) validatePluginRequirementConditional(plugin *internal.
 //	      key2: value2
 func debugPrintPendingRequirement(title string, kv ...[2]string) {
 	fmt.Fprintf(os.Stderr, "!  %s\n", title)
+
 	for _, p := range kv {
 		fmt.Fprintf(os.Stderr, "      %s: %s\n", p[0], p[1])
 	}
@@ -347,11 +367,13 @@ func (pc *PluginsCommand) validateKubernetesRequirement(plugin *internal.Plugin)
 	if plugin.Requirements.Kubernetes.Constraint == "" {
 		return nil
 	}
+
 	debugPrintPendingRequirement(
 		"plugin declares a Kubernetes version requirement but enforcement is not implemented yet",
 		[2]string{"plugin", plugin.Name},
 		[2]string{"constraint", plugin.Requirements.Kubernetes.Constraint},
 	)
+
 	return nil
 }
 
@@ -363,11 +385,13 @@ func (pc *PluginsCommand) validateDeckhouseRequirement(plugin *internal.Plugin) 
 	if plugin.Requirements.Deckhouse.Constraint == "" {
 		return nil
 	}
+
 	debugPrintPendingRequirement(
 		"plugin declares a Deckhouse version requirement but enforcement is not implemented yet",
 		[2]string{"plugin", plugin.Name},
 		[2]string{"constraint", plugin.Requirements.Deckhouse.Constraint},
 	)
+
 	return nil
 }
 
@@ -390,6 +414,7 @@ func (pc *PluginsCommand) validateModuleRequirement(plugin *internal.Plugin) err
 			[2]string{"constraint", m.Constraint},
 		)
 	}
+
 	for _, m := range mods.Conditional {
 		debugPrintPendingRequirement(
 			"plugin declares a conditional module requirement but enforcement is not implemented yet",
@@ -398,11 +423,13 @@ func (pc *PluginsCommand) validateModuleRequirement(plugin *internal.Plugin) err
 			[2]string{"constraint", m.Constraint},
 		)
 	}
+
 	for i, grp := range mods.AnyOf {
 		names := make([]string, 0, len(grp.Modules))
 		for _, m := range grp.Modules {
 			names = append(names, m.Name)
 		}
+
 		debugPrintPendingRequirement(
 			"plugin declares an anyOf module group but enforcement is not implemented yet",
 			[2]string{"plugin", plugin.Name},
@@ -411,5 +438,6 @@ func (pc *PluginsCommand) validateModuleRequirement(plugin *internal.Plugin) err
 			[2]string{"modules", strings.Join(names, ", ")},
 		)
 	}
+
 	return nil
 }

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -39,6 +39,7 @@ func initProgressBar(totalSize int64) (*mpb.Progress, *mpb.Bar) {
 	if totalSize > 0 {
 		return p, p.AddBar(totalSize, defaultOption...)
 	}
+
 	return p, p.AddBar(totalSize, unknownSizeOption...)
 }
 
@@ -77,6 +78,7 @@ func BarCallback(ctx context.Context) Callback {
 		if totalSize <= 0 {
 			bar.SetTotal(written, true)
 		}
+
 		p.Wait()
 
 		return nil
@@ -100,6 +102,7 @@ func CopyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (int64, 
 			return src.Read(p)
 		}
 	}))
+
 	return written, err
 }
 
@@ -114,6 +117,7 @@ func (dpb *DownloadBar) Init(contentLength int64) {
 		// we don't need a bar visible
 		return
 	}
+
 	dpb.p, dpb.bar = initProgressBar(contentLength)
 }
 
@@ -125,6 +129,7 @@ func (dpb *DownloadBar) IncrBy(n int) {
 	if dpb.bar == nil {
 		return
 	}
+
 	dpb.bar.IncrBy(n)
 }
 
@@ -132,6 +137,7 @@ func (dpb *DownloadBar) Abort(drop bool) {
 	if dpb.bar == nil {
 		return
 	}
+
 	dpb.bar.Abort(drop)
 }
 
@@ -139,6 +145,7 @@ func (dpb *DownloadBar) Wait() {
 	if dpb.bar == nil {
 		return
 	}
+
 	dpb.p.Wait()
 }
 
@@ -155,6 +162,7 @@ func (upb *UploadBar) InitUpload(totalSize int64, r io.Reader) {
 		upb.r = r
 		return
 	}
+
 	upb.progress, upb.bar = initProgressBar(totalSize)
 	upb.r = upb.bar.ProxyReader(r)
 }
@@ -168,6 +176,7 @@ func (upb *UploadBar) Init(totalSize int64) {
 		// we don't need a bar visible
 		return
 	}
+
 	upb.progress, upb.bar = initProgressBar(totalSize)
 }
 
@@ -175,6 +184,7 @@ func (upb *UploadBar) IncrBy(n int) {
 	if upb.bar == nil {
 		return
 	}
+
 	upb.bar.IncrBy(n)
 }
 
@@ -182,6 +192,7 @@ func (upb *UploadBar) Terminate() {
 	if upb.bar == nil {
 		return
 	}
+
 	upb.bar.Abort(true)
 }
 

--- a/internal/progress/progress_roundtripper.go
+++ b/internal/progress/progress_roundtripper.go
@@ -54,6 +54,7 @@ func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.sizes = append(t.sizes, resp.ContentLength)
 		resp.Body = bar.ProxyReader(resp.Body)
 	}
+
 	return resp, err
 }
 

--- a/internal/status/cmd/status.go
+++ b/internal/status/cmd/status.go
@@ -62,17 +62,21 @@ func NewCommand() *cobra.Command {
 
 func runStatus(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
+
 	restConfig, kubeCl, err := setupK8sClients(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to setup Kubernetes client: %w", err)
 	}
+
 	color.Cyan("\n┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓")
 	color.Cyan("┃      Cluster Status Report     ┃")
 	color.Cyan("┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛\n")
+
 	results := executeAll(ctx, restConfig, kubeCl)
 	for _, result := range results {
 		fmt.Println(result.Output)
 	}
+
 	return nil
 }
 

--- a/internal/status/objects/clusteralerts/clusteralerts.go
+++ b/internal/status/objects/clusteralerts/clusteralerts.go
@@ -33,10 +33,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, dynamicClient dynamic.Interface) statusresult.StatusResult {
 	alerts, err := getClusterAlerts(ctx, dynamicClient)
+
 	output := color.RedString("Error getting cluster alerts: %v\n", err)
 	if err == nil {
 		output = formatClusterAlerts(alerts)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Cluster Alerts",
 		Level:  0,
@@ -57,24 +59,29 @@ func getClusterAlerts(ctx context.Context, dynamicCl dynamic.Interface) ([]Clust
 		Version:  "v1alpha1",
 		Resource: "clusteralerts",
 	}
+
 	alertList, err := dynamicCl.Resource(gvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list cluster alerts: %w", err)
 	}
+
 	alerts := make([]ClusterAlert, 0, len(alertList.Items))
 	for _, item := range alertList.Items {
 		alert, ok := ClusterAlertProcessing(item.Object)
 		if !ok {
 			continue
 		}
+
 		alerts = append(alerts, alert)
 	}
+
 	return alerts, nil
 }
 
 // Processing converts raw resource data into a structured format for easier output and analysis.
 func ClusterAlertProcessing(item map[string]interface{}) (ClusterAlert, bool) {
 	alertSpecMap, ok1 := item["alert"].(map[string]interface{})
+
 	statusMap, ok2 := item["status"].(map[string]interface{})
 	if !ok1 || !ok2 {
 		return ClusterAlert{}, false
@@ -82,6 +89,7 @@ func ClusterAlertProcessing(item map[string]interface{}) (ClusterAlert, bool) {
 
 	name, ok3 := alertSpecMap["name"].(string)
 	phase, ok5 := statusMap["alertStatus"].(string)
+
 	severity, ok4 := alertSpecMap["severityLevel"].(string)
 	if !ok4 {
 		severity = "N/A"
@@ -111,9 +119,11 @@ func formatClusterAlerts(alerts []ClusterAlert) string {
 
 	countMap := make(map[AlertKey]int)
 	maxNameLen := len("ALERT")
+
 	for _, alert := range alerts {
 		key := AlertKey{Severity: alert.Severity, Name: alert.Name}
 		countMap[key]++
+
 		nameLen := len([]rune(alert.Name))
 		if nameLen > maxNameLen {
 			maxNameLen = nameLen
@@ -126,14 +136,17 @@ func formatClusterAlerts(alerts []ClusterAlert) string {
 	for key := range countMap {
 		sortedKeys = append(sortedKeys, key)
 	}
+
 	sort.SliceStable(sortedKeys, func(i, j int) bool {
 		if sortedKeys[i].Severity == sortedKeys[j].Severity {
 			return sortedKeys[i].Name < sortedKeys[j].Name
 		}
+
 		return sortedKeys[i].Severity < sortedKeys[j].Severity
 	})
 
 	var sb strings.Builder
+
 	yellow := color.New(color.FgYellow).SprintFunc()
 	sb.WriteString(yellow("┌ Cluster Alerts:\n"))
 	sb.WriteString(yellow(fmt.Sprintf("├ %-10s %-*s %s\n", "SEVERITY", nameColWidth, "ALERT", "SUM")))
@@ -143,6 +156,7 @@ func formatClusterAlerts(alerts []ClusterAlert) string {
 		if i == len(sortedKeys)-1 {
 			prefix = "└"
 		}
+
 		truncName := truncateName(key.Name, nameColWidth)
 		count := countMap[key]
 
@@ -174,8 +188,10 @@ func truncateName(name string, width int) string {
 	if len(nameRunes) <= width {
 		return name
 	}
+
 	if width < 3 {
 		return "..."
 	}
+
 	return string(nameRunes[:width-3]) + "..."
 }

--- a/internal/status/objects/cni_modules/cnimodules.go
+++ b/internal/status/objects/cni_modules/cnimodules.go
@@ -33,10 +33,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, dynamicClient dynamic.Interface) statusresult.StatusResult {
 	modules, err := getModules(ctx, dynamicClient)
+
 	output := color.RedString("Error getting modules: %v\n", err)
 	if err == nil {
 		output = formatModules(modules)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Modules",
 		Level:  0,
@@ -60,21 +62,26 @@ func getModules(ctx context.Context, dynamicCl dynamic.Interface) ([]CNIModule, 
 		Version:  "v1alpha1",
 		Resource: "modules",
 	}
+
 	moduleList, err := dynamicCl.Resource(gvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list modules: %w", err)
 	}
+
 	modules := make([]CNIModule, 0, len(moduleList.Items))
 	for _, item := range moduleList.Items {
 		if !strings.Contains(item.GetName(), "cni") {
 			continue
 		}
+
 		module, ok := CNIModuleProcessing(item.Object)
 		if !ok {
 			continue
 		}
+
 		modules = append(modules, module)
 	}
+
 	return modules, nil
 }
 
@@ -107,15 +114,18 @@ func CNIModuleProcessing(item map[string]interface{}) (CNIModule, bool) {
 
 	enabled := "False"
 	ready := "False"
+
 	for _, c := range conditionsRaw {
 		cond, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
+
 		conditionType, ok := cond["type"].(string)
 		if !ok {
 			continue
 		}
+
 		status, ok := cond["status"].(string)
 		if !ok {
 			continue
@@ -125,6 +135,7 @@ func CNIModuleProcessing(item map[string]interface{}) (CNIModule, bool) {
 			conditionType == constant.ModuleConditionEnabledByModuleManager {
 			enabled = status
 		}
+
 		if conditionType == constant.ModuleConditionIsReady {
 			ready = status
 		}
@@ -145,15 +156,19 @@ func formatModules(modules []CNIModule) string {
 	if len(modules) == 0 {
 		return color.YellowString("❗ No CNI modules found\n")
 	}
+
 	var sb strings.Builder
+
 	yellow := color.New(color.FgYellow).SprintFunc()
 	sb.WriteString(yellow("┌ CNI in cluster:\n"))
 	sb.WriteString(yellow(fmt.Sprintf("├ %-18s %-8s %-10s %-12s %-8s %-8s\n", "NAME", "WEIGHT", "SOURCE", "PHASE", "ENABLED", "READY")))
+
 	for i, module := range modules {
 		prefix := "├"
 		if i == len(modules)-1 {
 			prefix = "└"
 		}
+
 		name := module.Name
 		weight := module.Weight
 		source := module.Source
@@ -169,5 +184,6 @@ func formatModules(modules []CNIModule) string {
 			enabled,
 			ready)
 	}
+
 	return sb.String()
 }

--- a/internal/status/objects/edition/deckhouseedition.go
+++ b/internal/status/objects/edition/deckhouseedition.go
@@ -32,10 +32,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, kubeCl kubernetes.Interface) statusresult.StatusResult {
 	edition, err := getDeckhouseEdition(ctx, kubeCl)
+
 	output := color.RedString("Error getting Deckhouse edition: %v\n", err)
 	if err == nil {
 		output = formatDeckhouseEdition(edition)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse Edition",
 		Level:  0,
@@ -53,6 +55,7 @@ func getDeckhouseEdition(ctx context.Context, kubeCl kubernetes.Interface) (deck
 	if err != nil {
 		return deckhouseEditionInfo{}, fmt.Errorf("failed to get deployment: %w", err)
 	}
+
 	return deckhouseEditionProcessing(deployment)
 }
 
@@ -62,14 +65,17 @@ func deckhouseEditionProcessing(deployment *appsv1.Deployment) (deckhouseEdition
 	if !found {
 		return deckhouseEditionInfo{}, fmt.Errorf("annotation 'core.deckhouse.io/edition' not found in deployment")
 	}
+
 	return deckhouseEditionInfo{Edition: edition}, nil
 }
 
 // Format returns a readable view of resource status for CLI display.
 func formatDeckhouseEdition(info deckhouseEditionInfo) string {
 	var sb strings.Builder
+
 	yellow := color.New(color.FgYellow).SprintFunc()
 	sb.WriteString(yellow("┌ Deckhouse Edition:\n"))
 	fmt.Fprintf(&sb, "%s %s\n", yellow("└"), info.Edition)
+
 	return sb.String()
 }

--- a/internal/status/objects/masters/masters.go
+++ b/internal/status/objects/masters/masters.go
@@ -32,10 +32,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, kubeCl kubernetes.Interface) statusresult.StatusResult {
 	nodes, err := getMasterNodes(ctx, kubeCl)
+
 	output := color.RedString("Error getting master nodes: %v\n", err)
 	if err == nil {
 		output = formatMasterNodes(nodes)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Master Nodes",
 		Level:  0,
@@ -58,6 +60,7 @@ func getMasterNodes(ctx context.Context, kubeCl kubernetes.Interface) ([]corev1.
 	if err != nil {
 		return nil, fmt.Errorf("failed to list master nodes: %w", err)
 	}
+
 	return nodes.Items, nil
 }
 
@@ -73,12 +76,14 @@ func masterNodeStatus(node corev1.Node) MasterNodeStatus {
 
 func nodeReadyStatus(node corev1.Node) string {
 	status := "NotReady"
+
 	for _, cond := range node.Status.Conditions {
 		if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
 			status = "Ready"
 			break
 		}
 	}
+
 	return status
 }
 
@@ -88,6 +93,7 @@ func nodeInternalIP(node corev1.Node) string {
 			return addr.Address
 		}
 	}
+
 	return "<none>"
 }
 
@@ -99,12 +105,15 @@ func formatMasterNodes(nodes []corev1.Node) string {
 
 	statuses := make([]MasterNodeStatus, 0, len(nodes))
 	maxNameLen := len("NAME")
+
 	for _, node := range nodes {
 		status := masterNodeStatus(node)
+
 		nameRuneLen := len([]rune(status.Name))
 		if nameRuneLen > maxNameLen {
 			maxNameLen = nameRuneLen
 		}
+
 		statuses = append(statuses, status)
 	}
 
@@ -126,6 +135,7 @@ func formatMasterNodes(nodes []corev1.Node) string {
 		if i == len(statuses)-1 {
 			prefix = "└"
 		}
+
 		nodeName := truncateName(s.Name, nameColWidth)
 		fmt.Fprintf(&sb, "%s %-*s %-*s %-*s %s\n",
 			yellow(prefix),
@@ -156,8 +166,10 @@ func truncateName(str string, maxRunes int) string {
 	if len(runes) <= maxRunes {
 		return str
 	}
+
 	if maxRunes > 3 {
 		return string(runes[:maxRunes-3]) + "..."
 	}
+
 	return string(runes[:maxRunes])
 }

--- a/internal/status/objects/pods/deckhousepods.go
+++ b/internal/status/objects/pods/deckhousepods.go
@@ -33,10 +33,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, kubeCl kubernetes.Interface) statusresult.StatusResult {
 	pods, err := getDeckhousePods(ctx, kubeCl)
+
 	output := color.RedString("Error getting Deckhouse pods: %v\n", err)
 	if err == nil {
 		output = formatDeckhousePods(pods)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse Pods",
 		Level:  0,
@@ -65,6 +67,7 @@ func getDeckhousePods(ctx context.Context, kubeCl kubernetes.Interface) ([]deckh
 	for _, pod := range pods.Items {
 		infor = append(infor, deckhousePodProcessing(pod))
 	}
+
 	return infor, nil
 }
 
@@ -82,10 +85,12 @@ func deckhousePodProcessing(pod corev1.Pod) deckhousePod {
 	}
 
 	readyCount, restarts := 0, 0
+
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Ready {
 			readyCount++
 		}
+
 		restarts += int(cs.RestartCount)
 	}
 
@@ -105,6 +110,7 @@ func formatDeckhousePods(infor []deckhousePod) string {
 	}
 
 	var sb strings.Builder
+
 	yellow := color.New(color.FgYellow).SprintFunc()
 
 	sb.WriteString(yellow("┌ Deckhouse Pods Status:\n"))
@@ -115,6 +121,7 @@ func formatDeckhousePods(infor []deckhousePod) string {
 		if i == len(infor)-1 {
 			prefix = "└"
 		}
+
 		fmt.Fprintf(&sb, "%s%-29s %-8s %-12s %-10d %s\n",
 			yellow(prefix+" "),
 			info.Name,
@@ -123,5 +130,6 @@ func formatDeckhousePods(infor []deckhousePod) string {
 			info.Restarts,
 			info.Age)
 	}
+
 	return sb.String()
 }

--- a/internal/status/objects/queue/deckhousequeue.go
+++ b/internal/status/objects/queue/deckhousequeue.go
@@ -31,6 +31,7 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, kubeCl kubernetes.Interface, restConfig *rest.Config) statusresult.StatusResult {
 	fetcher := queuefetcher.New(kubeCl, restConfig)
+
 	queue, err := fetcher.GetQueue(ctx)
 	if err != nil {
 		return statusresult.StatusResult{
@@ -39,6 +40,7 @@ func Status(ctx context.Context, kubeCl kubernetes.Interface, restConfig *rest.C
 			Output: color.RedString("Error getting Deckhouse queue: %v", err),
 		}
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse Queue",
 		Level:  0,
@@ -69,14 +71,17 @@ func formatDeckhouseQueue(queue queuefetcher.DeckhouseQueue) string {
 		if i == len(queue.Summary)-1 {
 			prefix = "└"
 		}
+
 		if strings.HasPrefix(sum, "Summary:") {
 			sb.WriteString(yellow(prefix+" ") + blue(sum) + "\n")
 		} else {
 			sb.WriteString(yellow(prefix+" ") + sum + "\n")
 		}
 	}
+
 	if queue.Header == "" && len(queue.Tasks) == 0 && len(queue.Summary) == 0 {
 		sb.WriteString(yellow("│ ") + "no queue information available\n")
 	}
+
 	return sb.String()
 }

--- a/internal/status/objects/registry/deckhouseregistry.go
+++ b/internal/status/objects/registry/deckhouseregistry.go
@@ -32,10 +32,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, kubeCl kubernetes.Interface) statusresult.StatusResult {
 	info, err := getDeckhouseRegistry(ctx, kubeCl)
+
 	output := color.RedString("Error getting Deckhouse registry: %v\n", err)
 	if err == nil {
 		output = formatDeckhouseRegistry(info)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse Registry",
 		Level:  0,
@@ -54,6 +56,7 @@ func getDeckhouseRegistry(ctx context.Context, kubeCl kubernetes.Interface) (dec
 	if err != nil {
 		return deckhouseRegistry{}, fmt.Errorf("failed to get secret: %w", err)
 	}
+
 	return deckhouseRegistryProcessing(secret)
 }
 
@@ -64,12 +67,15 @@ func deckhouseRegistryProcessing(secret *v1.Secret) (deckhouseRegistry, error) {
 	if registryData, found := secret.Data["imagesRegistry"]; found {
 		dr.Registry = string(registryData)
 	}
+
 	if schemeData, found := secret.Data["scheme"]; found {
 		dr.Scheme = string(schemeData)
 	}
+
 	if dr.Registry == "" {
 		return deckhouseRegistry{}, fmt.Errorf("'imagesRegistry' not found")
 	}
+
 	if dr.Scheme == "" {
 		return deckhouseRegistry{}, fmt.Errorf("'scheme' not found")
 	}
@@ -85,6 +91,7 @@ func formatDeckhouseRegistry(info deckhouseRegistry) string {
 	if strings.TrimSpace(info.Registry) != "" {
 		registry = info.Registry
 	}
+
 	scheme := "not found"
 	if strings.TrimSpace(info.Scheme) != "" {
 		scheme = info.Scheme

--- a/internal/status/objects/releases/releases.go
+++ b/internal/status/objects/releases/releases.go
@@ -34,10 +34,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, dynamicClient dynamic.Interface) statusresult.StatusResult {
 	releases, err := getDeckhouseReleases(ctx, dynamicClient)
+
 	output := color.RedString("Error getting Deckhouse releases: %v\n", err)
 	if err == nil {
 		output = formatDeckhouseReleases(releases)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse Releases",
 		Level:  0,
@@ -71,6 +73,7 @@ func getDeckhouseReleases(ctx context.Context, dynamicCl dynamic.Interface) ([]D
 		if !ok {
 			continue
 		}
+
 		releases = append(releases, release)
 	}
 
@@ -111,6 +114,7 @@ func formatDeckhouseReleases(releases []DeckhouseRelease) string {
 	}
 
 	var sb strings.Builder
+
 	yellow := color.New(color.FgYellow).SprintFunc()
 
 	sb.WriteString(yellow("┌ Deckhouse Releases:\n"))
@@ -132,5 +136,6 @@ func formatDeckhouseReleases(releases []DeckhouseRelease) string {
 			timeAgo,
 			message)
 	}
+
 	return sb.String()
 }

--- a/internal/status/objects/settings/deckhouse_settings.go
+++ b/internal/status/objects/settings/deckhouse_settings.go
@@ -34,10 +34,12 @@ import (
 // Status orchestrates retrieval, processing, and formatting of the resource's current status.
 func Status(ctx context.Context, dynamicClient dynamic.Interface) statusresult.StatusResult {
 	settings, err := getModuleConfigSettings(ctx, dynamicClient)
+
 	output := color.RedString("Error getting ModuleConfig settings: %v", err)
 	if err == nil {
 		output = formatModuleConfigSettings(settings)
 	}
+
 	return statusresult.StatusResult{
 		Title:  "Deckhouse ModuleConfig",
 		Level:  0,
@@ -87,6 +89,7 @@ func configSettingsFromMapProcessing(settings map[string]interface{}) []ConfigSe
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Key < result[j].Key
 	})
+
 	return result
 }
 
@@ -101,9 +104,11 @@ func configSettingsProcessing(key string, data interface{}) ConfigSetting {
 		for k, v := range m {
 			children = append(children, configSettingsProcessing(k, v))
 		}
+
 		sort.Slice(children, func(i, j int) bool {
 			return children[i].Key < children[j].Key
 		})
+
 		return ConfigSetting{
 			Key:      key,
 			Children: children,
@@ -117,6 +122,7 @@ func configSettingsProcessing(key string, data interface{}) ConfigSetting {
 			itemKey := fmt.Sprintf("#%d", i)
 			items = append(items, configSettingsProcessing(itemKey, elem))
 		}
+
 		return ConfigSetting{
 			Key:   key,
 			Items: items,
@@ -143,6 +149,7 @@ func formatModuleConfigSettings(settings []ConfigSetting) string {
 		isLast := i == len(settings)-1
 		sb.WriteString(formatSettingLine(setting, "", nil, isLast, 0))
 	}
+
 	return sb.String()
 }
 
@@ -156,6 +163,7 @@ func formatSettingLine(setting ConfigSetting, indent string, prefixStack []bool,
 	if isLast {
 		lineOperator = "└"
 	}
+
 	coloredLineOperator := lineOperator
 	if level == 0 {
 		coloredLineOperator = color.New(color.FgYellow).Sprint(lineOperator)
@@ -170,11 +178,14 @@ func formatSettingLine(setting ConfigSetting, indent string, prefixStack []bool,
 	// Map/Struct (has "children").
 	if len(setting.Children) > 0 {
 		fmt.Fprintf(&sb, "%s%s %s:\n", prefix, coloredLineOperator, setting.Key)
+
 		newPrefixStack := append([]bool{}, prefixStack...)
+
 		newPrefixStack = append(newPrefixStack, !isLast)
 		for i, child := range setting.Children {
 			sb.WriteString(formatSettingLine(child, indent+"    ", newPrefixStack, i == len(setting.Children)-1, level+1))
 		}
+
 		return sb.String()
 	}
 
@@ -182,24 +193,31 @@ func formatSettingLine(setting ConfigSetting, indent string, prefixStack []bool,
 	if len(setting.Items) > 0 {
 		allScalars := areAllItemsScalars(setting.Items)
 		fmt.Fprintf(&sb, "%s%s %s:\n", prefix, coloredLineOperator, setting.Key)
+
 		newPrefixStack := append([]bool{}, prefixStack...)
 		newPrefixStack = append(newPrefixStack, !isLast)
+
 		if allScalars {
 			for i, item := range setting.Items {
 				fmt.Fprintf(&sb, "%s│   %s %s\n", prefix, mapLineOp(i == len(setting.Items)-1), item.Value)
 			}
+
 			return sb.String()
 		}
+
 		indentForArray := indent + "    "
+
 		for i, item := range setting.Items {
 			itemIsLast := i == len(setting.Items)-1
 			for j, child := range item.Children {
 				sb.WriteString(formatSettingLine(child, indentForArray, newPrefixStack, j == len(item.Children)-1, level+2))
 			}
+
 			if len(item.Children) == 0 && item.Value != "" {
 				fmt.Fprintf(&sb, "%s│   %s %s\n", prefix, mapLineOp(itemIsLast), item.Value)
 			}
 		}
+
 		return sb.String()
 	}
 
@@ -211,7 +229,9 @@ func buildPrefix(prefixStack []bool) string {
 	if len(prefixStack) == 0 {
 		return ""
 	}
+
 	var sb strings.Builder
+
 	for _, needPipe := range prefixStack {
 		if needPipe {
 			sb.WriteString("│   ")
@@ -219,6 +239,7 @@ func buildPrefix(prefixStack []bool) string {
 			sb.WriteString("    ")
 		}
 	}
+
 	return sb.String()
 }
 
@@ -229,6 +250,7 @@ func areAllItemsScalars(items []ConfigSetting) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -237,5 +259,6 @@ func mapLineOp(isLast bool) string {
 	if isLast {
 		return "└"
 	}
+
 	return "├"
 }

--- a/internal/status/tools/queuefetcher/queuefetcher.go
+++ b/internal/status/tools/queuefetcher/queuefetcher.go
@@ -83,9 +83,11 @@ func (q *DeckhouseQueueFetcher) findLeaderPod(ctx context.Context) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods: %w", err)
 	}
+
 	if len(pods.Items) == 0 {
 		return "", fmt.Errorf("no Deckhouse leader pods found with label %s", labelSelector)
 	}
+
 	return pods.Items[0].Name, nil
 }
 
@@ -108,7 +110,9 @@ func (q *DeckhouseQueueFetcher) execQueueList(ctx context.Context, podName strin
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize SPDY executor: %w", err)
 	}
+
 	var stdout, stderr strings.Builder
+
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: &stdout,
 		Stderr: &stderr,
@@ -116,9 +120,11 @@ func (q *DeckhouseQueueFetcher) execQueueList(ctx context.Context, podName strin
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command: %w", err)
 	}
+
 	if stderr.Len() > 0 {
 		return "", fmt.Errorf("stderr: %s", stderr.String())
 	}
+
 	return stdout.String(), nil
 }
 
@@ -126,8 +132,12 @@ func (q *DeckhouseQueueFetcher) execQueueList(ctx context.Context, podName strin
 func processDeckhouseQueue(raw string) DeckhouseQueue {
 	lines := strings.Split(strings.TrimRight(raw, "\n"), "\n")
 	header := ""
-	var tasks []DeckhouseQueueTask
-	var summary []string
+
+	var (
+		tasks   []DeckhouseQueueTask
+		summary []string
+	)
+
 	inSummary := false
 	taskRegexp := regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
 
@@ -136,11 +146,13 @@ func processDeckhouseQueue(raw string) DeckhouseQueue {
 		if line == "" {
 			continue
 		}
+
 		switch {
 		case i == 0 && strings.HasPrefix(line, "Queue "):
 			header = line
 		case strings.HasPrefix(line, "Summary:"):
 			inSummary = true
+
 			summary = append(summary, line)
 		case inSummary:
 			summary = append(summary, line)
@@ -155,6 +167,7 @@ func processDeckhouseQueue(raw string) DeckhouseQueue {
 			summary = append(summary, line)
 		}
 	}
+
 	return DeckhouseQueue{
 		Header:  header,
 		Tasks:   tasks,

--- a/internal/status/tools/timeutil/timeutil.go
+++ b/internal/status/tools/timeutil/timeutil.go
@@ -26,10 +26,12 @@ func AgeAgo(t time.Time) string {
 	if t.IsZero() {
 		return "<unknown>"
 	}
+
 	duration := time.Since(t)
 	if duration < 0 {
 		duration = 0
 	}
+
 	return formatDuration(duration)
 }
 
@@ -38,10 +40,12 @@ func AgeAgoStr(ts string) string {
 	if ts == "" {
 		return "<unknown>"
 	}
+
 	t, err := time.Parse(time.RFC3339, ts)
 	if err != nil {
 		return "Parse Error"
 	}
+
 	return AgeAgo(t)
 }
 
@@ -57,16 +61,19 @@ func formatDuration(d time.Duration) string {
 		if hours > 0 {
 			return fmt.Sprintf("%dd %dh", days, hours)
 		}
+
 		return fmt.Sprintf("%dd", days)
 	case hours > 0:
 		if minutes > 0 {
 			return fmt.Sprintf("%dh %dm", hours, minutes)
 		}
+
 		return fmt.Sprintf("%dh", hours)
 	case minutes > 0:
 		if seconds > 0 {
 			return fmt.Sprintf("%dm %ds", minutes, seconds)
 		}
+
 		return fmt.Sprintf("%dm", minutes)
 	default:
 		return fmt.Sprintf("%ds", seconds)

--- a/internal/system/cmd/collect-debug-info/collect-debug-info.go
+++ b/internal/system/cmd/collect-debug-info/collect-debug-info.go
@@ -78,11 +78,13 @@ func NewCommand() *cobra.Command {
 	collectDebugInfoCmd.Flags().BoolVarP(&listExclude, "list-exclude", "l", false, "List all files that can be excluded from the debug archive")
 	collectDebugInfoCmd.Flags().DurationVar(&commandTimeout, "command-timeout", 2*time.Minute, "Timeout for each individual debug command execution")
 	collectDebugInfoCmd.Flags().DurationVar(&requestInterval, "request-interval", 0, "Minimum interval between debug command executions to avoid overloading the cluster (e.g. 200ms, 500ms, 1s). Zero disables rate limiting (default 0s)")
+
 	return collectDebugInfoCmd
 }
 
 func printExcludableFiles() {
 	fmt.Println("List of possible data to exclude:")
+
 	for _, fileName := range debugtar.GetExcludableFiles() {
 		fmt.Println(fileName)
 	}
@@ -112,5 +114,6 @@ func collectDebugInfo(cmd *cobra.Command, listExclude bool, excludeList []string
 	if err = debugtar.Tarball(config, kubeCl, excludeList, commandTimeout, requestInterval); err != nil {
 		return fmt.Errorf("Error collecting debug info: %w", err)
 	}
+
 	return nil
 }

--- a/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
+++ b/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
@@ -374,15 +374,19 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 	}
 
 	var tickCh <-chan time.Time
+
 	if requestInterval > 0 {
 		ticker := time.NewTicker(requestInterval)
 		defer ticker.Stop()
+
 		tickCh = ticker.C
 	}
 
 	var stdout, stderr bytes.Buffer
+
 	gzipWriter := gzip.NewWriter(os.Stdout)
 	defer gzipWriter.Close()
+
 	tarWriter := tar.NewWriter(gzipWriter)
 	defer tarWriter.Close()
 
@@ -396,6 +400,7 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 		}
 
 		fullCommand := append([]string{cmd.Cmd}, cmd.Args...)
+
 		executor, err := utilk8s.ExecInPod(config, kubeCl, fullCommand, podName, namespace, containerName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: failed to create executor for %s: %v\n", cmd.File, err)
@@ -407,6 +412,7 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 			Stdout: &stdout,
 			Stderr: &stderr,
 		})
+
 		cancel()
 
 		if streamErr != nil {
@@ -420,9 +426,11 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 		if err = cmd.writeToTar(tarWriter, stdout.Bytes()); err != nil {
 			return fmt.Errorf("failed to write tar file %s: %w", cmd.File, err)
 		}
+
 		stdout.Reset()
 		stderr.Reset()
 	}
+
 	return nil
 }
 
@@ -434,12 +442,14 @@ func fetchActiveModules(
 	timeout time.Duration,
 ) (map[string]bool, error) {
 	cmdLine := []string{"kubectl", "get", "module", "-o", "json"}
+
 	executor, err := utilk8s.ExecInPod(config, kubeCl, cmdLine, podName, namespace, containerName)
 	if err != nil {
 		return nil, fmt.Errorf("create executor: %w", err)
 	}
 
 	var stdout, stderr bytes.Buffer
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -461,6 +471,7 @@ func fetchActiveModules(
 			active[item.Metadata.Name] = true
 		}
 	}
+
 	return active, nil
 }
 
@@ -471,9 +482,11 @@ func filterAndExpandCommands(commands []Command, activeModules map[string]bool) 
 			result = append(result, cmd)
 			continue
 		}
+
 		if len(activeModules) == 0 {
 			continue
 		}
+
 		if cmd.ExpandPerModule {
 			matchedModules := matchingModules(activeModules, cmd.RequiredModule)
 			for _, moduleName := range matchedModules {
@@ -492,17 +505,21 @@ func filterAndExpandCommands(commands []Command, activeModules map[string]bool) 
 			}
 		}
 	}
+
 	return result
 }
 
 func matchingModules(activeModules map[string]bool, required string) []string {
 	var matched []string
+
 	for name := range activeModules {
 		if isModuleMatch(name, required) {
 			matched = append(matched, name)
 		}
 	}
+
 	sort.Strings(matched)
+
 	return matched
 }
 
@@ -515,6 +532,7 @@ func replaceModuleName(args []string, moduleName string) []string {
 	for i, arg := range args {
 		expanded[i] = strings.ReplaceAll(arg, "{module-name}", moduleName)
 	}
+
 	return expanded
 }
 
@@ -540,6 +558,7 @@ func excludeBaseName(file string) string {
 	name := strings.TrimSuffix(file, ".json")
 	name = strings.TrimSuffix(name, ".txt")
 	name = strings.TrimSuffix(name, "-{module-name}")
+
 	return name
 }
 
@@ -549,6 +568,7 @@ func isFileExcluded(fileName string, excludeMap map[string]bool) bool {
 	}
 
 	base := strings.TrimSuffix(fileName, ".json")
+
 	base = strings.TrimSuffix(base, ".txt")
 	if excludeMap[base] {
 		return true
@@ -559,11 +579,13 @@ func isFileExcluded(fileName string, excludeMap map[string]bool) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
 func GetExcludableFiles() []string {
 	seen := make(map[string]bool, len(debugCommands))
+
 	files := make([]string, 0, len(debugCommands))
 	for _, cmd := range debugCommands {
 		name := excludeBaseName(cmd.File)
@@ -572,6 +594,8 @@ func GetExcludableFiles() []string {
 			files = append(files, name)
 		}
 	}
+
 	sort.Strings(files)
+
 	return files
 }

--- a/internal/system/cmd/edit/cluster-configuration/cluster-configuration.go
+++ b/internal/system/cmd/edit/cluster-configuration/cluster-configuration.go
@@ -41,6 +41,7 @@ func NewCommand() *cobra.Command {
 		RunE:          editClusterConfig,
 	}
 	flags.AddFlags(clusterConfigurationCmd.Flags())
+
 	return clusterConfigurationCmd
 }
 
@@ -49,5 +50,6 @@ func editClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error updating secret: %w", err)
 	}
+
 	return err
 }

--- a/internal/system/cmd/edit/editconfig/editconfig.go
+++ b/internal/system/cmd/edit/editconfig/editconfig.go
@@ -49,6 +49,7 @@ func BaseEditConfigCMD(cmd *cobra.Command, _ string, secret, dataKey string) err
 	if err != nil {
 		return err
 	}
+
 	defer func() {
 		_ = tempFile.Close()
 		_ = os.Remove(tempFile.Name())
@@ -58,6 +59,7 @@ func BaseEditConfigCMD(cmd *cobra.Command, _ string, secret, dataKey string) err
 	cmdExec.Stdin = os.Stdin
 	cmdExec.Stdout = os.Stdout
 	cmdExec.Stderr = os.Stderr
+
 	err = cmdExec.Run()
 	if err != nil {
 		return fmt.Errorf("Error opening in editor: %w", err)
@@ -76,6 +78,7 @@ func BaseEditConfigCMD(cmd *cobra.Command, _ string, secret, dataKey string) err
 	if err != nil {
 		return fmt.Errorf("Error encoding secret: %w", err)
 	}
+
 	_, err = kubeCl.CoreV1().
 		Secrets("kube-system").Patch(context.TODO(), secret, types.MergePatchType, encodedValue, metav1.PatchOptions{})
 	if err != nil {
@@ -83,6 +86,7 @@ func BaseEditConfigCMD(cmd *cobra.Command, _ string, secret, dataKey string) err
 	}
 
 	fmt.Println("Secret updated successfully")
+
 	return err
 }
 
@@ -96,6 +100,7 @@ func writeSecretTmp(secretConfig *v1.Secret, dataKey string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error writing decoded data to file: %w", err)
 	}
+
 	if err = tempFile.Sync(); err != nil {
 		return nil, fmt.Errorf("Sync temp file buffers to disk: %w", err)
 	}

--- a/internal/system/cmd/edit/flags/flags.go
+++ b/internal/system/cmd/edit/flags/flags.go
@@ -35,5 +35,6 @@ func defaultEditor() string {
 	if ed == "" {
 		ed = "vi"
 	}
+
 	return ed
 }

--- a/internal/system/cmd/edit/provider-cluster-configuration/provider-cluster-configuration.go
+++ b/internal/system/cmd/edit/provider-cluster-configuration/provider-cluster-configuration.go
@@ -41,6 +41,7 @@ func NewCommand() *cobra.Command {
 		RunE:          editProviderClusterConfig,
 	}
 	flags.AddFlags(providerClusterConfigurationCmd.Flags())
+
 	return providerClusterConfigurationCmd
 }
 
@@ -49,5 +50,6 @@ func editProviderClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error updating secret: %w", err)
 	}
+
 	return err
 }

--- a/internal/system/cmd/edit/static-cluster-configuration/static-cluster-configuration.go
+++ b/internal/system/cmd/edit/static-cluster-configuration/static-cluster-configuration.go
@@ -41,6 +41,7 @@ func NewCommand() *cobra.Command {
 		RunE:          editStaticClusterConfig,
 	}
 	flags.AddFlags(staticClusterConfigurationCmd.Flags())
+
 	return staticClusterConfigurationCmd
 }
 
@@ -49,5 +50,6 @@ func editStaticClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error updating secret: %w", err)
 	}
+
 	return err
 }

--- a/internal/system/cmd/get/cluster-configuration/cluster-configuration.go
+++ b/internal/system/cmd/get/cluster-configuration/cluster-configuration.go
@@ -39,6 +39,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          getClusterConfig,
 	}
+
 	return clusterConfigurationCmd
 }
 
@@ -47,5 +48,6 @@ func getClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting secret: %w", err)
 	}
+
 	return nil
 }

--- a/internal/system/cmd/get/getconfig/getconfig.go
+++ b/internal/system/cmd/get/getconfig/getconfig.go
@@ -58,5 +58,6 @@ func BaseGetConfigCMD(cmd *cobra.Command, _ string, secret, dataKey string) erro
 	}
 
 	fmt.Print(string(data))
+
 	return nil
 }

--- a/internal/system/cmd/get/provider-cluster-configuration/provider-cluster-configuration.go
+++ b/internal/system/cmd/get/provider-cluster-configuration/provider-cluster-configuration.go
@@ -39,6 +39,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          getProviderClusterConfig,
 	}
+
 	return providerClusterConfigurationCmd
 }
 
@@ -47,5 +48,6 @@ func getProviderClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting secret: %w", err)
 	}
+
 	return nil
 }

--- a/internal/system/cmd/get/static-cluster-configuration/static-cluster-configuration.go
+++ b/internal/system/cmd/get/static-cluster-configuration/static-cluster-configuration.go
@@ -39,6 +39,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          getStaticClusterConfig,
 	}
+
 	return staticClusterConfigurationCmd
 }
 
@@ -47,5 +48,6 @@ func getStaticClusterConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting secret: %w", err)
 	}
+
 	return nil
 }

--- a/internal/system/cmd/logs/logs.go
+++ b/internal/system/cmd/logs/logs.go
@@ -48,6 +48,7 @@ func NewCommand() *cobra.Command {
 		RunE:          getLogDeckhouse,
 	}
 	AddFlags(logCmd.Flags())
+
 	return logCmd
 }
 
@@ -71,6 +72,7 @@ func getLogDeckhouse(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to get Deckhouse pod: %w", err)
 	}
+
 	logOptions := &v1.PodLogOptions{
 		Container: "deckhouse",
 		Follow:    Follow,
@@ -78,16 +80,19 @@ func getLogDeckhouse(cmd *cobra.Command, _ []string) error {
 	if Tail > 0 {
 		logOptions.TailLines = &Tail
 	}
+
 	if Since != "" {
 		duration, _ := time.ParseDuration(Since)
 		logOptions.SinceSeconds = ptr.To(int64(duration.Seconds()))
 	}
+
 	if SinceTime != "" {
 		t, _ := time.Parse(time.DateTime, SinceTime)
 		logOptions.SinceTime = &metav1.Time{Time: t}
 	}
 
 	req := kubeCl.CoreV1().Pods("d8-system").GetLogs(podName, logOptions)
+
 	stream, err := req.Stream(context.Background())
 	if err != nil {
 		return fmt.Errorf("error opening log stream: %v", err)
@@ -99,5 +104,6 @@ func getLogDeckhouse(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf(
 			"error reading logs: %v", err)
 	}
+
 	return nil
 }

--- a/internal/system/cmd/logs/validation.go
+++ b/internal/system/cmd/logs/validation.go
@@ -27,18 +27,21 @@ func ValidateParameters(_ *cobra.Command, _ []string) error {
 	if Tail < -1 {
 		return fmt.Errorf("invalid --tail must be greater than or equal to -1")
 	}
+
 	if Since != "" {
 		_, err := time.ParseDuration(Since)
 		if err != nil {
 			return fmt.Errorf("invalid --since value: %v", err)
 		}
 	}
+
 	if SinceTime != "" {
 		_, err := time.Parse(time.DateTime, SinceTime)
 		if err != nil {
 			return fmt.Errorf("invalid --since-time value: %v", err)
 		}
 	}
+
 	if Since != "" && SinceTime != "" {
 		return fmt.Errorf("only one of --since-time or --since may be used")
 	}

--- a/internal/system/cmd/module/api/v1alpha1/module_release.go
+++ b/internal/system/cmd/module/api/v1alpha1/module_release.go
@@ -77,10 +77,12 @@ type ModuleReleaseStatus struct {
 // ModuleReleaseFromUnstructured converts an unstructured object to ModuleRelease.
 func ModuleReleaseFromUnstructured(obj *unstructured.Unstructured) (*ModuleRelease, error) {
 	var release ModuleRelease
+
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &release)
 	if err != nil {
 		return nil, err
 	}
+
 	return &release, nil
 }
 

--- a/internal/system/cmd/module/cli/completion.go
+++ b/internal/system/cmd/module/cli/completion.go
@@ -56,12 +56,14 @@ func completeModuleReleaseAndVersion(cmd *cobra.Command, args []string, toComple
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
 		return filterByPrefix(modules, toComplete), cobra.ShellCompDirectiveNoFileComp
 	case completingVersion:
 		versions, err := modulereleases.FindVersions(dynamicClient, args[0], match)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
 		return filterVersionsByPrefix(versions, toComplete), cobra.ShellCompDirectiveNoFileComp
 	default:
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -73,12 +75,15 @@ func filterByPrefix(items []string, prefix string) []string {
 	if prefix == "" {
 		return items
 	}
+
 	var filtered []string
+
 	for _, item := range items {
 		if strings.HasPrefix(item, prefix) {
 			filtered = append(filtered, item)
 		}
 	}
+
 	return filtered
 }
 
@@ -96,6 +101,7 @@ func filterVersionsByPrefix(versions []string, prefix string) []string {
 	returnWithV := strings.HasPrefix(prefix, "v")
 
 	var filtered []string
+
 	for _, version := range versions {
 		versionWithoutV := strings.TrimPrefix(version, "v")
 		if strings.HasPrefix(versionWithoutV, prefixWithoutV) {
@@ -106,5 +112,6 @@ func filterVersionsByPrefix(versions []string, prefix string) []string {
 			}
 		}
 	}
+
 	return filtered
 }

--- a/internal/system/cmd/module/cli/output.go
+++ b/internal/system/cmd/module/cli/output.go
@@ -50,6 +50,7 @@ func SuggestSuitableReleasesOnNotFound(dynamicClient dynamic.Interface, moduleNa
 	}
 
 	fmt.Fprintln(os.Stderr)
+
 	return ReleaseNotFoundError(moduleName, version)
 }
 
@@ -66,9 +67,11 @@ func PrintNearestVersionSuggestions(releases []modulereleases.ModuleReleaseInfo,
 	}
 
 	fmt.Fprintln(os.Stderr, "\nPerhaps you meant one of these?")
+
 	if nearest.Lower != nil {
 		fmt.Fprintf(os.Stderr, "   • %s (previous version)\n", nearest.Lower.Version)
 	}
+
 	if nearest.Upper != nil {
 		fmt.Fprintf(os.Stderr, "   • %s (next version)\n", nearest.Upper.Version)
 	}
@@ -77,6 +80,7 @@ func PrintNearestVersionSuggestions(releases []modulereleases.ModuleReleaseInfo,
 // PrintPendingReleases prints a list of available pending releases.
 func PrintPendingReleases(releases []modulereleases.ModuleReleaseInfo) {
 	fmt.Fprintln(os.Stderr, "\nAvailable pending releases:")
+
 	for _, r := range releases {
 		fmt.Fprintf(os.Stderr, "   • %s\n", r.Version)
 	}
@@ -89,6 +93,7 @@ func PrintNoReleasesHelp(dynamicClient dynamic.Interface, moduleName string) {
 	if len(allReleases) > 0 {
 		fmt.Fprintf(os.Stderr, "\nNo pending releases available for module '%s'.\n", moduleName)
 		fmt.Fprintln(os.Stderr, "All releases may already be deployed.")
+
 		return
 	}
 
@@ -110,7 +115,9 @@ func PrintSimilarModules(dynamicClient dynamic.Interface, moduleName string) {
 
 	// Find modules with similar prefix
 	prefix := moduleName[:min(similarModulePrefixLen, len(moduleName))]
+
 	var similar []string
+
 	for _, m := range modules {
 		if strings.HasPrefix(m, prefix) {
 			similar = append(similar, m)
@@ -119,6 +126,7 @@ func PrintSimilarModules(dynamicClient dynamic.Interface, moduleName string) {
 
 	if len(similar) > 0 {
 		fmt.Fprintln(os.Stderr, "\nSimilar modules:")
+
 		for _, m := range similar {
 			fmt.Fprintf(os.Stderr, "   • %s\n", m)
 		}
@@ -126,6 +134,7 @@ func PrintSimilarModules(dynamicClient dynamic.Interface, moduleName string) {
 
 	if len(modules) <= maxModulesToList {
 		fmt.Fprintln(os.Stderr, "\nAll available modules:")
+
 		for _, m := range modules {
 			fmt.Fprintf(os.Stderr, "   • %s\n", m)
 		}

--- a/internal/system/cmd/module/cmd/applynow/applynow.go
+++ b/internal/system/cmd/module/cmd/applynow/applynow.go
@@ -80,6 +80,7 @@ func applyNowRelease(cmd *cobra.Command, args []string) error {
 		if errors.IsNotFound(err) {
 			return cli.SuggestSuitableReleasesOnNotFound(dynamicClient, moduleName, version, modulereleases.CanBeAppliedNow)
 		}
+
 		return fmt.Errorf("failed to get module release: %w", err)
 	}
 
@@ -87,9 +88,11 @@ func applyNowRelease(cmd *cobra.Command, args []string) error {
 	if release.IsApplyNow {
 		fmt.Fprintf(os.Stderr, "%s Module release '%s' already has apply-now annotation.\n", cli.MsgInfo, release.Name)
 		fmt.Fprintf(os.Stderr, "   Phase: %s\n", release.Phase)
+
 		if release.Message != "" {
 			fmt.Fprintf(os.Stderr, "   Message: %s\n", release.Message)
 		}
+
 		return nil
 	}
 
@@ -97,10 +100,13 @@ func applyNowRelease(cmd *cobra.Command, args []string) error {
 	if release.Phase != v1alpha1.ModuleReleasePhasePending {
 		fmt.Fprintf(os.Stderr, "%s Module release '%s' is not in Pending phase.\n", cli.MsgWarn, release.Name)
 		fmt.Fprintf(os.Stderr, "   Current phase: %s\n", release.Phase)
+
 		if release.Message != "" {
 			fmt.Fprintf(os.Stderr, "   Message: %s\n", release.Message)
 		}
+
 		fmt.Fprintln(os.Stderr, "\nOnly releases in 'Pending' phase can be applied.")
+
 		return nil
 	}
 
@@ -109,6 +115,7 @@ func applyNowRelease(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to set apply-now annotation: %w", err)
 	}
+
 	fmt.Printf("%s Module release '%s' marked for immediate deployment.\n", cli.MsgInfo, release.Name)
 	fmt.Println("   The release will be applied immediately, bypassing update windows.")
 

--- a/internal/system/cmd/module/cmd/approve/approve.go
+++ b/internal/system/cmd/module/cmd/approve/approve.go
@@ -80,6 +80,7 @@ func approveRelease(cmd *cobra.Command, args []string) error {
 		if errors.IsNotFound(err) {
 			return cli.SuggestSuitableReleasesOnNotFound(dynamicClient, moduleName, version, modulereleases.CanBeApproved)
 		}
+
 		return fmt.Errorf("failed to get module release: %w", err)
 	}
 
@@ -87,9 +88,11 @@ func approveRelease(cmd *cobra.Command, args []string) error {
 	if release.IsApproved {
 		fmt.Fprintf(os.Stderr, "%s Module release '%s' is already approved.\n", cli.MsgInfo, release.Name)
 		fmt.Fprintf(os.Stderr, "   Phase: %s\n", release.Phase)
+
 		if release.Message != "" {
 			fmt.Fprintf(os.Stderr, "   Message: %s\n", release.Message)
 		}
+
 		return nil
 	}
 
@@ -97,10 +100,13 @@ func approveRelease(cmd *cobra.Command, args []string) error {
 	if release.Phase != v1alpha1.ModuleReleasePhasePending {
 		fmt.Fprintf(os.Stderr, "%s Module release '%s' is not in Pending phase.\n", cli.MsgWarn, release.Name)
 		fmt.Fprintf(os.Stderr, "   Current phase: %s\n", release.Phase)
+
 		if release.Message != "" {
 			fmt.Fprintf(os.Stderr, "   Message: %s\n", release.Message)
 		}
+
 		fmt.Fprintln(os.Stderr, "\nOnly releases in 'Pending' phase can be approved.")
+
 		return nil
 	}
 
@@ -109,6 +115,7 @@ func approveRelease(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to approve module release: %w", err)
 	}
+
 	fmt.Printf("%s Module release '%s' approved.\n", cli.MsgInfo, release.Name)
 	fmt.Println("   The release will be deployed according to the update policy.")
 

--- a/internal/system/cmd/module/cmd/disable/disable.go
+++ b/internal/system/cmd/module/cmd/disable/disable.go
@@ -42,6 +42,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          disableModule,
 	}
+
 	return disableCmd
 }
 
@@ -49,6 +50,7 @@ func disableModule(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
+
 	moduleName := args[0]
 
 	dynamicClient, err := cli.GetDynamicClient(cmd)

--- a/internal/system/cmd/module/cmd/enable/enable.go
+++ b/internal/system/cmd/module/cmd/enable/enable.go
@@ -43,6 +43,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          enableModule,
 	}
+
 	return enableCmd
 }
 
@@ -50,6 +51,7 @@ func enableModule(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
+
 	moduleName := args[0]
 
 	dynamicClient, err := cli.GetDynamicClient(cmd)
@@ -71,8 +73,10 @@ func enableModule(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "Or run:")
 			fmt.Fprintln(os.Stderr, "  kubectl patch mc deckhouse --type=merge -p '{\"spec\":{\"settings\":{\"allowExperimentalModules\":true}}}'")
+
 			return fmt.Errorf("module '%s' is experimental", expErr.ModuleName)
 		}
+
 		return fmt.Errorf("failed to enable module: %w", err)
 	}
 

--- a/internal/system/cmd/module/cmd/list/list.go
+++ b/internal/system/cmd/module/cmd/list/list.go
@@ -42,6 +42,7 @@ func NewCommand() *cobra.Command {
 		RunE:          listModule,
 	}
 	flags.AddFlags(listCmd.Flags())
+
 	return listCmd
 }
 

--- a/internal/system/cmd/module/cmd/snapshots/snapshots.go
+++ b/internal/system/cmd/module/cmd/snapshots/snapshots.go
@@ -41,6 +41,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          snapshotsModule,
 	}
+
 	return snapshotsCmd
 }
 
@@ -63,6 +64,7 @@ func snapshotsModule(cmd *cobra.Command, args []string) error {
 	}
 
 	pathFromOption := fmt.Sprintf("%s/snapshots.yaml", moduleName)
+
 	err = deckhouse.QueryAPI(config, kubeCl, pathFromOption)
 	if err != nil {
 		return fmt.Errorf("Error snapshot module: %w", err)

--- a/internal/system/cmd/module/cmd/values/values.go
+++ b/internal/system/cmd/module/cmd/values/values.go
@@ -41,6 +41,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          valuesModule,
 	}
+
 	return valuesCmd
 }
 
@@ -48,6 +49,7 @@ func valuesModule(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("this command requires exactly 1 argument: module name")
 	}
+
 	moduleName := args[0]
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
@@ -66,6 +68,7 @@ func valuesModule(cmd *cobra.Command, args []string) error {
 	}
 
 	pathFromOption := fmt.Sprintf("%s/values.yaml", moduleName)
+
 	err = deckhouse.QueryAPI(config, kubeCl, pathFromOption)
 	if err != nil {
 		return fmt.Errorf("Error print values: %w", err)

--- a/internal/system/cmd/module/deckhouse/api.go
+++ b/internal/system/cmd/module/deckhouse/api.go
@@ -30,17 +30,22 @@ func QueryAPI(config *rest.Config, kubeCl kubernetes.Interface, pathFromOption s
 
 	fullEndpointURL := fmt.Sprintf("%s://%s:%s/%s/%s", apiProtocol, apiEndpoint, apiPort, modulePath, pathFromOption)
 	getAPI := []string{"curl", fullEndpointURL}
+
 	podName, err := utilk8s.GetDeckhousePod(kubeCl)
 	if err != nil {
 		return err
 	}
+
 	executor, err := utilk8s.ExecInPod(config, kubeCl, getAPI, podName, namespace, containerName)
 	if err != nil {
 		return err
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
 	if err = executor.StreamWithContext(
 		context.Background(),
 		remotecommand.StreamOptions{
@@ -51,5 +56,6 @@ func QueryAPI(config *rest.Config, kubeCl kubernetes.Interface, pathFromOption s
 	}
 
 	fmt.Printf("%s\n", stdout.String())
+
 	return err
 }

--- a/internal/system/cmd/module/moduleconfig/enabled_state.go
+++ b/internal/system/cmd/module/moduleconfig/enabled_state.go
@@ -79,9 +79,11 @@ func SetEnabledState(dynamicClient dynamic.Interface, name string, state Enabled
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert the '%s' module config: %w", name, err)
 		}
+
 		if _, err = resourceClient.Create(ctx, obj, metav1.CreateOptions{}); err != nil {
 			return nil, parseOperationError(name, err)
 		}
+
 		return &Result{Status: Changed}, nil
 	}
 
@@ -95,9 +97,11 @@ func SetEnabledState(dynamicClient dynamic.Interface, name string, state Enabled
 	if err != nil {
 		return nil, err
 	}
+
 	if _, err = resourceClient.Patch(ctx, name, types.MergePatchType, enabledSpec, metav1.PatchOptions{}); err != nil {
 		return nil, parseOperationError(name, err)
 	}
+
 	return &Result{Status: Changed}, nil
 }
 
@@ -115,6 +119,7 @@ func isInState(obj *unstructured.Unstructured, desiredState EnabledState) bool {
 	}
 
 	desiredEnabled := desiredState == Enabled
+
 	return enabled == desiredEnabled
 }
 
@@ -129,6 +134,7 @@ func parseOperationError(moduleName string, err error) error {
 		if len(matches) > 1 {
 			return &ExperimentalModuleError{ModuleName: matches[1]}
 		}
+
 		return &ExperimentalModuleError{ModuleName: moduleName}
 	}
 
@@ -149,6 +155,7 @@ func createModuleConfig(name string, state EnabledState) (*unstructured.Unstruct
 		},
 	}
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newCfg)
+
 	return &unstructured.Unstructured{Object: content}, err
 }
 

--- a/internal/system/cmd/module/modulereleases/release_filter.go
+++ b/internal/system/cmd/module/modulereleases/release_filter.go
@@ -49,6 +49,7 @@ func FindReleases(dynamicClient dynamic.Interface, moduleName string, match Rele
 	}
 
 	var result []ModuleReleaseInfo
+
 	for _, r := range releases {
 		if match(r) {
 			result = append(result, r)
@@ -56,6 +57,7 @@ func FindReleases(dynamicClient dynamic.Interface, moduleName string, match Rele
 	}
 
 	SortReleasesByVersion(result)
+
 	return result, nil
 }
 
@@ -71,6 +73,7 @@ func FindVersions(dynamicClient dynamic.Interface, moduleName string, match Rele
 	for _, r := range releases {
 		versions = append(versions, NormalizeVersion(r.Version))
 	}
+
 	return versions, nil
 }
 
@@ -82,6 +85,7 @@ func ListModuleNames(dynamicClient dynamic.Interface) ([]string, error) {
 	}
 
 	moduleSet := make(map[string]struct{})
+
 	for _, r := range releases {
 		if r.ModuleName != "" {
 			moduleSet[r.ModuleName] = struct{}{}
@@ -92,6 +96,7 @@ func ListModuleNames(dynamicClient dynamic.Interface) ([]string, error) {
 	for m := range moduleSet {
 		modules = append(modules, m)
 	}
+
 	sort.Strings(modules)
 
 	return modules, nil

--- a/internal/system/cmd/module/modulereleases/version.go
+++ b/internal/system/cmd/module/modulereleases/version.go
@@ -28,9 +28,11 @@ func NormalizeVersion(version string) string {
 	if version == "" {
 		return version
 	}
+
 	if !strings.HasPrefix(version, "v") {
 		return "v" + version
 	}
+
 	return version
 }
 
@@ -45,10 +47,12 @@ type NearestVersions struct {
 func SortReleasesByVersion(releases []ModuleReleaseInfo) {
 	sort.Slice(releases, func(i, j int) bool {
 		vi, errI := semver.NewVersion(NormalizeVersion(releases[i].Version))
+
 		vj, errJ := semver.NewVersion(NormalizeVersion(releases[j].Version))
 		if errI != nil || errJ != nil {
 			return releases[i].Version < releases[j].Version
 		}
+
 		return vi.LessThan(vj)
 	})
 }
@@ -62,11 +66,14 @@ func FindNearestVersions(releases []ModuleReleaseInfo, targetVersion string) Nea
 		return NearestVersions{}
 	}
 
-	var result NearestVersions
-	var lowerVersion, upperVersion *semver.Version
+	var (
+		result                     NearestVersions
+		lowerVersion, upperVersion *semver.Version
+	)
 
 	for i := range releases {
 		r := &releases[i]
+
 		v, err := semver.NewVersion(NormalizeVersion(r.Version))
 		if err != nil {
 			continue
@@ -99,5 +106,6 @@ func extractVersionFromName(name, moduleName string) string {
 	if strings.HasPrefix(name, prefix) {
 		return strings.TrimPrefix(name, prefix)
 	}
+
 	return ""
 }

--- a/internal/system/cmd/package/cmd/scan/scan.go
+++ b/internal/system/cmd/package/cmd/scan/scan.go
@@ -112,12 +112,14 @@ func completeRepositoryNames(cmd *cobra.Command, args []string, toComplete strin
 	defer cancel()
 
 	repoClient := dynamicClient.Resource(packageRepositoryGVR)
+
 	list, err := repoClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	var names []string
+
 	for _, item := range list.Items {
 		name := item.GetName()
 		if strings.HasPrefix(name, toComplete) {
@@ -142,6 +144,7 @@ func runScan(cmd *cobra.Command, repositoryName string, opts *scanOptions) error
 		if errors.IsNotFound(err) {
 			return fmt.Errorf("PackageRepository '%s' not found", repositoryName)
 		}
+
 		return fmt.Errorf("failed to get PackageRepository: %w", err)
 	}
 
@@ -152,11 +155,14 @@ func runScan(cmd *cobra.Command, repositoryName string, opts *scanOptions) error
 		if err != nil {
 			return fmt.Errorf("failed to marshal operation: %w", err)
 		}
+
 		fmt.Printf("%s Would create PackageRepositoryOperation:\n---\n%s", cli.MsgInfo, string(yamlBytes))
+
 		return nil
 	}
 
 	operationClient := dynamicClient.Resource(packageRepositoryOperationGVR)
+
 	created, err := operationClient.Create(ctx, operation, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create PackageRepositoryOperation: %w", err)

--- a/internal/system/cmd/queue/flags/validation.go
+++ b/internal/system/cmd/queue/flags/validation.go
@@ -28,6 +28,7 @@ func ValidateParameters(cmd *cobra.Command, _ []string) error {
 		"yaml": true,
 		"text": true,
 	}
+
 	outputFormat, _ := cmd.Flags().GetString("output")
 	if _, valid := allowedOutput[outputFormat]; !valid {
 		return fmt.Errorf("please provide valid output: text, yaml, json. Got '%s', try --help", outputFormat)

--- a/internal/system/cmd/queue/list/list.go
+++ b/internal/system/cmd/queue/list/list.go
@@ -44,6 +44,7 @@ func NewCommand() *cobra.Command {
 	}
 	flags.AddFlags(listCmd.Flags())
 	AddFlags(listCmd.Flags())
+
 	return listCmd
 }
 

--- a/internal/system/cmd/queue/mainqueue/mainqueue.go
+++ b/internal/system/cmd/queue/mainqueue/mainqueue.go
@@ -43,6 +43,7 @@ func NewCommand() *cobra.Command {
 		RunE:          mainQueue,
 	}
 	flags.AddFlags(listCmd.Flags())
+
 	return listCmd
 }
 

--- a/internal/system/cmd/queue/operatequeue/operatequeue.go
+++ b/internal/system/cmd/queue/operatequeue/operatequeue.go
@@ -32,6 +32,7 @@ func executeQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, path
 	}
 
 	fmt.Printf("%s\n", out)
+
 	return nil
 }
 
@@ -48,17 +49,22 @@ func fetchQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOptio
 
 	fullEndpointURL := fmt.Sprintf("%s://%s:%s/%s/%s", apiProtocol, apiEndpoint, apiPort, queuePath, pathFromOption)
 	getAPI := []string{"curl", fullEndpointURL}
+
 	podName, err := utilk8s.GetDeckhousePod(kubeCl)
 	if err != nil {
 		return "", err
 	}
+
 	executor, err := utilk8s.ExecInPod(config, kubeCl, getAPI, podName, namespace, containerName)
 	if err != nil {
 		return "", err
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
 	if err := executor.StreamWithContext(
 		context.Background(),
 		remotecommand.StreamOptions{
@@ -73,6 +79,7 @@ func fetchQueue(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOptio
 
 func watchQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, pathFromOption string) error {
 	signals := make(chan os.Signal, 1)
+
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(signals)
 
@@ -82,6 +89,7 @@ func watchQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, pathFr
 	output := termenv.DefaultOutput()
 	output.AltScreen()
 	output.HideCursor()
+
 	defer func() {
 		output.ShowCursor()
 		output.ExitAltScreen()
@@ -99,10 +107,12 @@ func watchQueueCommand(config *rest.Config, kubeCl *kubernetes.Clientset, pathFr
 		// Move cursor to the top-left corner.
 		frame.WriteString("\x1b[H")
 		fmt.Fprintf(&frame, "Watching queue - %s (press Ctrl+C to stop)\n\n", time.Now().Format("15:04:05"))
+
 		if fetchErr != nil {
 			fmt.Fprintf(&frame, "Error fetching queue: %v\n", fetchErr)
 		} else {
 			frame.WriteString(body)
+
 			if len(body) == 0 || body[len(body)-1] != '\n' {
 				frame.WriteByte('\n')
 			}

--- a/internal/system/flags/flags.go
+++ b/internal/system/flags/flags.go
@@ -27,6 +27,7 @@ func AddPersistentFlags(cmd *cobra.Command) {
 	if p := os.Getenv("KUBECONFIG"); p != "" {
 		defaultKubeconfigPath = p
 	}
+
 	cmd.PersistentFlags().StringP(
 		"kubeconfig",
 		"k",

--- a/internal/system/flags/validation.go
+++ b/internal/system/flags/validation.go
@@ -33,6 +33,7 @@ func ValidateParameters(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("Invalid --kubeconfig: %w", err)
 	}
+
 	if !stats.Mode().IsRegular() {
 		return fmt.Errorf("Invalid --kubeconfig: %s is not a regular file", kubeconfigPath)
 	}

--- a/internal/tools/farconverter/convert.go
+++ b/internal/tools/farconverter/convert.go
@@ -79,7 +79,9 @@ type List struct {
 
 func Convert(_ *cobra.Command, args []string) error {
 	input := args[0]
+
 	var rules []RawRule
+
 	log.Printf("Convert rules from %q", input)
 
 	data, err := os.ReadFile(input)
@@ -103,6 +105,7 @@ func Convert(_ *cobra.Command, args []string) error {
 	if _, err = buf.WriteTo(os.Stdout); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -129,6 +132,7 @@ func convert(path string, rules []RawRule) FalcoAuditRule {
 					result.Spec.RequiredK8sAuditPluginVersion = plugin["version"].(string)
 				}
 			}
+
 			continue
 		}
 
@@ -139,6 +143,7 @@ func convert(path string, rules []RawRule) FalcoAuditRule {
 					Condition: r["condition"].(string),
 				},
 			})
+
 			continue
 		}
 
@@ -149,6 +154,7 @@ func convert(path string, rules []RawRule) FalcoAuditRule {
 					Items: r["items"].([]any),
 				},
 			})
+
 			continue
 		}
 
@@ -183,6 +189,7 @@ func convert(path string, rules []RawRule) FalcoAuditRule {
 			}
 
 			result.Spec.Rules = append(result.Spec.Rules, FalcoAuditRuleSpecRule{Rule: ruleToAdd})
+
 			continue
 		}
 	}
@@ -195,5 +202,6 @@ func nameFromPath(path string) string {
 	path, _, _ = strings.Cut(path, ".")
 	path = slug.Make(path)
 	path = strcase.ToKebab(path)
+
 	return path
 }

--- a/internal/tools/gostsum/gostsum.go
+++ b/internal/tools/gostsum/gostsum.go
@@ -19,6 +19,7 @@ func Gostsum(cmd *cobra.Command, args []string) error {
 	}
 
 	var hasher hash.Hash
+
 	switch length {
 	case 256:
 		hasher = streebog256.New()
@@ -34,24 +35,31 @@ func Gostsum(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
 		if _, err = fmt.Println(checksum); err != nil {
 			return err
 		}
+
 		return nil
 	}
 
 	// Have a set of file paths to hash provided as args
-	var reader io.Reader
-	var checksum string
+	var (
+		reader   io.Reader
+		checksum string
+	)
+
 	for _, filepath := range args {
 		reader, err = os.Open(filepath)
 		if err != nil {
 			return fmt.Errorf("%s: %w", filepath, err)
 		}
+
 		checksum, err = digest(bufio.NewReader(reader), hasher)
 		if err != nil {
 			return err
 		}
+
 		if _, err = fmt.Println(filepath+":", checksum); err != nil {
 			return err
 		}

--- a/internal/tools/imagedigest/cmd/add/add.go
+++ b/internal/tools/imagedigest/cmd/add/add.go
@@ -35,6 +35,7 @@ func NewCommand() *cobra.Command {
 			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
 				return err
 			}
+
 			return nil
 		},
 		RunE: runAdd,

--- a/internal/tools/imagedigest/cmd/calculate/calculate.go
+++ b/internal/tools/imagedigest/cmd/calculate/calculate.go
@@ -36,6 +36,7 @@ func NewCommand() *cobra.Command {
 			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
 				return err
 			}
+
 			return nil
 		},
 		RunE: runCalculate,

--- a/internal/tools/imagedigest/cmd/calculatefromfile/calculatefromfile.go
+++ b/internal/tools/imagedigest/cmd/calculatefromfile/calculatefromfile.go
@@ -35,6 +35,7 @@ func NewCommand() *cobra.Command {
 			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
 				return err
 			}
+
 			return nil
 		},
 		RunE: runCalculateFromFile,
@@ -47,12 +48,14 @@ func runCalculateFromFile(cmd *cobra.Command, args []string) error {
 	filename := args[0]
 
 	reader := os.Stdin
+
 	if filename != "-" {
 		file, err := os.Open(filename)
 		if err != nil {
 			return fmt.Errorf("failed to open file: %w", err)
 		}
 		defer file.Close()
+
 		reader = file
 	}
 

--- a/internal/tools/imagedigest/cmd/imagedigest.go
+++ b/internal/tools/imagedigest/cmd/imagedigest.go
@@ -39,9 +39,11 @@ func NewCommand() *cobra.Command {
 			debug, _ := cmd.Flags().GetBool("debug")
 
 			zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 			if !ojson {
 				log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
 			}
+
 			if debug {
 				zerolog.SetGlobalLevel(zerolog.DebugLevel)
 			}

--- a/internal/tools/imagedigest/cmd/validate/validate.go
+++ b/internal/tools/imagedigest/cmd/validate/validate.go
@@ -35,6 +35,7 @@ func NewCommand() *cobra.Command {
 			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
 				return err
 			}
+
 			return nil
 		},
 		RunE: runValidate,
@@ -69,12 +70,15 @@ func runValidate(cmd *cobra.Command, args []string) error {
 
 		if fix {
 			log.Info().Msg("Fix GOST Image Digest")
+
 			newDigest, fixErr := imagedigest.PullAnnotatePush(imageName, opts...)
 			if fixErr != nil {
 				log.Fatal().Err(fixErr).Msg("AddGostImageDigest")
 			}
+
 			log.Info().Msgf("GOST Image Digest: %s", newDigest)
 			log.Info().Msg("Added successfully")
+
 			return nil
 		}
 

--- a/internal/tools/imagedigest/imagedigest.go
+++ b/internal/tools/imagedigest/imagedigest.go
@@ -57,6 +57,7 @@ type ImageInfo struct {
 func CalculateGostHash(data []byte) []byte {
 	hasher := gost34112012256.New()
 	hasher.Write(data)
+
 	return hasher.Sum(nil)
 }
 
@@ -66,6 +67,7 @@ func CalculateGostHashFromReader(r io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return CalculateGostHash(data), nil
 }
 
@@ -86,10 +88,12 @@ func ExtractSortedLayerDigests(image v1.Image) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		digests = append(digests, digest.String())
 	}
 
 	slices.Sort(digests)
+
 	return digests, nil
 }
 
@@ -105,6 +109,7 @@ func ReadGostAnnotation(image v1.Image) (string, bool, error) {
 	if !ok {
 		log.Debug().Msg("the image does not contain gost digest")
 	}
+
 	return digest, ok, nil
 }
 
@@ -125,9 +130,11 @@ func CalculateImageGostDigest(image v1.Image) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if len(digests) == 0 {
 		return nil, fmt.Errorf("invalid layers hash data: no layers found")
 	}
+
 	return CalculateGostHash([]byte(strings.Join(digests, ""))), nil
 }
 
@@ -138,7 +145,9 @@ func AnnotateWithGostDigest(image v1.Image) (v1.Image, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+
 	digestHex := hex.EncodeToString(digest)
+
 	return AddGostAnnotation(image, digestHex), digestHex, nil
 }
 
@@ -149,6 +158,7 @@ func ValidateGostDigest(image v1.Image) (*ValidationResult, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if !ok {
 		return nil, fmt.Errorf("image does not contain GOST digest annotation (%s)", GostDigestAnnotationKey)
 	}
@@ -166,6 +176,7 @@ func ValidateGostDigest(image v1.Image) (*ValidationResult, error) {
 	if err := compareDigests(stored, calculated); err != nil {
 		return result, err
 	}
+
 	return result, nil
 }
 
@@ -180,6 +191,7 @@ func compareDigests(storedHex string, calculatedHash []byte) error {
 		return fmt.Errorf("GOST digest mismatch: stored=%s, calculated=%s",
 			storedHex, hex.EncodeToString(calculatedHash))
 	}
+
 	return nil
 }
 
@@ -193,6 +205,7 @@ func PullAndCalculate(imageName string, opts ...crane.Option) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return CalculateImageGostDigest(image)
 }
 
@@ -212,6 +225,7 @@ func PullAnnotatePush(imageName string, opts ...crane.Option) (string, error) {
 	if err := crane.Push(annotated, imageName, opts...); err != nil {
 		return "", err
 	}
+
 	return digestHex, nil
 }
 
@@ -221,6 +235,7 @@ func PullAndValidate(imageName string, opts ...crane.Option) (*ValidationResult,
 	if err != nil {
 		return nil, err
 	}
+
 	return ValidateGostDigest(image)
 }
 
@@ -236,12 +251,14 @@ func GetImageInfo(name string, image v1.Image) (*ImageInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	info.Digest = imageDigest.String()
 
 	gostDigest, ok, err := ReadGostAnnotation(image)
 	if err != nil {
 		return nil, err
 	}
+
 	if ok {
 		info.GostDigest = gostDigest
 	}
@@ -250,6 +267,7 @@ func GetImageInfo(name string, image v1.Image) (*ImageInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	info.LayerDigests = layerDigests
 
 	log.Debug().Interface("imageInfo", info).Msg("ImageMetadata")

--- a/internal/tools/pki/certs/certs.go
+++ b/internal/tools/pki/certs/certs.go
@@ -78,9 +78,11 @@ func BuildFullScanReport(certsDir, kubeconfigDir string) (*Report, error) {
 	if err != nil && !hasExpirations {
 		return nil, fmt.Errorf("no control-plane certificates or kubeconfig client certificates found: %w", err)
 	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	if !hasExpirations {
 		return nil, fmt.Errorf("no control-plane certificates or kubeconfig client certificates found in %q and %q", certsDir, kubeconfigDir)
 	}
@@ -146,6 +148,7 @@ func onlyNotExistErrors(err error) bool {
 				return false
 			}
 		}
+
 		return true
 	}
 
@@ -179,6 +182,7 @@ func BuildSingleFileReport(path string) (*Report, error) {
 				Authority: pkiDisplayName(string(certExp.Authority)),
 			}}
 		}
+
 		return report, nil
 	}
 
@@ -196,6 +200,7 @@ func RenderReport(w io.Writer, report *Report) {
 	if len(report.Certs) > 0 {
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 		fmt.Fprintln(tw, "CERTIFICATE\tEXPIRES\tRESIDUAL TIME\tCERTIFICATE AUTHORITY")
+
 		for _, c := range report.Certs {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
 				c.Name,
@@ -204,6 +209,7 @@ func RenderReport(w io.Writer, report *Report) {
 				c.Authority,
 			)
 		}
+
 		tw.Flush()
 	}
 
@@ -211,8 +217,10 @@ func RenderReport(w io.Writer, report *Report) {
 		if len(report.Certs) > 0 {
 			fmt.Fprintln(w)
 		}
+
 		tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 		fmt.Fprintln(tw, "CERTIFICATE AUTHORITY\tEXPIRES\tRESIDUAL TIME")
+
 		for _, ca := range report.CAs {
 			fmt.Fprintf(tw, "%s\t%s\t%s\n",
 				ca.Name,
@@ -220,6 +228,7 @@ func RenderReport(w io.Writer, report *Report) {
 				residualTime(ca.Expires, now),
 			)
 		}
+
 		tw.Flush()
 	}
 }
@@ -232,15 +241,20 @@ func residualTime(notAfter, now time.Time) string {
 	if !notAfter.After(now) {
 		return "expired"
 	}
+
 	d := notAfter.Sub(now)
+
 	totalDays := int(d.Hours() / 24)
 	if totalDays < 1 {
 		return "< 1 day"
 	}
+
 	if totalDays < 365 {
 		return fmt.Sprintf("%dd", totalDays)
 	}
+
 	years := totalDays / 365
+
 	return fmt.Sprintf("%dy", years)
 }
 

--- a/internal/tools/pki/certs/cmd/check.go
+++ b/internal/tools/pki/certs/cmd/check.go
@@ -50,8 +50,10 @@ auto-detects whether the file is a kubeconfig or a PEM certificate.
 
 // NewCheckCommand returns the "certs check" leaf command.
 func NewCheckCommand() *cobra.Command {
-	var certsDir string
-	var kubeconfigDir string
+	var (
+		certsDir      string
+		kubeconfigDir string
+	)
 
 	checkCmd := &cobra.Command{
 		Use:     "check [PATH]",
@@ -60,8 +62,10 @@ func NewCheckCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Example: "  d8 tools pki certs check\n  d8 tools pki certs check /etc/kubernetes/pki/apiserver.crt\n  d8 tools pki certs check /etc/kubernetes/admin.conf\n  d8 tools pki certs check --path /opt/k8s/pki --kubeconfig-dir /opt/k8s",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var report *certs.Report
-			var err error
+			var (
+				report *certs.Report
+				err    error
+			)
 
 			if len(args) == 1 {
 				report, err = certs.BuildSingleFileReport(args[0])
@@ -73,6 +77,7 @@ func NewCheckCommand() *cobra.Command {
 				if effectiveKubeconfigDir == "" {
 					effectiveKubeconfigDir = filepath.Dir(certsDir)
 				}
+
 				report, err = certs.BuildFullScanReport(certsDir, effectiveKubeconfigDir)
 				if err != nil {
 					return fmt.Errorf("checking certificates in %q and kubeconfig files in %q: %w", certsDir, effectiveKubeconfigDir, err)
@@ -80,6 +85,7 @@ func NewCheckCommand() *cobra.Command {
 			}
 
 			certs.RenderReport(cmd.OutOrStdout(), report)
+
 			return nil
 		},
 	}

--- a/internal/tools/sigmigrate/sigmigrate.go
+++ b/internal/tools/sigmigrate/sigmigrate.go
@@ -80,6 +80,7 @@ func newSigMigrateRunState(now time.Time) *sigMigrateRunState {
 func setCurrentRunState(state *sigMigrateRunState) {
 	runStateMu.Lock()
 	defer runStateMu.Unlock()
+
 	currentRunState = state
 }
 
@@ -130,6 +131,7 @@ func tracef(format string, args ...interface{}) {
 func syncLegacyRetryFile() error {
 	state := getCurrentRunState()
 	srcFile := state.FailedAttemptsFile
+
 	dstFile := state.LegacyFailedRetryFile
 	if srcFile == "" || dstFile == "" || srcFile == dstFile {
 		return nil
@@ -149,6 +151,7 @@ func syncLegacyRetryFile() error {
 	}
 
 	tracef("synced retry compatibility file: %s -> %s", srcFile, dstFile)
+
 	return nil
 }
 
@@ -156,8 +159,10 @@ func truncateFile(path string) {
 	if err := os.WriteFile(path, []byte{}, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to truncate %s: %v\n", path, err)
 		tracef("failed to truncate file %s: %v", path, err)
+
 		return
 	}
+
 	tracef("truncated file %s", path)
 }
 
@@ -185,6 +190,7 @@ func preferredVersionByGroup(apiGroupList *metav1.APIGroupList) map[string]strin
 		if group.Name == "" {
 			continue
 		}
+
 		if group.PreferredVersion.Version != "" {
 			preferred[group.Name] = group.PreferredVersion.Version
 		}
@@ -242,6 +248,7 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 	config := &SigMigrateConfig{}
 
 	var err error
+
 	config.RetryFailed, err = cmd.Flags().GetBool("retry")
 	if err != nil {
 		return fmt.Errorf("failed to get retry flag: %w", err)
@@ -273,18 +280,22 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 	}
 
 	runState := newSigMigrateRunState(time.Now())
+
 	traceFile, traceOpenErr := os.OpenFile(runState.TraceLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if traceOpenErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to open trace log file %s: %v\n", runState.TraceLogFile, traceOpenErr)
 	} else {
 		runState.traceFile = traceFile
 	}
+
 	setCurrentRunState(runState)
+
 	defer func() {
 		if runState.traceFile != nil {
 			_ = runState.traceFile.Sync()
 			_ = runState.traceFile.Close()
 		}
+
 		setCurrentRunState(nil)
 	}()
 	defer func() {
@@ -319,6 +330,7 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 	}
 
 	var objects map[string]ObjectRef
+
 	switch {
 	case config.Object != "" && !config.RetryFailed:
 		objects, err = collectSingleObject(discoveryClient, dynamicClient, config.Object, config.LogLevel)
@@ -326,32 +338,41 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 			tracef("failed to collect specified object %q: %v", config.Object, err)
 			return fmt.Errorf("failed to collect specified object: %w", err)
 		}
+
 		if len(objects) == 0 {
 			color.Red("Specified object not found: %s", config.Object)
 			tracef("specified object not found: %q", config.Object)
+
 			return nil
 		}
+
 		color.Cyan("\nCollected one object: %s\n", config.Object)
 	case config.RetryFailed:
 		color.Cyan("Retrying failed annotations from previous runs...\n")
+
 		objects, err = loadFailedObjects()
 		if err != nil {
 			tracef("failed to load failed objects from %s: %v", getLegacyRetryFilePath(), err)
 			return fmt.Errorf("failed to load failed objects: %w", err)
 		}
+
 		if len(objects) == 0 {
 			color.Red("No valid objects found in retry list. Exiting.")
 			tracef("retry list is empty: %s", getLegacyRetryFilePath())
+
 			return nil
 		}
+
 		if config.Object != "" {
 			objects = filterObjectsByIdentifier(objects, config.Object)
 			if len(objects) == 0 {
 				color.Red("Specified object not found in retry list: %s", config.Object)
 				tracef("specified object not found in retry list: %q", config.Object)
+
 				return nil
 			}
 		}
+
 		color.Cyan("Loaded %d objects for retry from %s.\n", len(objects), getLegacyRetryFilePath())
 	default:
 		objects, err = collectAllObjects(discoveryClient, dynamicClient, config.LogLevel)
@@ -359,12 +380,14 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 			tracef("failed to collect objects: %v", err)
 			return fmt.Errorf("failed to collect objects: %w", err)
 		}
+
 		color.Cyan("\nTotal objects collected: %d\n", len(objects))
 	}
 
 	if len(objects) == 0 {
 		color.Red("No objects available for annotation. Exiting.")
 		tracef("no objects available for annotation")
+
 		return nil
 	}
 
@@ -376,6 +399,7 @@ func SigMigrate(cmd *cobra.Command, _ []string) error {
 	// Create switch account config for retry
 	switchRestConfig := rest.CopyConfig(restConfig)
 	switchRestConfig.Impersonate.UserName = switchAccount
+
 	switchDynamicClient, err := dynamic.NewForConfig(switchRestConfig)
 	if err != nil {
 		tracef("failed to create switch dynamic client: %v", err)
@@ -403,6 +427,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 		tracef("failed to discover API groups: %v", err)
 		return nil, fmt.Errorf("failed to discover API groups: %w", err)
 	}
+
 	preferredByGroup := preferredVersionByGroup(apiGroupList)
 
 	namespacedResources := []schema.GroupVersionResource{}
@@ -414,6 +439,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 		gvr        schema.GroupVersionResource
 		namespaced bool
 	}
+
 	resourceMap := make(map[string]resourceInfo)
 
 	// Iterate through all API groups and their versions (like kubectl api-resources does)
@@ -426,7 +452,9 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 				if logLevel == "TRACE" {
 					fmt.Printf("Warning: failed to get resources for %s: %v\n", version.GroupVersion, err)
 				}
+
 				tracef("failed to get resources for %s: %v", version.GroupVersion, err)
+
 				continue
 			}
 
@@ -491,6 +519,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 	for _, gvr := range namespacedResources {
 		currentResource++
 		progress := (currentResource * 100) / totalResources
+
 		if logLevel == "TRACE" {
 			fmt.Printf("\nFetching resource: %s\n", gvr.String())
 		} else {
@@ -499,12 +528,15 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 		}
 
 		resourceClient := dynamicClient.Resource(gvr)
+
 		list, err := resourceClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			if logLevel == "TRACE" {
 				fmt.Printf("Error listing %s: %v\n", gvr.String(), err)
 			}
+
 			tracef("error listing %s: %v", gvr.String(), err)
+
 			continue
 		}
 
@@ -513,6 +545,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 			if namespace == "" {
 				namespace = "clusterwide"
 			}
+
 			name := item.GetName()
 			upsertCollectedObject(objects, namespace, name, gvr, preferredByGroup)
 		}
@@ -522,6 +555,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 	for _, gvr := range clusterResources {
 		currentResource++
 		progress := (currentResource * 100) / totalResources
+
 		if logLevel == "TRACE" {
 			fmt.Printf("\nFetching resource: %s\n", gvr.String())
 		} else {
@@ -530,12 +564,15 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 		}
 
 		resourceClient := dynamicClient.Resource(gvr)
+
 		list, err := resourceClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			if logLevel == "TRACE" {
 				fmt.Printf("Error listing %s: %v\n", gvr.String(), err)
 			}
+
 			tracef("error listing %s: %v", gvr.String(), err)
+
 			continue
 		}
 
@@ -546,6 +583,7 @@ func collectAllObjects(discoveryClient discovery.DiscoveryInterface, dynamicClie
 	}
 
 	fmt.Println()
+
 	return objects, nil
 }
 
@@ -562,11 +600,14 @@ func annotateObjects(
 
 	for _, obj := range objects {
 		var err error
+
 		if unsupportedTypes[obj.Kind] {
 			if logLevel == "DEBUG" || logLevel == "TRACE" {
 				color.Yellow("\nSkipping type that does not support annotation: %s\n", obj.Kind)
 			}
+
 			recordSkippedObject(obj, "MethodNotSupported", fmt.Sprintf("Resource type %s does not support PATCH operation", obj.Kind))
+
 			continue
 		}
 
@@ -578,9 +619,11 @@ func annotateObjects(
 		if logLevel == "TRACE" {
 			color.Cyan("\n[TRACE] Processing object: Kind=%s, Namespace=%s, Name=%s, GVR=%s\n", obj.Kind, obj.Namespace, obj.Name, obj.GVR.String())
 		}
+
 		tracef("processing object kind=%s namespace=%s name=%s gvr=%s", obj.Kind, obj.Namespace, obj.Name, obj.GVR.String())
 
 		resourceClient := dynamicClient.Resource(obj.GVR)
+
 		var objClient dynamic.ResourceInterface
 		if obj.Namespace == "clusterwide" {
 			objClient = resourceClient
@@ -600,6 +643,7 @@ func annotateObjects(
 				color.Yellow("\nRetrying with different service account: %s for %s/%s/%s\n", switchAccount, obj.Kind, obj.Namespace, obj.Name)
 				tracef("retrying with switch account %s for %s/%s/%s", switchAccount, obj.Kind, obj.Namespace, obj.Name)
 				switchResourceClient := switchDynamicClient.Resource(obj.GVR)
+
 				var switchObjClient dynamic.ResourceInterface
 				if obj.Namespace == "clusterwide" {
 					switchObjClient = switchResourceClient
@@ -614,16 +658,20 @@ func annotateObjects(
 						if logLevel == "TRACE" {
 							color.Cyan("\n[TRACE] MethodNotSupported error after switching account: %v\n", err)
 						}
+
 						tracef("method not supported after switch account for %s/%s/%s: %s", obj.Kind, obj.Namespace, obj.Name, formatServerErrorDetails(err))
 						unsupportedTypes[obj.Kind] = true
 						color.Yellow("\nAdding %s to unsupported annotation types due to MethodNotSupported (after trying switch account).\n", obj.Kind)
 						recordSkippedObject(obj, "MethodNotSupported", fmt.Sprintf("After switching to account %s: %v", switchAccount, err))
+
 						continue
 					}
+
 					color.Red("\nFailed to add annotation after switching accounts for %s/%s/%s\n", obj.Kind, obj.Namespace, obj.Name)
 					color.Yellow("Retry Details: %v\n", err)
 					tracef("failed to add annotation after switch account for %s/%s/%s: %s", obj.Kind, obj.Namespace, obj.Name, formatServerErrorDetails(err))
 					recordFailure(obj, err.Error())
+
 					continue
 				}
 				// Success with switch account, continue to next object
@@ -643,10 +691,12 @@ func annotateObjects(
 						color.Cyan("[TRACE] Status message: %s\n", statusErr.Status().Message)
 					}
 				}
+
 				tracef("method not supported for %s/%s/%s: %s", obj.Kind, obj.Namespace, obj.Name, formatServerErrorDetails(err))
 				unsupportedTypes[obj.Kind] = true
 				color.Yellow("\nAdding %s to unsupported annotation types due to MethodNotSupported.\n", obj.Kind)
 				recordSkippedObject(obj, "MethodNotSupported", fmt.Sprintf("Error: %v", err))
+
 				continue
 			}
 
@@ -665,6 +715,7 @@ func annotateObjects(
 				tracef("failed to add annotation for %s/%s/%s: %s", obj.Kind, obj.Namespace, obj.Name, formatServerErrorDetails(err))
 				recordFailure(obj, errStr)
 			}
+
 			continue
 		}
 
@@ -695,7 +746,9 @@ func addAnnotation(client dynamic.ResourceInterface, name, key, value, logLevel 
 		if logLevel == "TRACE" {
 			color.Cyan("\n[TRACE] Get failed for %s: %v\n", name, err)
 		}
+
 		tracef("get failed for %s: %s", name, formatServerErrorDetails(err))
+
 		return err
 	}
 
@@ -703,12 +756,14 @@ func addAnnotation(client dynamic.ResourceInterface, name, key, value, logLevel 
 		color.Cyan("\n[TRACE] Running annotation command: add %s=%s to %s\n", key, value, name)
 		color.Cyan("[TRACE] Object UID: %s, ResourceVersion: %s\n", obj.GetUID(), obj.GetResourceVersion())
 	}
+
 	tracef("add annotation key=%s value=%s object=%s uid=%s rv=%s", key, value, name, obj.GetUID(), obj.GetResourceVersion())
 
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
+
 	annotations[key] = value
 	obj.SetAnnotations(annotations)
 
@@ -727,6 +782,7 @@ func addAnnotation(client dynamic.ResourceInterface, name, key, value, logLevel 
 		color.Cyan("[TRACE] Patch payload: %s\n", string(patchBytes))
 		color.Cyan("[TRACE] Calling Patch with MergePatchType for %s\n", name)
 	}
+
 	tracef("patch payload for %s: %s", name, string(patchBytes))
 
 	// Try MergePatchType first
@@ -738,16 +794,20 @@ func addAnnotation(client dynamic.ResourceInterface, name, key, value, logLevel 
 			if logLevel == "TRACE" {
 				color.Cyan("[TRACE] MergePatchType not supported, trying StrategicMergePatchType for %s\n", name)
 			}
+
 			tracef("merge patch type not supported for %s, retry with StrategicMergePatchType", name)
 			_, err = client.Patch(context.TODO(), name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 		}
+
 		if err != nil && logLevel == "TRACE" {
 			color.Cyan("[TRACE] Patch failed for %s: %v\n", name, err)
 		}
+
 		if err != nil {
 			tracef("patch failed for %s: %s", name, formatServerErrorDetails(err))
 		}
 	}
+
 	return err
 }
 
@@ -757,6 +817,7 @@ func removeAnnotation(client dynamic.ResourceInterface, name, keyPrefix, _ strin
 		if errors.IsNotFound(err) {
 			return nil
 		}
+
 		return err
 	}
 
@@ -767,9 +828,11 @@ func removeAnnotation(client dynamic.ResourceInterface, name, keyPrefix, _ strin
 
 	// Remove all annotations that start with keyPrefix
 	modified := false
+
 	for key := range annotations {
 		if strings.HasPrefix(key, keyPrefix) {
 			delete(annotations, key)
+
 			modified = true
 		}
 	}
@@ -790,6 +853,7 @@ func removeAnnotation(client dynamic.ResourceInterface, name, keyPrefix, _ strin
 	}
 
 	_, err = client.Patch(context.TODO(), name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+
 	return err
 }
 
@@ -797,12 +861,14 @@ func loadFailedObjects() (map[string]ObjectRef, error) {
 	objects := make(map[string]ObjectRef)
 
 	retryFile := getLegacyRetryFilePath()
+
 	data, err := os.ReadFile(retryFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			tracef("retry file does not exist: %s", retryFile)
 			return objects, nil
 		}
+
 		return nil, fmt.Errorf("failed to read failed attempts file %s: %w", retryFile, err)
 	}
 
@@ -856,8 +922,10 @@ func recordFailure(obj ObjectRef, errorMsg string) {
 		// If we can't write to the file, log to stderr as fallback
 		fmt.Fprintf(os.Stderr, "Warning: failed to write to %s: %v\n", failedAttemptsFile, err)
 		tracef("failed to append failed attempts file %s: %v", failedAttemptsFile, err)
+
 		return
 	}
+
 	_, _ = fmt.Fprintf(f, "%s|%s|%s|%s|%s\n", obj.Namespace, obj.Name, obj.Kind, obj.GVR.Group, obj.GVR.Version)
 	_ = f.Sync()
 	_ = f.Close()
@@ -868,8 +936,10 @@ func recordFailure(obj ObjectRef, errorMsg string) {
 		// If we can't write to the file, log to stderr as fallback
 		fmt.Fprintf(os.Stderr, "Warning: failed to write to %s: %v\n", errorLogFile, err)
 		tracef("failed to append error log file %s: %v", errorLogFile, err)
+
 		return
 	}
+
 	_, _ = fmt.Fprintf(f, "%s|%s|%s|%s\n", obj.Namespace, obj.Name, obj.Kind, errorMsg)
 	_ = f.Sync()
 	_ = f.Close()
@@ -877,6 +947,7 @@ func recordFailure(obj ObjectRef, errorMsg string) {
 
 func recordSkippedObject(obj ObjectRef, reason string, details string) {
 	skippedObjectsFile := getSkippedObjectsFilePath()
+
 	tracef("recording skipped object %s/%s/%s: reason=%s details=%s", obj.Kind, obj.Namespace, obj.Name, reason, details)
 
 	// Append to skipped objects file
@@ -885,8 +956,10 @@ func recordSkippedObject(obj ObjectRef, reason string, details string) {
 		// If we can't write to the file, log to stderr as fallback
 		fmt.Fprintf(os.Stderr, "Warning: failed to write to %s: %v\n", skippedObjectsFile, err)
 		tracef("failed to append skipped objects file %s: %v", skippedObjectsFile, err)
+
 		return
 	}
+
 	timestamp := time.Now().Format(time.RFC3339)
 	gvrStr := obj.GVR.String()
 	_, _ = fmt.Fprintf(f, "%s|%s|%s|%s|%s|%s|%s\n", timestamp, obj.Namespace, obj.Name, obj.Kind, gvrStr, reason, details)
@@ -910,6 +983,7 @@ func contains(slice []string, item string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -921,6 +995,7 @@ func classifyNotFoundError(err error) (string, string) {
 	}
 
 	tracef("classified not found error as NotFound: %s", serverDetails)
+
 	return "NotFound", fmt.Sprintf("Object not found (it may have been removed): %s", serverDetails)
 }
 
@@ -939,6 +1014,7 @@ func isResourceEndpointNotFound(err error) bool {
 	}
 
 	statusMessage := strings.ToLower(statusErr.Status().Message)
+
 	return strings.Contains(statusMessage, requestedResourceNotFoundPhrase)
 }
 
@@ -953,11 +1029,13 @@ func formatServerErrorDetails(err error) string {
 	}
 
 	status := statusErr.Status()
+
 	return fmt.Sprintf("%s (status: code=%d, reason=%s, message=%q)", err.Error(), status.Code, status.Reason, status.Message)
 }
 
 func parseObjectIdentifier(objectIdentifier string) (string, string, string, error) {
 	trimmedIdentifier := strings.TrimSpace(objectIdentifier)
+
 	parts := strings.Split(trimmedIdentifier, "/")
 	if len(parts) != 3 {
 		return "", "", "", fmt.Errorf("invalid object format: expected <namespace>/<name>/<kind>")
@@ -965,6 +1043,7 @@ func parseObjectIdentifier(objectIdentifier string) (string, string, string, err
 
 	namespace := strings.TrimSpace(parts[0])
 	name := strings.TrimSpace(parts[1])
+
 	kind := strings.TrimSpace(parts[2])
 	if namespace == "" || name == "" || kind == "" {
 		return "", "", "", fmt.Errorf("invalid object format: namespace, name and kind must be non-empty")
@@ -998,7 +1077,9 @@ func collectSingleObject(
 				if logLevel == "TRACE" {
 					fmt.Printf("Warning: failed to get resources for %s: %v\n", version.GroupVersion, err)
 				}
+
 				tracef("failed to get resources for %s while collecting single object: %v", version.GroupVersion, err)
+
 				continue
 			}
 
@@ -1023,6 +1104,7 @@ func collectSingleObject(
 				if namespace == "clusterwide" && apiResource.Namespaced {
 					continue
 				}
+
 				if namespace != "clusterwide" && !apiResource.Namespaced {
 					continue
 				}
@@ -1034,6 +1116,7 @@ func collectSingleObject(
 				}
 
 				resourceClient := dynamicClient.Resource(gvr)
+
 				var objClient dynamic.ResourceInterface
 				if namespace == "clusterwide" {
 					objClient = resourceClient
@@ -1046,10 +1129,13 @@ func collectSingleObject(
 					if errors.IsNotFound(err) {
 						continue
 					}
+
 					if logLevel == "TRACE" {
 						fmt.Printf("Warning: failed to get object %s/%s/%s in %s: %v\n", namespace, name, kind, gvr.String(), err)
 					}
+
 					tracef("failed to get object %s/%s/%s in %s: %s", namespace, name, kind, gvr.String(), formatServerErrorDetails(err))
+
 					continue
 				}
 
@@ -1076,6 +1162,7 @@ func filterObjectsByIdentifier(objects map[string]ObjectRef, objectIdentifier st
 	}
 
 	filtered := make(map[string]ObjectRef)
+
 	for key, object := range objects {
 		if object.Namespace == namespace && object.Name == name && object.Kind == kind {
 			filtered[key] = object
@@ -1096,6 +1183,7 @@ func checkFailedAnnotations() {
 		if os.IsNotExist(err) {
 			return
 		}
+
 		tracef("failed to read failed attempts file %s: %v", failedAttemptsFile, err)
 		// If we can't read the file, just return silently
 		return
@@ -1110,6 +1198,7 @@ func checkFailedAnnotations() {
 	// Count failed objects
 	lines := strings.Split(content, "\n")
 	failedCount := 0
+
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" {
 			failedCount++

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -25,6 +25,7 @@ func SetupK8sClientSet(kubeconfigPath, contextName string) (*rest.Config, *kuber
 	kubeconfigFiles := filepath.SplitList(kubeconfigPath)
 	chain := make([]string, 0, len(kubeconfigFiles))
 	loadingRules := &clientcmd.ClientConfigLoadingRules{}
+
 	chain = append(chain, deduplicate(kubeconfigFiles)...)
 
 	if len(chain) > 1 {

--- a/internal/utilk8s/completion.go
+++ b/internal/utilk8s/completion.go
@@ -39,12 +39,14 @@ func CompleteResourceNames(cmd *cobra.Command, gvr schema.GroupVersionResource, 
 	}
 
 	nri := dyn.Resource(gvr)
+
 	var list *unstructured.UnstructuredList
 	if namespace == "" {
 		list, err = nri.List(cmd.Context(), metav1.ListOptions{})
 	} else {
 		list, err = nri.Namespace(namespace).List(cmd.Context(), metav1.ListOptions{})
 	}
+
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -56,6 +58,7 @@ func CompleteResourceNames(cmd *cobra.Command, gvr schema.GroupVersionResource, 
 			names = append(names, n)
 		}
 	}
+
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -73,6 +76,7 @@ func FilterByPrefix(values []string, toComplete string) []string {
 			out = append(out, v)
 		}
 	}
+
 	return out
 }
 

--- a/internal/utilk8s/dynamic.go
+++ b/internal/utilk8s/dynamic.go
@@ -33,9 +33,11 @@ func NewDynamicClient(cmd *cobra.Command) (dynamic.Interface, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup Kubernetes client: %w", err)
 	}
+
 	dyn, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
+
 	return dyn, nil
 }

--- a/internal/utilk8s/operatepod.go
+++ b/internal/utilk8s/operatepod.go
@@ -23,13 +23,16 @@ func GetDeckhousePod(kubeCl kubernetes.Interface) (string, error) {
 	if len(pods.Items) == 0 {
 		return "", fmt.Errorf("no pods deckhouse available in namespace d8-system")
 	}
+
 	pod := pods.Items[0]
 	podName := pod.Name
+
 	return podName, nil
 }
 
 func ExecInPod(config *rest.Config, kubeCl kubernetes.Interface, cmdLine []string, podName string, namespace string, containerName string) (remotecommand.Executor, error) {
 	scheme := runtime.NewScheme()
+
 	parameterCodec := runtime.NewParameterCodec(scheme)
 	if err := v1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("Failed to create parameter codec: %w", err)
@@ -54,5 +57,6 @@ func ExecInPod(config *rest.Config, kubeCl kubernetes.Interface, cmdLine []strin
 	if err != nil {
 		return nil, fmt.Errorf("Creating SPDY executor for Pod %s: %v", podName, err)
 	}
+
 	return executor, nil
 }

--- a/internal/utilk8s/output.go
+++ b/internal/utilk8s/output.go
@@ -44,15 +44,18 @@ func PrintObject(w io.Writer, obj *unstructured.Unstructured, format string) err
 		if err != nil {
 			return fmt.Errorf("marshalling JSON: %w", err)
 		}
+
 		fmt.Fprintln(w, string(data))
 	case "yaml":
 		data, err := sigsyaml.Marshal(obj.Object)
 		if err != nil {
 			return fmt.Errorf("marshalling YAML: %w", err)
 		}
+
 		fmt.Fprint(w, string(data))
 	default:
 		fmt.Fprintf(w, "%s/%s\n", obj.GetKind(), obj.GetName())
 	}
+
 	return nil
 }

--- a/pkg/diagnostic/diagnostic.go
+++ b/pkg/diagnostic/diagnostic.go
@@ -37,6 +37,7 @@ func (e *HelpfulError) Error() string {
 	if e.OriginalErr == nil {
 		return e.Category
 	}
+
 	return e.Category + ": " + e.OriginalErr.Error()
 }
 

--- a/pkg/diagnostic/format.go
+++ b/pkg/diagnostic/format.go
@@ -43,6 +43,7 @@ func (t textStyler) style(text string, ansiCodes ...string) string {
 	if !t.enabled {
 		return text
 	}
+
 	return strings.Join(ansiCodes, "") + text + ansiReset
 }
 
@@ -58,6 +59,7 @@ func newTextStyler() textStyler {
 	if os.Getenv("NO_COLOR") != "" {
 		return textStyler{}
 	}
+
 	return textStyler{
 		enabled: os.Getenv("FORCE_COLOR") != "" || term.IsTerminal(int(os.Stderr.Fd())),
 	}
@@ -77,6 +79,7 @@ func (e *HelpfulError) Format() string {
 
 	var b strings.Builder
 	b.WriteString("\n" + t.danger("error") + t.header(": "+e.Category) + "\n")
+
 	if e.OriginalErr != nil {
 		chain := unwrapChain(e.OriginalErr)
 		for i, msg := range chain {
@@ -84,16 +87,19 @@ func (e *HelpfulError) Format() string {
 			b.WriteString("  " + indent + t.hint("╰─▶ ") + msg + "\n")
 		}
 	}
+
 	b.WriteString("\n")
 
 	for _, s := range e.Suggestions {
 		b.WriteString("  " + t.warn("* "+s.Cause) + "\n")
+
 		for _, sol := range s.Solutions {
 			b.WriteString("    " + t.hint("-> ") + sol + "\n")
 		}
 	}
 
 	b.WriteString("\n")
+
 	return b.String()
 }
 
@@ -111,6 +117,7 @@ func unwrapChain(err error) []string {
 
 		full := err.Error()
 		innerText := inner.Error()
+
 		context := strings.TrimSuffix(full, ": "+innerText)
 		if context == full {
 			// Can't extract prefix cleanly - use full message and stop

--- a/pkg/libmirror/bundle/bundle.go
+++ b/pkg/libmirror/bundle/bundle.go
@@ -32,6 +32,7 @@ import (
 
 func Unpack(ctx context.Context, source io.Reader, targetPath string, pkgName string) error {
 	var err error
+
 	tarReader := tar.NewReader(source)
 
 	// support old behavior when inside "module-<name>.tar" isn't have modules/<name> folder
@@ -62,22 +63,27 @@ func Unpack(ctx context.Context, source io.Reader, targetPath string, pkgName st
 		if err = os.MkdirAll(filepath.Dir(writePath), 0o755); err != nil {
 			return fmt.Errorf("setup dir tree: %w", err)
 		}
+
 		bundleFile, err := os.OpenFile(writePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 		if err != nil {
 			return fmt.Errorf("create file: %w", err)
 		}
+
 		if _, err = io.Copy(bundleFile, tarReader); err != nil {
 			return fmt.Errorf("write %q: %w", writePath, err)
 		}
+
 		if err = bundleFile.Sync(); err != nil {
 			return fmt.Errorf("write %q: %w", writePath, err)
 		}
+
 		if err = bundleFile.Close(); err != nil {
 			return fmt.Errorf("write %q: %w", writePath, err)
 		}
 	}
 
 	from := filepath.Join(targetPath, "tmp")
+
 	to := targetPath
 	if isLegacyModule {
 		to = filepath.Join(targetPath, "modules", moduleName)
@@ -90,6 +96,7 @@ func Unpack(ctx context.Context, source io.Reader, targetPath string, pkgName st
 		if err != nil {
 			return fmt.Errorf("move module from tmp: %w", err)
 		}
+
 		return nil
 	}
 
@@ -129,13 +136,16 @@ func PackWithPrefix(ctx context.Context, sourcePath string, prefix string, sink 
 
 func packFuncWithPrefix(ctx context.Context, pathPrefix string, tarPrefix string, writer *tar.Writer) filepath.WalkFunc {
 	unixEpochStart := time.Unix(0, 0)
+
 	return func(path string, info fs.FileInfo, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+
 		if err != nil {
 			return err
 		}
+
 		if path == pathPrefix || info.IsDir() {
 			return nil
 		}
@@ -150,6 +160,7 @@ func packFuncWithPrefix(ctx context.Context, pathPrefix string, tarPrefix string
 		if tarPrefix != "" {
 			pathInTar = tarPrefix + "/" + pathInTar
 		}
+
 		err = writer.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeReg,
 			Format:   tar.FormatGNU,

--- a/pkg/libmirror/bundle/validation.go
+++ b/pkg/libmirror/bundle/validation.go
@@ -52,6 +52,7 @@ func ValidateUnpackedPackage(mandatoryLayouts map[string]string) error {
 		if err != nil {
 			return fmt.Errorf("%s: %w", layoutDescription, err)
 		}
+
 		index, err := l.ImageIndex()
 		if err != nil {
 			return fmt.Errorf("%s image index: %w", layoutDescription, err)

--- a/pkg/libmirror/images/extract_file.go
+++ b/pkg/libmirror/images/extract_file.go
@@ -36,6 +36,7 @@ func ExtractFileFromImage(img v1.Image, fileName string) (*bytes.Buffer, error) 
 	// We should go down from the top layer to the bottom one to fetch the most
 	// recent version of the file in question
 	slices.Reverse(layers)
+
 	for _, layer := range layers {
 		// Do not use layer.Uncompressed() here. We decompress layers ourselves because
 		// decompressor that is built into go-containerregistry is bugged and sometimes

--- a/pkg/libmirror/layouts/indexes.go
+++ b/pkg/libmirror/layouts/indexes.go
@@ -51,6 +51,7 @@ func (a indexManifestAnnotations) MarshalJSON() ([]byte, error) {
 
 	buf := bytes.Buffer{}
 	buf.WriteRune('{')
+
 	for _, key := range names {
 		buf.WriteRune('"')
 		buf.WriteString(key)
@@ -58,8 +59,10 @@ func (a indexManifestAnnotations) MarshalJSON() ([]byte, error) {
 		buf.WriteString(a[key])
 		buf.Write([]byte(`",`))
 	}
+
 	js := buf.Bytes()
 	js[len(js)-1] = '}'
+
 	return js, nil
 }
 
@@ -82,6 +85,7 @@ func SortIndexManifests(l layout.Path) error {
 	sort.Slice(indexManifest.Manifests, func(i, j int) bool {
 		ref1 := indexManifest.Manifests[i].Annotations["org.opencontainers.image.ref.name"]
 		ref2 := indexManifest.Manifests[j].Annotations["org.opencontainers.image.ref.name"]
+
 		return ref1 < ref2
 	})
 
@@ -89,6 +93,7 @@ func SortIndexManifests(l layout.Path) error {
 	if err != nil {
 		return fmt.Errorf("Marshal image index manifest: %w", err)
 	}
+
 	if err = l.WriteFile("index.json", rawManifest, os.ModePerm); err != nil {
 		return fmt.Errorf("Write image index manifest: %w", err)
 	}
@@ -103,6 +108,7 @@ func FindImageByTag(l layout.Path, tag string) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	indexManifest, err := index.IndexManifest()
 	if err != nil {
 		return nil, err
@@ -152,6 +158,7 @@ func CreateEmptyImageLayout(path string) (layout.Path, error) {
 	if err != nil {
 		return "", fmt.Errorf("create index.json: %w", err)
 	}
+
 	if err = os.WriteFile(indexFilePath, rawJSON, 0o644); err != nil {
 		return "", fmt.Errorf("create index.json: %w", err)
 	}
@@ -160,6 +167,7 @@ func CreateEmptyImageLayout(path string) (layout.Path, error) {
 	if err != nil {
 		return "", fmt.Errorf("create oci-layout: %w", err)
 	}
+
 	if err = os.WriteFile(layoutFilePath, rawJSON, 0o644); err != nil {
 		return "", fmt.Errorf("create oci-layout: %w", err)
 	}
@@ -172,6 +180,7 @@ func FindImageDescriptorByTag(l layout.Path, tag string) (v1.Descriptor, error) 
 	if err != nil {
 		return v1.Descriptor{}, err
 	}
+
 	indexManifest, err := index.IndexManifest()
 	if err != nil {
 		return v1.Descriptor{}, err
@@ -193,6 +202,7 @@ func TagImage(l layout.Path, imageDigest v1.Hash, tag string) error {
 	if err != nil {
 		return err
 	}
+
 	indexManifest, err := index.IndexManifest()
 	if err != nil {
 		return err
@@ -205,10 +215,12 @@ func TagImage(l layout.Path, imageDigest v1.Hash, tag string) error {
 			if found {
 				imageDescriptor.Annotations["org.opencontainers.image.ref.name"] = imageRepo + ":" + tag
 			}
+
 			imageDescriptor.Annotations["io.deckhouse.image.short_tag"] = tag
 			if err = l.AppendDescriptor(imageDescriptor); err != nil {
 				return fmt.Errorf("append descriptor %s: %w", tag, err)
 			}
+
 			return nil
 		}
 	}

--- a/pkg/libmirror/util/auth/auth.go
+++ b/pkg/libmirror/util/auth/auth.go
@@ -48,12 +48,14 @@ func MakeRemoteRegistryRequestOptions(authProvider authn.Authenticator, insecure
 	if err != nil {
 		panic(err)
 	}
+
 	puller, err := remote.NewPuller(r...)
 	if err != nil {
 		panic(err)
 	}
 
 	r = append(r, remote.Reuse(puller), remote.Reuse(pusher))
+
 	return n, r
 }
 

--- a/pkg/libmirror/util/log/slog.go
+++ b/pkg/libmirror/util/log/slog.go
@@ -78,16 +78,22 @@ func (s *SLogger) WarnLn(a ...any) {
 
 func (s *SLogger) Process(topic string, run func() error) error {
 	start := time.Now()
+
 	s.delegate.Info(strings.Repeat("║", s.processDepth) + "╔ " + topic)
 	s.processDepth++
+
 	defer func() { s.processDepth-- }()
+
 	if err := run(); err != nil {
 		s.delegate.Error(
 			strings.Repeat("║", s.processDepth-1)+topic+" failed",
 			"error", err)
+
 		return err
 	}
+
 	s.delegate.Info(strings.Repeat("║", s.processDepth-1) + "╚ " + topic + " succeeded in " + time.Since(start).String())
+
 	return nil
 }
 
@@ -97,6 +103,7 @@ func (s *SLogger) formatRecord(template string, args ...any) string {
 	if template == "" {
 		msg := &strings.Builder{}
 		msg.WriteString(prefix)
+
 		for _, arg := range args {
 			fmt.Fprintf(msg, " %v", arg)
 		}

--- a/pkg/libmirror/util/retry/retry.go
+++ b/pkg/libmirror/util/retry/retry.go
@@ -36,11 +36,14 @@ func RunTask(ctx context.Context, logger params.Logger, name string, task Task) 
 
 func runTaskWithContext(ctx context.Context, logger params.Logger, name string, task Task) error {
 	restarts := uint(0)
+
 	var lastErr error
+
 	for restarts < task.MaxRetries() {
 		if restarts > 0 {
 			interval := task.Interval(restarts)
 			logger.Infof("%s failed, next retry in %v", name, interval)
+
 			select {
 			case <-time.After(interval):
 				// Pause completed, proceed with next attempt
@@ -50,6 +53,7 @@ func runTaskWithContext(ctx context.Context, logger params.Logger, name string, 
 		}
 
 		logger.InfoLn(name)
+
 		lastErr = task.Do(ctx, restarts)
 		if lastErr == nil {
 			return nil

--- a/pkg/libmirror/util/retry/task/constant_interval.go
+++ b/pkg/libmirror/util/retry/task/constant_interval.go
@@ -37,6 +37,7 @@ func WithConstantRetries(maxRetries uint, waitInterval time.Duration, payload fu
 	if task.maxRetries == 0 {
 		task.maxRetries = 1
 	}
+
 	if task.waitInterval <= 0 {
 		task.waitInterval = time.Second
 	}

--- a/pkg/libsaferequest/client/http.go
+++ b/pkg/libsaferequest/client/http.go
@@ -24,14 +24,17 @@ var (
 
 func newRestConfig(flags ...*pflag.FlagSet) (*rest.Config, error) {
 	kubeConfigFlags := genericclioptions.ConfigFlags{}
+
 	if len(flags) == 0 {
 		flags = []*pflag.FlagSet{pflag.CommandLine}
 	}
+
 	for _, f := range flags {
 		if flags != nil {
 			kubeConfigFlags.AddFlags(f)
 		}
 	}
+
 	restConfig, err := kubeConfigFlags.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -55,6 +58,7 @@ func NewSafeClient(flags ...*pflag.FlagSet) (*SafeClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &SafeClient{restConfig}, nil
 }
 
@@ -146,12 +150,14 @@ func (c *SafeClient) NewRTClient(schemeFuncs ...func(s *apiruntime.Scheme) error
 	}
 
 	schemeFuncs = append(schemeFuncs, kubescheme.AddToScheme)
+
 	scheme := apiruntime.NewScheme()
 	for _, f := range schemeFuncs {
 		if err := f(scheme); err != nil {
 			return nil, err
 		}
 	}
+
 	clientOpts := ctrlrtclient.Options{
 		Scheme: scheme,
 	}
@@ -185,11 +191,14 @@ func (c *SafeClient) SetTLSCAData(caData []byte) {
 		if !ok {
 			return transport
 		}
+
 		clonedTrasport := transport.Clone()
 		if clonedTrasport.TLSClientConfig == nil {
 			clonedTrasport.TLSClientConfig = &tls.Config{}
 		}
+
 		clonedTrasport.TLSClientConfig.RootCAs = sysPool
+
 		return clonedTrasport
 	}
 }

--- a/pkg/registry/service/plugin_service.go
+++ b/pkg/registry/service/plugin_service.go
@@ -154,9 +154,11 @@ func unmarshalContract(raw []byte, dst *PluginContract) error {
 		if (typeErr.Field == "requirements.modules" || typeErr.Field == "requirements.plugins") && typeErr.Value == "array" {
 			return fmt.Errorf("invalid contract: field %q must be an object with mandatory/conditional sections, got a JSON array", typeErr.Field)
 		}
+
 		if typeErr.Field != "" {
 			return fmt.Errorf("invalid contract: field %q has wrong JSON type (got %s)", typeErr.Field, typeErr.Value)
 		}
+
 		return fmt.Errorf("invalid contract: wrong JSON type (got %s)", typeErr.Value)
 	}
 
@@ -191,6 +193,7 @@ func (s *PluginService) ExtractPlugin(ctx context.Context, pluginName, tag, dest
 	pluginClient := s.client.WithSegment(pluginName)
 
 	platform := &v1.Platform{Architecture: runtime.GOARCH, OS: runtime.GOOS}
+
 	img, err := pluginClient.GetImage(ctx, tag, regclient.WithPlatform{Platform: platform})
 	if err != nil {
 		return fmt.Errorf("failed to get image: %w", err)
@@ -217,6 +220,7 @@ func (s *PluginService) extractPluginFromTar(r io.Reader, destination, pluginNam
 		if err == io.EOF {
 			break // End of archive
 		}
+
 		if err != nil {
 			return fmt.Errorf("failed to read tar header: %w", err)
 		}
@@ -258,6 +262,7 @@ func ContractToDomain(contract *PluginContract) *internal.Plugin {
 	for _, envDTO := range contract.Env {
 		plugin.Env = append(plugin.Env, internal.EnvVar{Name: envDTO.Name})
 	}
+
 	for _, flagDTO := range contract.Flags {
 		plugin.Flags = append(plugin.Flags, internal.Flag{Name: flagDTO.Name})
 	}
@@ -291,6 +296,7 @@ func DomainToContract(plugin *internal.Plugin) *PluginContract {
 	for _, env := range plugin.Env {
 		contract.Env = append(contract.Env, EnvVarDTO{Name: env.Name})
 	}
+
 	for _, flag := range plugin.Flags {
 		contract.Flags = append(contract.Flags, FlagDTO{Name: flag.Name})
 	}
@@ -317,6 +323,7 @@ func pluginReqsToDomain(reqs []PluginRequirementDTO) []internal.PluginRequiremen
 	for _, r := range reqs {
 		out = append(out, internal.PluginRequirement{Name: r.Name, Constraint: r.Constraint})
 	}
+
 	return out
 }
 
@@ -325,6 +332,7 @@ func pluginReqsToDTO(reqs []internal.PluginRequirement) []PluginRequirementDTO {
 	for _, r := range reqs {
 		out = append(out, PluginRequirementDTO{Name: r.Name, Constraint: r.Constraint})
 	}
+
 	return out
 }
 
@@ -336,6 +344,7 @@ func moduleGroupToDomain(g ModuleRequirementsGroupDTO) internal.ModuleRequiremen
 			Modules:     moduleReqsToDomain(grp.Modules),
 		})
 	}
+
 	return internal.ModuleRequirementsGroup{
 		Mandatory:   moduleReqsToDomain(g.Mandatory),
 		Conditional: moduleReqsToDomain(g.Conditional),
@@ -351,6 +360,7 @@ func moduleGroupToDTO(g internal.ModuleRequirementsGroup) ModuleRequirementsGrou
 			Modules:     moduleReqsToDTO(grp.Modules),
 		})
 	}
+
 	return ModuleRequirementsGroupDTO{
 		Mandatory:   moduleReqsToDTO(g.Mandatory),
 		Conditional: moduleReqsToDTO(g.Conditional),
@@ -363,6 +373,7 @@ func moduleReqsToDomain(reqs []ModuleRequirementDTO) []internal.ModuleRequiremen
 	for _, r := range reqs {
 		out = append(out, internal.ModuleRequirement{Name: r.Name, Constraint: r.Constraint})
 	}
+
 	return out
 }
 
@@ -371,6 +382,7 @@ func moduleReqsToDTO(reqs []internal.ModuleRequirement) []ModuleRequirementDTO {
 	for _, r := range reqs {
 		out = append(out, ModuleRequirementDTO{Name: r.Name, Constraint: r.Constraint})
 	}
+
 	return out
 }
 
@@ -386,6 +398,7 @@ func (s *PluginService) ListPlugins(ctx context.Context) ([]string, error) {
 	if err != nil {
 		s.log.Warn("Failed to list repositories from registry. The registry may not allow catalog access or you may need special permissions.",
 			slog.String("error", err.Error()))
+
 		return nil, fmt.Errorf("failed to list repositories (registry may not allow catalog access): %w", err)
 	}
 

--- a/pkg/registry/service/service.go
+++ b/pkg/registry/service/service.go
@@ -65,6 +65,7 @@ func NewService(c client.Client, edition pkg.Edition, logger *log.Logger) *Servi
 	} else {
 		base = c.WithSegment(edition.String())
 	}
+
 	s.editionBase = base
 
 	s.modulesService = NewModulesService(base.WithSegment(moduleSegment), logger.Named("modules"))

--- a/testing/util/mirror/registry.go
+++ b/testing/util/mirror/registry.go
@@ -39,6 +39,7 @@ type ListableBlobHandler struct {
 func (h *ListableBlobHandler) Get(ctx context.Context, repo string, hash v1.Hash) (io.ReadCloser, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
 	h.ingestedBlobs = append(h.ingestedBlobs, hash.String())
 
 	return h.BlobHandler.Get(ctx, repo, hash)
@@ -67,6 +68,7 @@ func SetupEmptyRegistryRepo(useTLS bool) ( /*host*/ string /*repoPath*/, string,
 
 	host = strings.TrimPrefix(server.URL, "http://")
 	repoPath = "/deckhouse/ee"
+
 	if useTLS {
 		host = strings.TrimPrefix(server.URL, "https://")
 	}


### PR DESCRIPTION
## Description

Added the wsl_v5 linter to .golangci.yaml and fixed all resulting violations across 208 files by inserting blank lines where required by the wsl (whitespace) rule. The wsl_v5 linter enforces consistent blank line placement in Go code - specifically, it requires blank lines before return, break, continue, and after multi-line block openings, among other rules.

## Changes
- Enabled the wsl_v5 linter in .golangci.yaml
- Added blank lines throughout the codebase to satisfy wsl_v5 rules — no logic changes, only formatting