### PR TITLE
[deckhouse-cli] Preserve object-level default map

### DIFF
--- a/internal/packagecmd/internal/packages/values/schema/defaults/generator.go
+++ b/internal/packagecmd/internal/packages/values/schema/defaults/generator.go
@@ -9,7 +9,10 @@
 //  3. `enum`, preferring `default` if set, else the first enum value.
 //  4. Object walk — explicit `type: object`, structural `properties`, or
 //     composition keywords (allOf / oneOf / anyOf) contribute properties.
-//  5. `default` (deep-copied so callers may mutate the result).
+//     If `default` is a map, it is overlaid on top of the walked properties
+//     (same precedence rule as `x-example`), so a schema can declare both
+//     a property set and a richer default map without losing either.
+//  5. `default` for non-object schemas (deep-copied so callers may mutate).
 //  6. Array walk — one element synthesized from `items.schema`.
 //  7. Scalar placeholder by type: 123 for integer/number, true for boolean,
 //     a pattern-matching string via reggen for string.
@@ -132,7 +135,16 @@ func synthesizeValue(s *spec.Schema) (any, error) {
 	}
 
 	if isObject(s) {
-		return synthesizeObject(s)
+		base, err := synthesizeObject(s)
+		if err != nil {
+			return nil, err
+		}
+
+		if def, ok := s.Default.(map[string]any); ok {
+			deepMergeOverride(base, def)
+		}
+
+		return base, nil
 	}
 
 	if s.Default != nil {


### PR DESCRIPTION
## Problem

Object schemas with both `properties` and a `default: {...}` map silently dropped the default. `synthesizeValue` short-circuited on `isObject(s)` and returned the walk output, so rule 5 (`default`) never fired for object nodes.

## Fix

In the object branch, overlay a map-typed `s.Default` on top of the walked properties via `deepMergeOverride`. Same precedence as `x-example`: walked properties form the baseline, the default wins on conflicts, nested unset fields keep their synthesized fallbacks.

## Before / After

Schema:
```yaml
type: object
properties:
  name: { type: string }
  port: { type: integer }
default:
  name: "override"
  extra: "kept"
```

Before:
```yaml
name: "aB3xK9pQ"   # synthesized, default ignored
port: 123
```

After:
```yaml
name: "override"   # from default
port: 123          # from walk
extra: "kept"      # from default