### PR TITLE
[deckhouse-cli] mirror: add packages mirroring support

### DIFF
--- a/internal/layout.go
+++ b/internal/layout.go
@@ -36,6 +36,12 @@ import "path"
 //	<root>/modules/<module-name>:<version>                    - Module main image
 //	<root>/modules/<module-name>/release:<channel>            - Module release channel metadata
 //	<root>/modules/<module-name>/extra/<extra-name>:<version> - Module extra images
+//
+// Packages (same shape as modules, but under packages/ with a version/ release segment):
+//
+//	<root>/packages/<package-name>:<version>                    - Package main image
+//	<root>/packages/<package-name>/version:<channel>            - Package version channel metadata
+//	<root>/packages/<package-name>/extra/<extra-name>:<version> - Package extra images
 const (
 	InstallSegment           = "install"
 	InstallStandaloneSegment = "install-standalone"
@@ -44,6 +50,10 @@ const (
 	ModulesSegment        = "modules"
 	ModulesReleaseSegment = "release"
 	ModulesExtraSegment   = "extra"
+
+	PackagesSegment        = "packages"
+	PackagesVersionSegment = "version"
+	PackagesExtraSegment   = "extra"
 
 	InstallerSegment = "installer"
 
@@ -64,6 +74,10 @@ var pathByMirrorType = map[MirrorType]string{
 	// Module paths are relative to modules/<module-name>/ directory
 	MirrorTypeModules:                "",                    // Module main image at root of module dir
 	MirrorTypeModulesReleaseChannels: ModulesReleaseSegment, // modules/<name>/release
+
+	// Package paths are relative to packages/<package-name>/ directory
+	MirrorTypePackages:                "",                     // Package main image at root of package dir
+	MirrorTypePackagesVersionChannels: PackagesVersionSegment, // packages/<name>/version
 
 	MirrorTypeSecurity:                   SecuritySegment,
 	MirrorTypeSecurityTrivyDBSegment:     path.Join(SecuritySegment, SecurityTrivyDBSegment),

--- a/internal/mirror.go
+++ b/internal/mirror.go
@@ -30,4 +30,6 @@ const (
 	MirrorTypeSecurityTrivyBDUSegment
 	MirrorTypeSecurityTrivyJavaDBSegment
 	MirrorTypeSecurityTrivyChecksSegment
+	MirrorTypePackages
+	MirrorTypePackagesVersionChannels
 )

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -58,9 +58,8 @@ var (
 	ModulesWhitelist  []string
 	ModulesBlacklist  []string
 
-	PackagesPathSuffix string
-	PackagesWhitelist  []string
-	PackagesBlacklist  []string
+	PackagesWhitelist []string
+	PackagesBlacklist []string
 
 	SourceRegistryRepo     = EnterpriseEditionRepo // Fallback to EE if nothing was given as source.
 	SourceRegistryLogin    string
@@ -218,12 +217,6 @@ Packages are mirrored exactly like modules (same name@version constraint dialect
 		"exclude-package",
 		nil,
 		`Blacklist specific packages from downloading. Format is "package-name[@version]". Use one flag per each package. Overridden by use of --include-package.`,
-	)
-	flagSet.StringVar(
-		&PackagesPathSuffix,
-		"packages-path-suffix",
-		"/packages",
-		"Suffix to append to source repo path to locate packages.",
 	)
 	flagSet.Int64VarP(
 		&ImagesBundleChunkSizeGB,

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -58,6 +58,10 @@ var (
 	ModulesWhitelist  []string
 	ModulesBlacklist  []string
 
+	PackagesPathSuffix string
+	PackagesWhitelist  []string
+	PackagesBlacklist  []string
+
 	SourceRegistryRepo     = EnterpriseEditionRepo // Fallback to EE if nothing was given as source.
 	SourceRegistryLogin    string
 	SourceRegistryPassword string
@@ -70,6 +74,7 @@ var (
 	NoPlatform      bool
 	NoSecurityDB    bool
 	NoModules       bool
+	NoPackages      bool
 	NoInstaller     bool
 	OnlyExtraImages bool
 	SkipVexImages   bool
@@ -200,6 +205,26 @@ module-name@=v1.3.0+stable → exact tag match: include only v1.3.0 and and publ
 		"/modules",
 		"Suffix to append to source repo path to locate modules.",
 	)
+	flagSet.StringArrayVar(
+		&PackagesWhitelist,
+		"include-package",
+		nil,
+		`Whitelist specific packages for downloading. Use one flag per each package. Disables blacklisting by --exclude-package.
+
+Packages are mirrored exactly like modules (same name@version constraint dialect), but live under the packages/ registry segment with their release metadata under packages/<name>/version.`,
+	)
+	flagSet.StringArrayVar(
+		&PackagesBlacklist,
+		"exclude-package",
+		nil,
+		`Blacklist specific packages from downloading. Format is "package-name[@version]". Use one flag per each package. Overridden by use of --include-package.`,
+	)
+	flagSet.StringVar(
+		&PackagesPathSuffix,
+		"packages-path-suffix",
+		"/packages",
+		"Suffix to append to source repo path to locate packages.",
+	)
 	flagSet.Int64VarP(
 		&ImagesBundleChunkSizeGB,
 		"images-bundle-chunk-size",
@@ -248,6 +273,12 @@ module-name@=v1.3.0+stable → exact tag match: include only v1.3.0 and and publ
 		"no-modules",
 		false,
 		"Do not pull Deckhouse modules into bundle.",
+	)
+	flagSet.BoolVar(
+		&NoPackages,
+		"no-packages",
+		false,
+		"Do not pull Deckhouse packages into bundle.",
 	)
 	flagSet.BoolVar(
 		&NoInstaller,

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -156,7 +156,6 @@ func buildPullParams(logger params.Logger) *params.PullParams {
 			SkipTLSVerification:   pullflags.TLSSkipVerify,
 			DeckhouseRegistryRepo: pullflags.SourceRegistryRepo,
 			ModulesPathSuffix:     pullflags.ModulesPathSuffix,
-			PackagesPathSuffix:    pullflags.PackagesPathSuffix,
 			RegistryAuth:          getSourceRegistryAuthProvider(),
 			BundleDir:             pullflags.ImagesBundlePath,
 			WorkingDir: filepath.Join(

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -99,6 +99,7 @@ func NewCommand() *cobra.Command {
 
 	pullflags.AddFlags(pullCmd.Flags())
 	pullCmd.MarkFlagsMutuallyExclusive("include-module", "exclude-module")
+	pullCmd.MarkFlagsMutuallyExclusive("include-package", "exclude-package")
 	pullCmd.MarkFlagsMutuallyExclusive("include-platform", "deckhouse-tag")
 	pullCmd.MarkFlagsMutuallyExclusive("include-platform", "since-version")
 	pullCmd.MarkFlagsMutuallyExclusive("proxy-registry", "deckhouse-tag")
@@ -155,6 +156,7 @@ func buildPullParams(logger params.Logger) *params.PullParams {
 			SkipTLSVerification:   pullflags.TLSSkipVerify,
 			DeckhouseRegistryRepo: pullflags.SourceRegistryRepo,
 			ModulesPathSuffix:     pullflags.ModulesPathSuffix,
+			PackagesPathSuffix:    pullflags.PackagesPathSuffix,
 			RegistryAuth:          getSourceRegistryAuthProvider(),
 			BundleDir:             pullflags.ImagesBundlePath,
 			WorkingDir: filepath.Join(
@@ -171,6 +173,7 @@ func buildPullParams(logger params.Logger) *params.PullParams {
 		SkipPlatform:          pullflags.NoPlatform,
 		SkipSecurityDatabases: pullflags.NoSecurityDB,
 		SkipModules:           pullflags.NoModules,
+		SkipPackages:          pullflags.NoPackages,
 		SkipInstaller:         pullflags.NoInstaller,
 		OnlyExtraImages:       pullflags.OnlyExtraImages,
 		IgnoreSuspend:         pullflags.IgnoreSuspend,
@@ -285,6 +288,12 @@ func (p *Puller) Execute(ctx context.Context) error {
 		return err
 	}
 
+	// Create package filter from CLI flags
+	packageFilter, err := p.createPackageFilter()
+	if err != nil {
+		return err
+	}
+
 	svc := mirror.NewPullService(
 		registryservice.NewService(c, edition, logger),
 		pullflags.TempDir,
@@ -293,6 +302,7 @@ func (p *Puller) Execute(ctx context.Context) error {
 			SkipPlatform:       pullflags.NoPlatform,
 			SkipSecurity:       pullflags.NoSecurityDB,
 			SkipModules:        pullflags.NoModules,
+			SkipPackages:       pullflags.NoPackages,
 			SkipVexImages:      pullflags.SkipVexImages,
 			SkipInstaller:      pullflags.NoInstaller,
 			InstallerTag:       pullflags.InstallerTag,
@@ -300,6 +310,7 @@ func (p *Puller) Execute(ctx context.Context) error {
 			IgnoreSuspend:      pullflags.IgnoreSuspend,
 			PlatformConstraint: pullflags.PlatformConstraint,
 			ModuleFilter:       filter,
+			PackageFilter:      packageFilter,
 			BundleDir:          pullflags.ImagesBundlePath,
 			BundleChunkSize:    pullflags.ImagesBundleChunkSizeGB * 1000 * 1000 * 1000,
 			Timeout:            pullflags.MirrorTimeout,
@@ -407,6 +418,27 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 	filter, err := modules.NewFilter(pullflags.ModulesBlacklist, modules.FilterTypeBlacklist)
 	if err != nil {
 		return nil, fmt.Errorf("Prepare module filter: %w", err)
+	}
+
+	return filter, nil
+}
+
+// createPackageFilter creates the appropriate package filter based on whitelist/blacklist.
+// Packages reuse the modules filter because selection logic (names + semver
+// constraints) is identical.
+func (p *Puller) createPackageFilter() (*modules.Filter, error) {
+	if pullflags.PackagesWhitelist != nil {
+		filter, err := modules.NewFilter(pullflags.PackagesWhitelist, modules.FilterTypeWhitelist)
+		if err != nil {
+			return nil, fmt.Errorf("Prepare package filter: %w", err)
+		}
+
+		return filter, nil
+	}
+
+	filter, err := modules.NewFilter(pullflags.PackagesBlacklist, modules.FilterTypeBlacklist)
+	if err != nil {
+		return nil, fmt.Errorf("Prepare package filter: %w", err)
 	}
 
 	return filter, nil

--- a/internal/mirror/cmd/pull/pull_test.go
+++ b/internal/mirror/cmd/pull/pull_test.go
@@ -1262,6 +1262,7 @@ func TestPullFunction(t *testing.T) {
 	originalNoPlatform := pullflags.NoPlatform
 	originalNoSecurityDB := pullflags.NoSecurityDB
 	originalNoModules := pullflags.NoModules
+	originalNoPackages := pullflags.NoPackages
 	originalNoInstaller := pullflags.NoInstaller
 
 	defer func() {
@@ -1271,6 +1272,7 @@ func TestPullFunction(t *testing.T) {
 		pullflags.NoPlatform = originalNoPlatform
 		pullflags.NoSecurityDB = originalNoSecurityDB
 		pullflags.NoModules = originalNoModules
+		pullflags.NoPackages = originalNoPackages
 		pullflags.NoInstaller = originalNoInstaller
 	}()
 
@@ -1281,6 +1283,7 @@ func TestPullFunction(t *testing.T) {
 	pullflags.NoPlatform = true
 	pullflags.NoSecurityDB = true
 	pullflags.NoModules = true
+	pullflags.NoPackages = true
 	pullflags.NoInstaller = true
 
 	cmd := &cobra.Command{}

--- a/internal/mirror/packages/layout.go
+++ b/internal/mirror/packages/layout.go
@@ -184,20 +184,26 @@ func (l *ImageLayouts) AsList() []layout.Path {
 // package was discovered but no images were pulled into it).
 func (l *ImageLayouts) HasImages() bool {
 	for _, lp := range l.AsList() {
-		index, err := lp.ImageIndex()
-		if err != nil {
-			continue
-		}
-
-		manifest, err := index.IndexManifest()
-		if err != nil {
-			continue
-		}
-
-		if len(manifest.Manifests) > 0 {
+		if LayoutHasManifests(lp) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// LayoutHasManifests reports whether the OCI layout at the given path contains
+// at least one image manifest.
+func LayoutHasManifests(lp layout.Path) bool {
+	index, err := lp.ImageIndex()
+	if err != nil {
+		return false
+	}
+
+	manifest, err := index.IndexManifest()
+	if err != nil {
+		return false
+	}
+
+	return len(manifest.Manifests) > 0
 }

--- a/internal/mirror/packages/layout.go
+++ b/internal/mirror/packages/layout.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"fmt"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+
+	"github.com/deckhouse/deckhouse-cli/internal"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
+	regimage "github.com/deckhouse/deckhouse-cli/pkg/registry/image"
+)
+
+type PackagesDownloadList struct {
+	rootURL string
+	list    map[string]*ImageDownloadList
+}
+
+func NewPackagesDownloadList(rootURL string) *PackagesDownloadList {
+	return &PackagesDownloadList{
+		rootURL: rootURL,
+		list:    make(map[string]*ImageDownloadList),
+	}
+}
+
+func (l *PackagesDownloadList) Package(packageName string) *ImageDownloadList {
+	return l.list[packageName]
+}
+
+type ImageDownloadList struct {
+	rootURL string
+
+	Package                map[string]*puller.ImageMeta
+	PackageVersionChannels map[string]*puller.ImageMeta
+	PackageExtra           map[string]*puller.ImageMeta
+}
+
+func NewImageDownloadList(rootURL string) *ImageDownloadList {
+	return &ImageDownloadList{
+		rootURL: rootURL,
+
+		Package:                make(map[string]*puller.ImageMeta),
+		PackageVersionChannels: make(map[string]*puller.ImageMeta),
+		PackageExtra:           make(map[string]*puller.ImageMeta),
+	}
+}
+
+type PackagesImageLayouts struct {
+	platform   v1.Platform
+	workingDir string
+
+	list map[string]*ImageLayouts
+}
+
+func NewPackagesImageLayouts(rootFolder string) *PackagesImageLayouts {
+	l := &PackagesImageLayouts{
+		workingDir: rootFolder,
+		platform:   v1.Platform{Architecture: "amd64", OS: "linux"},
+		list:       make(map[string]*ImageLayouts),
+	}
+
+	return l
+}
+
+func (l *PackagesImageLayouts) Package(packageName string) *ImageLayouts {
+	return l.list[packageName]
+}
+
+// AsList returns a list of layout.Path's from all packages. Undefined path's are not included in the list.
+func (l *PackagesImageLayouts) AsList() []layout.Path {
+	var paths []layout.Path
+
+	for _, imgLayout := range l.list {
+		if imgLayout != nil {
+			paths = append(paths, imgLayout.AsList()...)
+		}
+	}
+
+	return paths
+}
+
+type ImageLayouts struct {
+	platform   v1.Platform
+	workingDir string
+
+	// Packages is the main package image layout (packages/<name>/)
+	Packages *regimage.ImageLayout
+	// PackageVersionChannels is the version channel layout (packages/<name>/version/)
+	PackageVersionChannels *regimage.ImageLayout
+	// ExtraImages holds layouts for each extra image (packages/<name>/extra/<extra-name>/)
+	// Key is the extra image name.
+	ExtraImages map[string]*regimage.ImageLayout
+}
+
+func NewImageLayouts(rootFolder string) *ImageLayouts {
+	l := &ImageLayouts{
+		workingDir:  rootFolder,
+		platform:    v1.Platform{Architecture: "amd64", OS: "linux"},
+		ExtraImages: make(map[string]*regimage.ImageLayout),
+	}
+
+	return l
+}
+
+func (l *ImageLayouts) setLayoutByMirrorType(rootFolder string, mirrorType internal.MirrorType) error {
+	layoutPath := filepath.Join(rootFolder, internal.InstallPathByMirrorType(mirrorType))
+
+	layout, err := regimage.NewImageLayout(layoutPath)
+	if err != nil {
+		return fmt.Errorf("failed to create image layout: %w", err)
+	}
+
+	switch mirrorType {
+	case internal.MirrorTypePackages:
+		l.Packages = layout
+	case internal.MirrorTypePackagesVersionChannels:
+		l.PackageVersionChannels = layout
+	default:
+		return fmt.Errorf("wrong mirror type in packages image layout: %v", mirrorType)
+	}
+
+	return nil
+}
+
+// GetOrCreateExtraLayout returns or creates a layout for a specific extra image.
+// Extra images are stored under: packages/<name>/extra/<extra-name>/
+func (l *ImageLayouts) GetOrCreateExtraLayout(extraName string) (*regimage.ImageLayout, error) {
+	if existing, ok := l.ExtraImages[extraName]; ok {
+		return existing, nil
+	}
+
+	// Create layout at packages/<package-name>/extra/<extra-name>/
+	layoutPath := filepath.Join(l.workingDir, "extra", extraName)
+
+	layout, err := regimage.NewImageLayout(layoutPath)
+	if err != nil {
+		return nil, fmt.Errorf("create extra image layout for %s: %w", extraName, err)
+	}
+
+	l.ExtraImages[extraName] = layout
+
+	return layout, nil
+}
+
+// AsList returns a list of layout.Path's in it. Undefined path's are not included in the list.
+func (l *ImageLayouts) AsList() []layout.Path {
+	paths := make([]layout.Path, 0)
+	if l.Packages != nil {
+		paths = append(paths, l.Packages.Path())
+	}
+
+	if l.PackageVersionChannels != nil {
+		paths = append(paths, l.PackageVersionChannels.Path())
+	}
+	// Add all extra image layouts
+	for _, extraLayout := range l.ExtraImages {
+		if extraLayout != nil {
+			paths = append(paths, extraLayout.Path())
+		}
+	}
+
+	return paths
+}
+
+// HasImages reports whether any sub-layout of this package contains at least
+// one image manifest. Returns false when all layouts are empty (i.e. the
+// package was discovered but no images were pulled into it).
+func (l *ImageLayouts) HasImages() bool {
+	for _, lp := range l.AsList() {
+		index, err := lp.ImageIndex()
+		if err != nil {
+			continue
+		}
+
+		manifest, err := index.IndexManifest()
+		if err != nil {
+			continue
+		}
+
+		if len(manifest.Manifests) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/mirror/packages/packages.go
+++ b/internal/mirror/packages/packages.go
@@ -1,0 +1,1091 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package packages mirrors Deckhouse "packages", which are structurally
+// identical to modules but live under a different set of registry segments:
+//
+//	<root>/packages/<name>:<version>             - package main image
+//	<root>/packages/<name>/version:<channel>     - package version-channel metadata
+//	<root>/packages/<name>/version:<vX.Y.Z>      - package version-tagged release metadata
+//	<root>/packages/<name>/extra/<extra>:<tag>   - package extra images
+//
+// The pull pipeline, filtering and version selection are intentionally the
+// same as for modules, so the generic version-selection vocabulary
+// (Filter, Module, VersionConstraint, ProbeAvailableVersions) is reused from
+// the modules package rather than duplicated here.
+package packages
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/deckhouse/deckhouse/pkg/registry/client"
+
+	"github.com/deckhouse/deckhouse-cli/internal"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/layouts"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
+)
+
+// Options contains configuration options for the packages service.
+type Options struct {
+	// Filter is the package filter (whitelist/blacklist). It reuses the
+	// modules filter because package selection works exactly like module
+	// selection (names + semver constraints).
+	Filter *modules.Filter
+	// OnlyExtraImages pulls only extra images without main package images
+	OnlyExtraImages bool
+	// SkipVexImages allows skipping VEX images
+	SkipVexImages bool
+	// BundleDir is the directory to store the bundle
+	BundleDir string
+	// BundleChunkSize is the max size of bundle chunks in bytes (0 = no chunking)
+	BundleChunkSize int64
+	// Timeout is the timeout for the packages access check
+	Timeout time.Duration
+	// DryRun prints the pull plan without downloading any image blobs
+	DryRun bool
+	// ProxyRegistry replaces catalog-based discovery with a sequential probe
+	// of individual version tags derived from the user's --include-package
+	// version constraint. See the modules service for the full rationale.
+	ProxyRegistry bool
+}
+
+type Service struct {
+	workingDir string
+
+	// packagesService handles Deckhouse packages registry operations
+	packagesService *registryservice.PackagesService
+	// layout manages the OCI image layouts for different components
+	layout *PackagesImageLayouts
+	// packagesDownloadList manages the list of images to be downloaded
+	packagesDownloadList *PackagesDownloadList
+	// pullerService handles the pulling of images
+	pullerService *puller.PullerService
+
+	// options contains service configuration
+	options *Options
+
+	// rootURL is the base registry URL for packages images
+	rootURL string
+
+	// logger is for internal debug logging
+	logger *dkplog.Logger
+	// userLogger is for user-facing informational messages
+	userLogger *log.SLogger
+}
+
+func NewService(
+	registryService *registryservice.Service,
+	workingDir string,
+	options *Options,
+	logger *dkplog.Logger,
+	userLogger *log.SLogger,
+) *Service {
+	userLogger.Infof("Creating OCI Image Layouts for Packages")
+
+	if options == nil {
+		options = &Options{}
+	}
+
+	// Create default filter (blacklist with no items = accept all)
+	if options.Filter == nil {
+		filter, _ := modules.NewFilter(nil, modules.FilterTypeBlacklist)
+		options.Filter = filter
+	}
+
+	// rootURL must include the edition segment (e.g. .../deckhouse/fe) so that
+	// per-package references like <rootURL>/packages/<name>:<tag> resolve to
+	// the same path served by registryService.PackageService().
+	rootURL := registryService.GetEditionRoot()
+
+	return &Service{
+		workingDir:           workingDir,
+		packagesService:      registryService.PackageService(),
+		packagesDownloadList: NewPackagesDownloadList(rootURL),
+		pullerService:        puller.NewPullerService(logger, userLogger),
+		options:              options,
+		rootURL:              rootURL,
+		logger:               logger,
+		userLogger:           userLogger,
+	}
+}
+
+// PullPackages pulls the Deckhouse packages.
+// It validates access to the registry and pulls the package images.
+func (svc *Service) PullPackages(ctx context.Context) error {
+	err := svc.validatePackagesAccess(ctx)
+	if err != nil {
+		return fmt.Errorf("validate packages access: %w", err)
+	}
+
+	err = svc.pullPackages(ctx)
+	if err != nil {
+		return fmt.Errorf("pull packages: %w", err)
+	}
+
+	return nil
+}
+
+// validatePackagesAccess validates access to the packages registry.
+func (svc *Service) validatePackagesAccess(ctx context.Context) error {
+	svc.logger.Debug("Validating access to the packages registry")
+
+	// Proxy registries typically refuse the catalog API entirely. The CLI has
+	// already required --include-package so we know exactly which packages to
+	// probe, and per-tag CheckImageExists/GetImage calls work fine against a
+	// proxy.
+	if svc.options.ProxyRegistry {
+		return nil
+	}
+
+	_, err := svc.packagesService.ListTags(ctx)
+	if errors.Is(err, client.ErrImageNotFound) {
+		svc.userLogger.Warnf("Skipping pull of packages: %v", err)
+
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to list packages from registry: %w", err)
+	}
+
+	return nil
+}
+
+// packageData represents a package with its metadata.
+type packageData struct {
+	name         string
+	registryPath string
+}
+
+func (svc *Service) pullPackages(ctx context.Context) error {
+	logger := svc.userLogger
+
+	// Temporary workspace for package OCI layouts.
+	tmpDir := filepath.Join(svc.workingDir, internal.PackagesSegment)
+
+	packageNames, err := svc.discoverPackageNames(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(packageNames) == 0 {
+		logger.WarnLn("Packages were not found, check your source repository address and packages path suffix")
+		return nil
+	}
+
+	// Filter-out packages that are not allowed by the filter (blacklist or whitelist)
+	filteredPackages := make([]packageData, 0)
+
+	for _, packageName := range packageNames {
+		pkg := &modules.Module{
+			Name:         packageName,
+			RegistryPath: filepath.Join(svc.rootURL, internal.PackagesSegment, packageName),
+		}
+		if svc.options.Filter.Match(pkg) {
+			filteredPackages = append(filteredPackages, packageData{
+				name:         packageName,
+				registryPath: pkg.RegistryPath,
+			})
+			logger.Infof("Package found: %s", packageName)
+		} else {
+			logger.Debugf("Package %s filtered out", packageName)
+		}
+	}
+
+	if len(filteredPackages) == 0 {
+		logger.WarnLn("No packages matched the filter criteria")
+		return nil
+	}
+
+	logger.Infof("Repo contains %d packages to pull", len(filteredPackages))
+
+	packageImagesLayout, err := createOCIImageLayoutsForPackages(tmpDir, getPackageNames(filteredPackages))
+	if err != nil {
+		return fmt.Errorf("create OCI image layouts for packages: %w", err)
+	}
+
+	svc.layout = packageImagesLayout
+
+	processName := "Pull Packages"
+	if svc.options.OnlyExtraImages {
+		processName = "Pull Extra Images"
+	}
+
+	// pullCancelled is set when the user interrupts mid-pull. In that case we
+	// still want the post-processing + packing phase to finalize whatever was
+	// successfully downloaded so far.
+	pullCancelled := false
+
+	err = logger.Process(processName, func() error {
+		for i, pkg := range filteredPackages {
+			if err := ctx.Err(); err != nil {
+				logger.Warnf("Pull cancelled; %d/%d packages attempted, will pack already-downloaded packages", i, len(filteredPackages))
+
+				pullCancelled = true
+
+				return nil
+			}
+
+			logger.Infof("[%d/%d] Processing package: %s", i+1, len(filteredPackages), pkg.name)
+
+			if err := svc.pullSinglePackage(ctx, pkg); err != nil {
+				if isContextErr(err) {
+					logger.Warnf("Pull of package %s cancelled, will pack already-downloaded packages", pkg.name)
+
+					pullCancelled = true
+
+					return nil
+				}
+
+				return fmt.Errorf("pull package %s: %w", pkg.name, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Skip OCI layout post-processing in dry-run (layouts are empty)
+	if svc.options.DryRun {
+		return nil
+	}
+
+	// Decouple the post-pull phase from the cancellation context so that the
+	// last bit of packing finalizes for the packages that *did* download.
+	postCtx := ctx
+	if pullCancelled {
+		postCtx = context.WithoutCancel(ctx)
+	}
+
+	err = logger.Process("Processing packages image indexes", func() error {
+		for _, l := range svc.layout.AsList() {
+			err = layouts.SortIndexManifests(l)
+			if err != nil {
+				return fmt.Errorf("sorting index manifests of %s: %w", l, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("processing packages image indexes: %w", err)
+	}
+
+	// Apply channel aliases if needed (not for OnlyExtraImages mode)
+	if !svc.options.OnlyExtraImages {
+		for _, pkg := range filteredPackages {
+			if err := svc.applyChannelAliases(pkg.name); err != nil {
+				return fmt.Errorf("apply channel aliases for package %s: %w", pkg.name, err)
+			}
+		}
+	}
+
+	// Pack each package into separate tar
+	if err := svc.packPackages(postCtx, filteredPackages); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// isContextErr reports whether err is one of the context cancellation errors,
+// either directly or wrapped.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func (svc *Service) pullSinglePackage(ctx context.Context, pkg packageData) error {
+	downloadList := NewImageDownloadList(filepath.Join(svc.rootURL, internal.PackagesSegment, pkg.name))
+	svc.packagesDownloadList.list[pkg.name] = downloadList
+
+	channelVersions, err := svc.discoverChannelVersions(ctx, pkg.name, downloadList)
+	if err != nil {
+		return err
+	}
+
+	tags, err := svc.listTagsIfConstrained(ctx, pkg.name)
+	if err != nil {
+		return err
+	}
+
+	packageVersions := svc.mergeAndDedupeVersions(pkg.name, pkg.registryPath, channelVersions, tags)
+
+	if svc.options.DryRun {
+		svc.printDryRunPlan(pkg.name, downloadList, packageVersions)
+		return nil
+	}
+
+	if !svc.options.OnlyExtraImages {
+		if err := svc.pullPackageImages(ctx, pkg.name, packageVersions, downloadList); err != nil {
+			return err
+		}
+
+		svc.pullVersionReleaseImages(ctx, pkg.name, packageVersions, downloadList)
+		svc.pullInternalDigestImages(ctx, pkg.name, packageVersions, downloadList)
+	}
+
+	if err := svc.pullExtraImages(ctx, pkg.name, packageVersions, downloadList); err != nil {
+		return err
+	}
+
+	if !svc.options.SkipVexImages {
+		svc.pullVexImages(ctx, pkg.name, downloadList)
+	}
+
+	return nil
+}
+
+// discoverChannelVersions enqueues version-channel refs into downloadList,
+// optionally pulls them (skipped on DryRun), and returns versions extracted
+// from those channels.
+func (svc *Service) discoverChannelVersions(ctx context.Context, packageName string, downloadList *ImageDownloadList) ([]string, error) {
+	if !svc.options.Filter.ShouldMirrorReleaseChannels(packageName) || svc.options.OnlyExtraImages {
+		return nil, nil
+	}
+
+	for _, channel := range internal.GetAllDefaultReleaseChannels() {
+		downloadList.PackageVersionChannels[svc.versionRef(packageName, channel)] = nil
+	}
+
+	// Add LTS channel if it exists
+	if err := svc.packagesService.Package(packageName).VersionChannels().CheckImageExists(ctx, internal.LTSChannel); err == nil {
+		downloadList.PackageVersionChannels[svc.versionRef(packageName, internal.LTSChannel)] = nil
+	}
+
+	if !svc.options.DryRun {
+		config := puller.PullConfig{
+			Name:             packageName + " version channels",
+			ImageSet:         downloadList.PackageVersionChannels,
+			Layout:           svc.layout.Package(packageName).PackageVersionChannels,
+			AllowMissingTags: true,
+			GetterService:    svc.packagesService.Package(packageName).VersionChannels(),
+		}
+
+		if err := svc.pullerService.PullImages(ctx, config); err != nil {
+			return nil, fmt.Errorf("pull version channels: %w", err)
+		}
+	}
+
+	// Calls GetImage() directly against the remote registry, not from the local
+	// OCI layout, so it works in DryRun too.
+	return svc.extractVersionsFromVersionChannels(ctx, packageName), nil
+}
+
+// discoverPackageNames returns the list of package names this run should
+// consider. The behaviour mirrors the modules service: ListTags on the
+// packages root by default, or the whitelist filter when --proxy-registry
+// is set.
+func (svc *Service) discoverPackageNames(ctx context.Context) ([]string, error) {
+	if svc.options.ProxyRegistry {
+		if svc.options.Filter == nil || !svc.options.Filter.IsWhitelist() {
+			return nil, fmt.Errorf("--proxy-registry requires a whitelist of packages (--include-package)")
+		}
+
+		return svc.options.Filter.ModuleNames(), nil
+	}
+
+	packageNames, err := svc.packagesService.ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list packages: %w", err)
+	}
+
+	return packageNames, nil
+}
+
+// listTagsIfConstrained returns the package's tag list, but only when the
+// filter has a non-exact (semver) constraint.
+func (svc *Service) listTagsIfConstrained(ctx context.Context, packageName string) ([]string, error) {
+	constraint, hasConstraint := svc.options.Filter.GetConstraint(packageName)
+	if !hasConstraint || constraint.IsExact() {
+		return nil, nil
+	}
+
+	if svc.options.ProxyRegistry {
+		return svc.probePackageTags(ctx, packageName, constraint)
+	}
+
+	tags, err := svc.packagesService.Package(packageName).ListTags(ctx)
+	switch {
+	case errors.Is(err, client.ErrImageNotFound):
+		svc.userLogger.Warnf("Skipping tag list for package %s: %v", packageName, err)
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("list tags for package %s: %w", packageName, err)
+	}
+
+	return tags, nil
+}
+
+// probePackageTags walks tags for a single package via HEAD requests instead
+// of asking the registry to enumerate them.
+func (svc *Service) probePackageTags(ctx context.Context, packageName string, constraint modules.VersionConstraint) ([]string, error) {
+	semverConstraint, ok := constraint.(*modules.SemanticVersionConstraint)
+	if !ok {
+		return nil, fmt.Errorf("package %s: --proxy-registry only supports semver-style constraints, got %T", packageName, constraint)
+	}
+
+	check := func(ctx context.Context, v *semver.Version) (bool, error) {
+		tag := "v" + v.String()
+
+		err := svc.packagesService.Package(packageName).CheckImageExists(ctx, tag)
+		if err == nil {
+			return true, nil
+		}
+
+		if errors.Is(err, client.ErrImageNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("check package %s tag %q: %w", packageName, tag, err)
+	}
+
+	versions, err := modules.ProbeAvailableVersions(ctx, semverConstraint, check)
+	if err != nil {
+		return nil, fmt.Errorf("probe tags for package %s: %w", packageName, err)
+	}
+
+	tags := make([]string, 0, len(versions))
+	for _, v := range versions {
+		tags = append(tags, "v"+v.String())
+	}
+
+	return tags, nil
+}
+
+// mergeAndDedupeVersions merges channel-derived versions with versions resolved
+// from filter constraints over the given tags, then deduplicates.
+func (svc *Service) mergeAndDedupeVersions(packageName, registryPath string, channelVersions, tags []string) []string {
+	versions := append([]string(nil), channelVersions...)
+
+	pkg := &modules.Module{
+		Name:         packageName,
+		RegistryPath: registryPath,
+		Releases:     tags,
+	}
+	versions = append(versions, svc.options.Filter.VersionsToMirror(pkg)...)
+
+	return deduplicateStrings(versions)
+}
+
+// printDryRunPlan prints the set of refs that would be pulled, without downloading.
+func (svc *Service) printDryRunPlan(packageName string, downloadList *ImageDownloadList, versions []string) {
+	svc.userLogger.InfoLn("[dry-run] Package '" + packageName + "' images that would be pulled:")
+
+	for ref := range downloadList.PackageVersionChannels {
+		svc.userLogger.InfoLn("  " + ref)
+	}
+
+	for _, version := range versions {
+		svc.userLogger.InfoLn("  " + svc.packageRef(packageName, version))
+	}
+
+	if len(versions) > 0 {
+		svc.userLogger.InfoLn("  (extra images discovery requires a real pull)")
+	}
+}
+
+// pullPackageImages pulls package images for the given versions (packages/<name>:vX.Y.Z).
+func (svc *Service) pullPackageImages(ctx context.Context, packageName string, versions []string, downloadList *ImageDownloadList) error {
+	if len(versions) == 0 {
+		return nil
+	}
+
+	for _, version := range versions {
+		downloadList.Package[svc.packageRef(packageName, version)] = nil
+	}
+
+	config := puller.PullConfig{
+		Name:             packageName + " images",
+		ImageSet:         downloadList.Package,
+		Layout:           svc.layout.Package(packageName).Packages,
+		AllowMissingTags: true,
+		GetterService:    svc.packagesService.Package(packageName),
+	}
+
+	if err := svc.pullerService.PullImages(ctx, config); err != nil {
+		return fmt.Errorf("pull package images: %w", err)
+	}
+
+	return nil
+}
+
+// pullVersionReleaseImages pulls packages/<name>/version:vX.Y.Z tags in addition
+// to channel tags (alpha, beta, ...). These may not exist for every version, so
+// errors are logged at Debug and not propagated.
+func (svc *Service) pullVersionReleaseImages(ctx context.Context, packageName string, versions []string, downloadList *ImageDownloadList) {
+	if len(versions) == 0 {
+		return
+	}
+
+	versionReleaseSet := make(map[string]*puller.ImageMeta)
+	for _, version := range versions {
+		versionReleaseSet[svc.versionRef(packageName, version)] = nil
+		downloadList.PackageVersionChannels[svc.versionRef(packageName, version)] = nil
+	}
+
+	config := puller.PullConfig{
+		Name:             packageName + " version releases",
+		ImageSet:         versionReleaseSet,
+		Layout:           svc.layout.Package(packageName).PackageVersionChannels,
+		AllowMissingTags: true,
+		GetterService:    svc.packagesService.Package(packageName).VersionChannels(),
+	}
+
+	if err := svc.pullerService.PullImages(ctx, config); err != nil {
+		svc.logger.Debug(fmt.Sprintf("Failed to pull version release images for %s: %v", packageName, err))
+	}
+}
+
+// pullInternalDigestImages discovers and pulls images referenced by
+// images_digests.json inside each package version.
+func (svc *Service) pullInternalDigestImages(ctx context.Context, packageName string, versions []string, downloadList *ImageDownloadList) {
+	digestImages := svc.extractInternalDigestImages(ctx, packageName, versions)
+	if len(digestImages) == 0 {
+		return
+	}
+
+	digestImageSet := make(map[string]*puller.ImageMeta)
+	for _, digestRef := range digestImages {
+		digestImageSet[digestRef] = nil
+		downloadList.Package[digestRef] = nil
+	}
+
+	config := puller.PullConfig{
+		Name:             packageName + " internal images",
+		ImageSet:         digestImageSet,
+		Layout:           svc.layout.Package(packageName).Packages,
+		AllowMissingTags: true,
+		GetterService:    svc.packagesService.Package(packageName),
+	}
+
+	if err := svc.pullerService.PullImages(ctx, config); err != nil {
+		svc.logger.Debug(fmt.Sprintf("Failed to pull internal digest images for %s: %v", packageName, err))
+	}
+}
+
+// pullExtraImages discovers extra images declared by each package version and
+// pulls them into per-extra layouts (packages/<name>/extra/<extra-name>/).
+func (svc *Service) pullExtraImages(ctx context.Context, packageName string, versions []string, downloadList *ImageDownloadList) error {
+	extraImagesByName := svc.findExtraImages(ctx, packageName, versions)
+
+	for extraName, images := range extraImagesByName {
+		if len(images) == 0 {
+			continue
+		}
+
+		extraLayout, err := svc.layout.Package(packageName).GetOrCreateExtraLayout(extraName)
+		if err != nil {
+			return fmt.Errorf("create layout for extra image %s: %w", extraName, err)
+		}
+
+		imageSet := make(map[string]*puller.ImageMeta)
+		for _, img := range images {
+			imageSet[img.FullRef] = nil
+			downloadList.PackageExtra[img.FullRef] = nil
+		}
+
+		config := puller.PullConfig{
+			Name:             packageName + "/" + extraName,
+			ImageSet:         imageSet,
+			Layout:           extraLayout,
+			AllowMissingTags: true,
+			GetterService:    svc.packagesService.Package(packageName).ExtraImage(extraName),
+		}
+
+		if err := svc.pullerService.PullImages(ctx, config); err != nil {
+			return fmt.Errorf("pull extra image %s: %w", extraName, err)
+		}
+	}
+
+	return nil
+}
+
+// pullVexImages finds and pulls VEX attestation images for package images.
+func (svc *Service) pullVexImages(ctx context.Context, packageName string, downloadList *ImageDownloadList) {
+	allImages := make([]string, 0, len(downloadList.Package)+len(downloadList.PackageExtra))
+
+	for img := range downloadList.Package {
+		allImages = append(allImages, img)
+	}
+
+	for img := range downloadList.PackageExtra {
+		allImages = append(allImages, img)
+	}
+
+	vexImageSet := make(map[string]*puller.ImageMeta)
+
+	for _, img := range allImages {
+		vexImageName, err := svc.findVexImage(ctx, packageName, img)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to find VEX image for %s: %v", img, err))
+			continue
+		}
+
+		if vexImageName != "" {
+			svc.logger.Debug(fmt.Sprintf("Found VEX image: %s", vexImageName))
+			vexImageSet[vexImageName] = nil
+			downloadList.Package[vexImageName] = nil
+		}
+	}
+
+	if len(vexImageSet) > 0 {
+		config := puller.PullConfig{
+			Name:             packageName + " VEX images",
+			ImageSet:         vexImageSet,
+			Layout:           svc.layout.Package(packageName).Packages,
+			AllowMissingTags: true,
+			GetterService:    svc.packagesService.Package(packageName),
+		}
+
+		if err := svc.pullerService.PullImages(ctx, config); err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to pull VEX images for %s: %v", packageName, err))
+		}
+	}
+}
+
+// findVexImage checks if a VEX attestation image exists for the given image.
+func (svc *Service) findVexImage(ctx context.Context, packageName string, imageRef string) (string, error) {
+	vexImageName := strings.Replace(strings.Replace(imageRef, "@sha256:", "@sha256-", 1), "@sha256", ":sha256", 1) + ".att"
+
+	splitIndex := strings.LastIndex(vexImageName, ":")
+	if splitIndex == -1 {
+		return "", nil
+	}
+
+	tag := vexImageName[splitIndex+1:]
+
+	err := svc.packagesService.Package(packageName).CheckImageExists(ctx, tag)
+	if errors.Is(err, client.ErrImageNotFound) {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return vexImageName, nil
+}
+
+// extractVersionsFromVersionChannels extracts version tags from pulled version channel images.
+func (svc *Service) extractVersionsFromVersionChannels(ctx context.Context, packageName string) []string {
+	versions := make([]string, 0)
+
+	channels := internal.GetAllDefaultReleaseChannels()
+
+	if err := svc.packagesService.Package(packageName).VersionChannels().CheckImageExists(ctx, internal.LTSChannel); err == nil {
+		channels = append(channels, internal.LTSChannel)
+	}
+
+	for _, channel := range channels {
+		img, err := svc.packagesService.Package(packageName).VersionChannels().GetImage(ctx, channel)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to get version channel image for %s/%s: %v", packageName, channel, err))
+			continue
+		}
+
+		versionJSON, err := extractVersionJSON(img)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to extract version.json for %s/%s: %v", packageName, channel, err))
+			continue
+		}
+
+		if versionJSON.Version != "" {
+			version := versionJSON.Version
+			if !strings.HasPrefix(version, "v") {
+				version = "v" + version
+			}
+
+			versions = append(versions, version)
+		}
+	}
+
+	return versions
+}
+
+type versionJSON struct {
+	Version string `json:"version"`
+}
+
+// extractVersionJSON extracts version.json from an image using the Extract method.
+func extractVersionJSON(img interface{ Extract() io.ReadCloser }) (*versionJSON, error) {
+	rc := img.Extract()
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("version.json not found in image")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if hdr.Name == "version.json" {
+			var version versionJSON
+			if err := json.NewDecoder(tr).Decode(&version); err != nil {
+				return nil, fmt.Errorf("parse version.json: %w", err)
+			}
+
+			return &version, nil
+		}
+	}
+}
+
+// extraImageInfo holds information about an extra image to pull.
+type extraImageInfo struct {
+	Name    string
+	Tag     string
+	FullRef string
+}
+
+// findExtraImages finds extra images from package images.
+// Extra images are stored under: packages/<name>/extra/<extra-name>:<tag>
+func (svc *Service) findExtraImages(ctx context.Context, packageName string, versions []string) map[string][]extraImageInfo {
+	extraImages := make(map[string][]extraImageInfo)
+
+	for _, version := range versions {
+		if strings.Contains(version, "@sha256:") {
+			continue
+		}
+
+		tag := version
+		if strings.Contains(version, ":") {
+			parts := strings.SplitN(version, ":", 2)
+			tag = parts[1]
+		}
+
+		img, err := svc.packagesService.Package(packageName).GetImage(ctx, tag)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to get package image %s:%s: %v", packageName, tag, err))
+			continue
+		}
+
+		extraImagesJSON, err := extractExtraImagesJSON(img)
+		if err != nil {
+			continue // No extra_images.json in this version
+		}
+
+		for imageName, tagValue := range extraImagesJSON {
+			var imageTag string
+
+			switch v := tagValue.(type) {
+			case float64:
+				imageTag = fmt.Sprintf("%.0f", v)
+			case int:
+				imageTag = fmt.Sprintf("%d", v)
+			case string:
+				imageTag = v
+			default:
+				continue
+			}
+
+			fullImagePath := svc.rootURL + "/" + internal.PackagesSegment + "/" + packageName + "/" + internal.PackagesExtraSegment + "/" + imageName + ":" + imageTag
+
+			extraImages[imageName] = append(extraImages[imageName], extraImageInfo{
+				Name:    imageName,
+				Tag:     imageTag,
+				FullRef: fullImagePath,
+			})
+		}
+	}
+
+	return extraImages
+}
+
+// extractExtraImagesJSON extracts extra_images.json from an image.
+func extractExtraImagesJSON(img interface{ Extract() io.ReadCloser }) (map[string]interface{}, error) {
+	rc := img.Extract()
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("extra_images.json not found in image")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if hdr.Name == "extra_images.json" {
+			var extraImages map[string]interface{}
+			if err := json.NewDecoder(tr).Decode(&extraImages); err != nil {
+				return nil, fmt.Errorf("parse extra_images.json: %w", err)
+			}
+
+			return extraImages, nil
+		}
+	}
+}
+
+// extractInternalDigestImages extracts internal digest images from package versions.
+func (svc *Service) extractInternalDigestImages(ctx context.Context, packageName string, versions []string) []string {
+	seenDigests := make(map[string]struct{})
+
+	var digestRefs []string
+
+	packageRepo := svc.rootURL + "/" + internal.PackagesSegment + "/" + packageName
+
+	for _, version := range versions {
+		if strings.Contains(version, "@sha256:") {
+			continue
+		}
+
+		tag := version
+		if strings.Contains(version, ":") {
+			parts := strings.SplitN(version, ":", 2)
+			tag = parts[1]
+		}
+
+		img, err := svc.packagesService.Package(packageName).GetImage(ctx, tag)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("Failed to get package image %s:%s for digest extraction: %v", packageName, tag, err))
+			continue
+		}
+
+		digests, err := extractImagesDigestsJSON(img)
+		if err != nil {
+			svc.logger.Debug(fmt.Sprintf("No images_digests.json in %s:%s: %v", packageName, tag, err))
+			continue
+		}
+
+		svc.logger.Debug(fmt.Sprintf("Found %d internal digests in %s:%s", len(digests), packageName, tag))
+
+		for _, digest := range digests {
+			if _, seen := seenDigests[digest]; seen {
+				continue
+			}
+
+			seenDigests[digest] = struct{}{}
+
+			digestRef := packageRepo + "@" + digest
+			digestRefs = append(digestRefs, digestRef)
+		}
+	}
+
+	return digestRefs
+}
+
+// digestRegex matches sha256 digests in images_digests.json.
+var digestRegex = regexp.MustCompile(`sha256:[a-f0-9]{64}`)
+
+// extractImagesDigestsJSON extracts images_digests.json from a package image
+// and returns a list of sha256 digests.
+func extractImagesDigestsJSON(img interface{ Extract() io.ReadCloser }) ([]string, error) {
+	rc := img.Extract()
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, fmt.Errorf("images_digests.json not found in image")
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if hdr.Name == "images_digests.json" {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("read images_digests.json: %w", err)
+			}
+
+			digests := digestRegex.FindAllString(string(data), -1)
+
+			return digests, nil
+		}
+	}
+}
+
+// applyChannelAliases applies version channel tags to images with exact tag constraints.
+func (svc *Service) applyChannelAliases(packageName string) error {
+	constraint, ok := svc.options.Filter.GetConstraint(packageName)
+	if !ok || !constraint.IsExact() {
+		return nil
+	}
+
+	exact, ok := constraint.(*modules.ExactTagConstraint)
+	if !ok {
+		return nil
+	}
+
+	packageLayout := svc.layout.Package(packageName)
+	if packageLayout == nil || packageLayout.PackageVersionChannels == nil {
+		return nil
+	}
+
+	desc, err := layouts.FindImageDescriptorByTag(packageLayout.PackageVersionChannels.Path(), exact.Tag())
+	if err != nil {
+		if errors.Is(err, layouts.ErrImageNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	if exact.HasChannelAlias() {
+		if err := layouts.TagImage(packageLayout.PackageVersionChannels.Path(), desc.Digest, exact.Channel()); err != nil {
+			return err
+		}
+	} else {
+		for _, channel := range append(internal.GetAllDefaultReleaseChannels(), internal.LTSChannel) {
+			if err := layouts.TagImage(packageLayout.PackageVersionChannels.Path(), desc.Digest, channel); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (svc *Service) packPackages(ctx context.Context, pkgs []packageData) error {
+	logger := svc.userLogger
+
+	bundleDir := svc.options.BundleDir
+	bundleChunkSize := svc.options.BundleChunkSize
+
+	for _, pkg := range pkgs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		pkgName := "package-" + pkg.name + ".tar"
+
+		packageLayout := svc.layout.Package(pkg.name)
+		if packageLayout == nil {
+			return fmt.Errorf("no layout found for package %s", pkg.name)
+		}
+
+		// Skip packages that produced no images silently.
+		if !packageLayout.HasImages() {
+			continue
+		}
+
+		if err := logger.Process(fmt.Sprintf("Pack %s", pkgName), func() error {
+			// Pack from the package's working directory with prefix to create
+			// the correct registry structure (packages/<name>/index.json ...).
+			packageDir := filepath.Join(svc.layout.workingDir, pkg.name)
+			tarPrefix := filepath.Join(internal.PackagesSegment, pkg.name)
+
+			return pack.Bundle(ctx, bundleDir, pkgName, bundleChunkSize, func(w io.Writer) error {
+				return bundle.PackWithPrefix(ctx, packageDir, tarPrefix, w)
+			})
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// packageRef builds the registry reference for a package main image tag.
+func (svc *Service) packageRef(packageName, tag string) string {
+	return svc.rootURL + "/" + internal.PackagesSegment + "/" + packageName + ":" + tag
+}
+
+// versionRef builds the registry reference for a package version-channel tag.
+func (svc *Service) versionRef(packageName, tag string) string {
+	return svc.rootURL + "/" + internal.PackagesSegment + "/" + packageName + "/" + internal.PackagesVersionSegment + ":" + tag
+}
+
+func getPackageNames(pkgs []packageData) []string {
+	names := make([]string, len(pkgs))
+	for i, p := range pkgs {
+		names[i] = p.name
+	}
+
+	return names
+}
+
+func deduplicateStrings(items []string) []string {
+	seen := make(map[string]struct{})
+
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if _, ok := seen[item]; !ok {
+			seen[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+
+	return result
+}
+
+func createOCIImageLayoutsForPackages(
+	rootFolder string,
+	pkgs []string,
+) (*PackagesImageLayouts, error) {
+	layouts := NewPackagesImageLayouts(rootFolder)
+
+	for _, packageName := range pkgs {
+		packageLayouts, err := createOCIImageLayoutsForPackage(
+			filepath.Join(rootFolder, packageName),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create OCI image layouts for package %s: %w", packageName, err)
+		}
+
+		layouts.list[packageName] = packageLayouts
+	}
+
+	return layouts, nil
+}
+
+func createOCIImageLayoutsForPackage(
+	rootFolder string,
+) (*ImageLayouts, error) {
+	layouts := NewImageLayouts(rootFolder)
+
+	// Only create layouts for main package and version channels.
+	// Extra image layouts are created dynamically when extra images are discovered.
+	mirrorTypes := []internal.MirrorType{
+		internal.MirrorTypePackages,
+		internal.MirrorTypePackagesVersionChannels,
+	}
+
+	for _, mtype := range mirrorTypes {
+		err := layouts.setLayoutByMirrorType(rootFolder, mtype)
+		if err != nil {
+			return nil, fmt.Errorf("set layout by mirror type %v: %w", mtype, err)
+		}
+	}
+
+	return layouts, nil
+}

--- a/internal/mirror/packages/packages.go
+++ b/internal/mirror/packages/packages.go
@@ -52,6 +52,7 @@ import (
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/layouts"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+	regimage "github.com/deckhouse/deckhouse-cli/pkg/registry/image"
 	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
 )
 
@@ -153,6 +154,134 @@ func (svc *Service) PullPackages(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// PullPackageVersions pulls the release/version images of every package and
+// packs them into a single shared archive (package-versions.tar).
+//
+// Unlike PullPackages this runs on EVERY mirror operation, independently of
+// which components are being mirrored and of the --no-packages flag, so the
+// package release-image catalog is always cloned into the bundle. Release
+// images may therefore be duplicated between this archive and the per-package
+// archives produced by PullPackages — that duplication is intentional.
+func (svc *Service) PullPackageVersions(ctx context.Context) error {
+	logger := svc.userLogger
+
+	names, err := svc.discoverPackageNames(ctx)
+	if err != nil {
+		// A registry without a packages catalog must never break the rest of
+		// the mirror operation: just skip the package-versions archive.
+		logger.Warnf("Skipping package release images (package-versions): %v", err)
+		return nil
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+
+	if svc.options.DryRun {
+		logger.InfoLn("[dry-run] package-versions archive would contain release images for: " + strings.Join(names, ", "))
+		return nil
+	}
+
+	// Dedicated working dir so this never collides with the per-package pull
+	// working dir (".../packages") used by PullPackages.
+	versionsRoot := filepath.Join(svc.workingDir, "package-versions")
+
+	sources := make([]bundle.PackSource, 0, len(names))
+
+	err = logger.Process("Pull Package Release Images", func() error {
+		for i, name := range names {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			logger.Infof("[%d/%d] Pulling release images for package: %s", i+1, len(names), name)
+
+			versionDir := filepath.Join(versionsRoot, name, internal.PackagesVersionSegment)
+
+			versionLayout, err := regimage.NewImageLayout(versionDir)
+			if err != nil {
+				return fmt.Errorf("create version layout for package %s: %w", name, err)
+			}
+
+			if err := svc.pullAllVersionImages(ctx, name, versionLayout); err != nil {
+				if isContextErr(err) {
+					return err
+				}
+
+				logger.Warnf("Failed to pull release images for package %s: %v", name, err)
+
+				continue
+			}
+
+			if err := layouts.SortIndexManifests(versionLayout.Path()); err != nil {
+				return fmt.Errorf("sort index manifests for package %s: %w", name, err)
+			}
+
+			// Skip packages whose version repo produced no images.
+			if !LayoutHasManifests(versionLayout.Path()) {
+				continue
+			}
+
+			sources = append(sources, bundle.PackSource{
+				Dir:    versionDir,
+				Prefix: filepath.Join(internal.PackagesSegment, name, internal.PackagesVersionSegment),
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(sources) == 0 {
+		logger.InfoLn("No package release images found, skipping package-versions archive")
+		return nil
+	}
+
+	return logger.Process("Pack package-versions.tar", func() error {
+		return pack.Bundle(ctx, svc.options.BundleDir, "package-versions.tar", svc.options.BundleChunkSize, func(w io.Writer) error {
+			return bundle.PackSourcesWithPrefix(ctx, w, sources...)
+		})
+	})
+}
+
+// pullAllVersionImages pulls every release/version image for a single package
+// (default release channels, the LTS channel when present, and the version
+// tags advertised by those channels) into the provided layout.
+func (svc *Service) pullAllVersionImages(ctx context.Context, packageName string, versionLayout *regimage.ImageLayout) error {
+	pkgSvc := svc.packagesService.Package(packageName)
+
+	imageSet := make(map[string]*puller.ImageMeta)
+
+	for _, channel := range internal.GetAllDefaultReleaseChannels() {
+		imageSet[svc.versionRef(packageName, channel)] = nil
+	}
+
+	if err := pkgSvc.VersionChannels().CheckImageExists(ctx, internal.LTSChannel); err == nil {
+		imageSet[svc.versionRef(packageName, internal.LTSChannel)] = nil
+	}
+
+	// Version tags (vX.Y.Z) advertised by the channels' version.json.
+	for _, version := range svc.extractVersionsFromVersionChannels(ctx, packageName) {
+		imageSet[svc.versionRef(packageName, version)] = nil
+	}
+
+	if len(imageSet) == 0 {
+		return nil
+	}
+
+	config := puller.PullConfig{
+		Name:             packageName + " release images",
+		ImageSet:         imageSet,
+		Layout:           versionLayout,
+		AllowMissingTags: true,
+		GetterService:    pkgSvc.VersionChannels(),
+	}
+
+	return svc.pullerService.PullImages(ctx, config)
 }
 
 // validatePackagesAccess validates access to the packages registry.

--- a/internal/mirror/packages/packages_test.go
+++ b/internal/mirror/packages/packages_test.go
@@ -1,0 +1,1025 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	golayout "github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	dkpreg "github.com/deckhouse/deckhouse/pkg/registry"
+	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
+
+	"github.com/deckhouse/deckhouse-cli/internal"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
+	"github.com/deckhouse/deckhouse-cli/pkg"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+	pkgclient "github.com/deckhouse/deckhouse-cli/pkg/registry/client"
+	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
+)
+
+// =============================================================================
+// Shared fixtures
+// =============================================================================
+
+const (
+	testHost        = "fake.registry"
+	testPackageName = "console"
+	channelVersion  = "v1.45.2" // version every version-channel points at
+)
+
+// defaultRegistryVersions is a small but representative tag set for tests
+// that don't care about the exact list - a few patches and a few minors.
+var defaultRegistryVersions = []string{"v1.40.0", "v1.40.1", "v1.41.0", "v1.45.2"}
+
+// =============================================================================
+// Tests: which versions get pulled
+// =============================================================================
+
+// Regression for --include-package <name>@<semver>: every (major, minor) bucket
+// in the registry that satisfies the semver constraint must contribute exactly
+// its highest patch to the download list. Packages reuse the modules filter, so
+// this pins down that the same latest-patch-per-minor + inclusive-anchor policy
+// is wired through the package pull flow.
+//
+// The version pinned by the version-channel snapshot (`channelVersion`) is
+// always pulled in addition to the constraint-derived set, so it must appear
+// in every wantTags below.
+func TestPullPackages_SemverConstraintPullsAllMatchingTags(t *testing.T) {
+	registryVersions := []string{
+		"v1.39.0",
+		// Two patches in 1.40.x to exercise the per-minor collapse.
+		"v1.40.0", "v1.40.1",
+		"v1.41.0", "v1.42.0", "v1.43.0",
+		channelVersion,
+	}
+
+	cases := []struct {
+		name       string
+		constraint string   // text after "<package>@" in --include-package
+		wantTags   []string // tags expected to land in the download list
+		rejectTags []string // tags present in the registry that the constraint must reject
+	}{
+		{
+			name:       "implicit caret (1.40.0 -> ^1.40.0) keeps only latest patch per minor",
+			constraint: "1.40.0",
+			wantTags:   []string{"v1.40.1", "v1.41.0", "v1.42.0", "v1.43.0", channelVersion},
+			rejectTags: []string{"v1.39.0", "v1.40.0"},
+		},
+		{
+			name:       "explicit caret (^1.40.0) keeps only latest patch per minor",
+			constraint: "^1.40.0",
+			wantTags:   []string{"v1.40.1", "v1.41.0", "v1.42.0", "v1.43.0", channelVersion},
+			rejectTags: []string{"v1.39.0", "v1.40.0"},
+		},
+		{
+			name:       "tilde (~1.40.0 - patch only) keeps only latest patch",
+			constraint: "~1.40.0",
+			wantTags:   []string{"v1.40.1", channelVersion},
+			rejectTags: []string{"v1.40.0", "v1.41.0"},
+		},
+		{
+			name:       "explicit range (>=1.40.0 <1.43.0) preserves >= anchor and keeps latest patch per minor",
+			constraint: ">=1.40.0 <1.43.0",
+			wantTags:   []string{"v1.40.0", "v1.40.1", "v1.41.0", "v1.42.0", channelVersion},
+			rejectTags: []string{"v1.43.0"},
+		},
+		{
+			name:       "bare >= preserves anchor and keeps latest patch in same minor",
+			constraint: ">=1.40.0",
+			wantTags:   []string{"v1.40.0", "v1.40.1", "v1.41.0", "v1.42.0", "v1.43.0", channelVersion},
+			rejectTags: []string{"v1.39.0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := singlePackageRegistry(testPackageName, channelVersion, registryVersions)
+			filter := mustNewFilter(t, modules.FilterTypeWhitelist, testPackageName+"@"+tc.constraint)
+			svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), filter)
+
+			require.NoError(t, svc.PullPackages(context.Background()))
+
+			got := pulledPackageVersionRefs(t, svc, testPackageName)
+			assert.ElementsMatch(t, packageRefs(testPackageName, tc.wantTags), got)
+			for _, rejected := range tc.rejectTags {
+				assert.NotContains(t, got, packageRef(testPackageName, rejected),
+					"constraint %q must reject %s (out-of-range or older patch in same minor)", tc.constraint, rejected)
+			}
+		})
+	}
+}
+
+// Each --include-package flag carries its own constraint - the matcher must
+// scope to the named package and not leak across packages. Mixes a semver and
+// an exact constraint to exercise both filter branches in one shot.
+func TestPullPackages_PerPackageConstraintIsolation(t *testing.T) {
+	const (
+		consoleName = "console"
+		scannerName = "scanner"
+	)
+
+	reg := upfake.NewRegistry(testHost)
+	addPackage(reg, consoleName, "v1.40.1", []string{"v1.40.0", "v1.40.1", "v1.41.0", channelVersion})
+	addPackage(reg, scannerName, "v0.5.1", []string{"v0.5.0", "v0.5.1", "v0.6.0"})
+
+	filter := mustNewFilter(t, modules.FilterTypeWhitelist,
+		consoleName+"@~1.40.0", // tilde matches v1.40.x; collapses to latest patch v1.40.1
+		scannerName+"@=v0.6.0", // exact tag
+	)
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), filter)
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	assert.ElementsMatch(t,
+		packageRefs(consoleName, []string{"v1.40.1"}),
+		pulledPackageVersionRefs(t, svc, consoleName),
+		"console: tilde must match only v1.40.x and collapse to the latest patch (v1.40.1)")
+	assert.NotContains(t, pulledPackageVersionRefs(t, svc, consoleName),
+		packageRef(consoleName, "v1.40.0"),
+		"console: older patch v1.40.0 must be dropped by the per-minor latest-patch filter")
+	assert.ElementsMatch(t,
+		packageRefs(scannerName, []string{"v0.6.0"}),
+		pulledPackageVersionRefs(t, svc, scannerName),
+		"scanner: exact must match only v0.6.0 - no leak from console's tilde")
+}
+
+// TestPullPackages_LatestPatchPerMinor verifies the latest-patch-per-minor
+// collapse for packages: --include-package code@v1.6.0 against a registry that
+// publishes six patches in 1.6.x and two in 1.7.x must collapse to a single
+// (highest) patch per (major, minor).
+func TestPullPackages_LatestPatchPerMinor(t *testing.T) {
+	const (
+		packageName         = "code"
+		issueChannelVersion = "v1.6.5"
+	)
+	registryVersions := []string{
+		"v1.6.0", "v1.6.1", "v1.6.2", "v1.6.3", "v1.6.4", "v1.6.5",
+		"v1.7.0", "v1.7.1",
+	}
+
+	reg := singlePackageRegistry(packageName, issueChannelVersion, registryVersions)
+	filter := mustNewFilter(t, modules.FilterTypeWhitelist, packageName+"@v1.6.0")
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), filter)
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	got := pulledPackageVersionRefs(t, svc, packageName)
+
+	wantLatestPatches := []string{"v1.6.5", "v1.7.1"}
+	assert.ElementsMatch(t,
+		packageRefs(packageName, wantLatestPatches),
+		got,
+		"--include-package code@v1.6.0 must collapse to one tag per minor")
+
+	for _, dropped := range []string{"v1.6.0", "v1.6.1", "v1.6.2", "v1.6.3", "v1.6.4", "v1.7.0"} {
+		assert.NotContains(t, got, packageRef(packageName, dropped),
+			"older patch %s must be dropped by the latest-patch-per-minor filter", dropped)
+	}
+}
+
+// =============================================================================
+// Tests: per-package ListTags policy
+// =============================================================================
+
+// Per-package ListTags is only needed for non-exact constraints. The baseline
+// cost of a default pull or an exact-tag pull must not regress by adding an
+// unconditional per-package call.
+func TestPullPackages_PerPackageListTagsCallCount(t *testing.T) {
+	// PullPackages lists tags at the packages root twice:
+	//   - validatePackagesAccess (reachability check)
+	//   - pullPackages (package-name enumeration)
+	const baselineRootCalls int64 = 2
+
+	cases := []struct {
+		name        string
+		filterType  modules.FilterType
+		filterExprs []string
+		wantExtra   int64 // extra ListTags calls on top of the baseline
+	}{
+		{
+			name:        "exact constraint skips per-package ListTags",
+			filterType:  modules.FilterTypeWhitelist,
+			filterExprs: []string{testPackageName + "@=v1.40.0"},
+			wantExtra:   0,
+		},
+		{
+			name:        "blacklist filter (no constraint) skips per-package ListTags",
+			filterType:  modules.FilterTypeBlacklist,
+			filterExprs: nil,
+			wantExtra:   0,
+		},
+		{
+			name:        "semver constraint triggers one per-package ListTags",
+			filterType:  modules.FilterTypeWhitelist,
+			filterExprs: []string{testPackageName + "@1.40.0"},
+			wantExtra:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+			counter := newListTagsCounter(upfake.NewClient(reg))
+			filter := mustNewFilter(t, tc.filterType, tc.filterExprs...)
+			svc := newService(t, pkgclient.Adapt(counter), filter)
+
+			require.NoError(t, svc.PullPackages(context.Background()))
+
+			assert.Equal(t, baselineRootCalls+tc.wantExtra, counter.calls.Load())
+		})
+	}
+}
+
+// Per-package ListTags reuses validatePackagesAccess's error policy:
+//   - ErrImageNotFound: warn-and-skip (the package repo simply isn't there).
+//   - any other error:  fail-fast (we cannot verify the constraint and refuse
+//     to silently produce a partial bundle).
+func TestPullPackages_PerPackageListTagsErrorHandling(t *testing.T) {
+	transientErr := errors.New("simulated registry 503")
+
+	cases := []struct {
+		name     string
+		injected error
+		wantErr  error    // nil = pull must succeed
+		wantTags []string // checked only on success - the channel snapshot is the sole contributor when per-package ListTags is skipped
+	}{
+		{
+			name:     "ErrImageNotFound is warned and skipped",
+			injected: dkpreg.ErrImageNotFound,
+			wantTags: []string{channelVersion},
+		},
+		{
+			name:     "transient error fails fast",
+			injected: transientErr,
+			wantErr:  transientErr,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+			client := newListTagsErrAtPackage(upfake.NewClient(reg), tc.injected)
+			// Semver constraint to actually trigger the per-package ListTags.
+			filter := mustNewFilter(t, modules.FilterTypeWhitelist, testPackageName+"@1.40.0")
+			svc := newService(t, pkgclient.Adapt(client), filter)
+
+			err := svc.PullPackages(context.Background())
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				assert.ElementsMatch(t,
+					packageRefs(testPackageName, tc.wantTags),
+					pulledPackageVersionRefs(t, svc, testPackageName))
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+			assert.Contains(t, err.Error(), "list tags for package "+testPackageName)
+		})
+	}
+}
+
+// =============================================================================
+// Tests: empty package layouts are not packed into tars
+// =============================================================================
+
+// TestPullPackages_EmptyPackageNotPacked verifies that when a package is present
+// in the registry listing but has no pullable images (all version channels are
+// missing and no version tags match), packPackages skips it and does not create
+// an empty stub tar in the bundle directory.
+func TestPullPackages_EmptyPackageNotPacked(t *testing.T) {
+	// Registry has the package listed but zero version images.
+	reg := upfake.NewRegistry(testHost)
+	reg.MustAddImage(internal.PackagesSegment, testPackageName, versionImage(channelVersion))
+	// Intentionally: no packages/<name>:<version> and no packages/<name>/version:<channel>.
+
+	bundleDir := t.TempDir()
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+	svc.options.BundleDir = bundleDir
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries,
+		"bundle dir must stay empty when package has no images; got: %v", entries)
+}
+
+// TestPackPackages_EmptyPackageIsSilent guards the user-facing log output for
+// packages whose layout has no pulled images: there must be no "Pack
+// package-<name>.tar" header for the empty package. The populated package's
+// Pack header is asserted as a positive control to prove the capture pipeline
+// is wired up.
+func TestPackPackages_EmptyPackageIsSilent(t *testing.T) {
+	const (
+		fullPkg  = "with-images"
+		emptyPkg = "no-images"
+	)
+
+	reg := upfake.NewRegistry(testHost)
+	addPackage(reg, fullPkg, channelVersion, defaultRegistryVersions)
+	// Packages-list entry only - no version tags and no version channels.
+	reg.MustAddImage(internal.PackagesSegment, emptyPkg, versionImage(channelVersion))
+
+	bundleDir := t.TempDir()
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+	svc.options.BundleDir = bundleDir
+
+	// Capture user-facing log output by redirecting os.Stdout, then build a
+	// fresh Info-level SLogger bound to the redirected stdout.
+	stdoutSave := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = stdoutSave }()
+
+	var captured strings.Builder
+	drained := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&captured, r)
+		close(drained)
+	}()
+
+	svc.userLogger = log.NewSLogger(slog.LevelInfo)
+
+	runErr := svc.PullPackages(context.Background())
+
+	require.NoError(t, w.Close())
+	<-drained
+	os.Stdout = stdoutSave
+	require.NoError(t, runErr)
+
+	out := captured.String()
+
+	// Positive control: the populated package went through the Pack pipeline.
+	assert.Contains(t, out, "Pack package-"+fullPkg+".tar",
+		"log-capture sanity: pack header for populated package must appear in captured output; got:\n%s", out)
+
+	// Headline: zero noise for the empty package.
+	emptyTar := "package-" + emptyPkg + ".tar"
+	assert.NotContains(t, out, emptyTar,
+		"empty package must not appear anywhere in user-facing logs; got:\n%s", out)
+}
+
+// TestPullPackages_NonEmptyPackagePacked is the positive counterpart: a package
+// with at least one pulled image must produce a non-empty tar in the bundle dir.
+func TestPullPackages_NonEmptyPackagePacked(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+	bundleDir := t.TempDir()
+
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+	svc.options.BundleDir = bundleDir
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "bundle dir must contain a tar for a package with images")
+
+	for _, e := range entries {
+		info, err := e.Info()
+		require.NoError(t, err)
+		assert.Greater(t, info.Size(), int64(5120),
+			"tar %q must be larger than 5120 bytes (the empty-layout skeleton)", e.Name())
+	}
+}
+
+// TestPullPackages_InterruptedPullDoesNotProduceEmptyStubTars is the regression
+// for the cancellation path: pulling a registry that lists many packages, then
+// cancelling mid-flight, must NOT leave behind a stub ~5120-byte
+// package-<name>.tar for every package that did not actually download.
+func TestPullPackages_InterruptedPullDoesNotProduceEmptyStubTars(t *testing.T) {
+	const (
+		earlyPkg = "aaa-pulled-first"  // alphabetically first, will fully pull
+		latePkg  = "zzz-never-touched" // alphabetically last, will be cancelled out
+	)
+
+	reg := upfake.NewRegistry(testHost)
+	addPackage(reg, earlyPkg, channelVersion, defaultRegistryVersions)
+	addPackage(reg, latePkg, channelVersion, defaultRegistryVersions)
+
+	bundleDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Wire the fake client through a wrapper that cancels the user's context
+	// the moment a request hits the *second* package's path.
+	client := &cancelOnSecondPackage{
+		Client:   upfake.NewClient(reg),
+		cancel:   cancel,
+		trigger:  internal.PackagesSegment + "/" + latePkg,
+		canceled: new(atomic.Bool),
+	}
+
+	svc := newService(t, pkgclient.Adapt(client), nil)
+	svc.options.BundleDir = bundleDir
+
+	err := svc.PullPackages(ctx)
+	require.NoError(t, err,
+		"PullPackages must finish gracefully after cancellation (packing what was downloaded)")
+	require.True(t, client.canceled.Load(), "test bug: cancellation trigger never fired")
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+
+	var sawEarly bool
+	for _, e := range entries {
+		name := e.Name()
+
+		require.NotContains(t, name, latePkg,
+			"cancelled package %q must not appear in the bundle dir, found %q", latePkg, name)
+
+		info, err := e.Info()
+		require.NoError(t, err)
+		require.Greater(t, info.Size(), int64(5120),
+			"bundle file %q has stub size %d (must be > 5120 bytes; that's the empty-layout skeleton)",
+			name, info.Size())
+
+		if name == "package-"+earlyPkg+".tar" {
+			sawEarly = true
+		}
+	}
+
+	require.True(t, sawEarly,
+		"%s should have been pulled and packed before cancellation; entries=%v", earlyPkg, entries)
+}
+
+// =============================================================================
+// Tests: image layout HasImages helper
+// =============================================================================
+
+// TestImageLayouts_HasImages_Empty verifies HasImages returns false when no
+// images have been appended to any of the package's sub-layouts.
+func TestImageLayouts_HasImages_Empty(t *testing.T) {
+	layouts, err := createOCIImageLayoutsForPackage(t.TempDir())
+	require.NoError(t, err)
+	assert.False(t, layouts.HasImages(),
+		"HasImages must return false for a freshly created (empty) layout")
+}
+
+// TestImageLayouts_HasImages_WithImage verifies HasImages returns true once an
+// image has been appended to one of the package's sub-layouts.
+func TestImageLayouts_HasImages_WithImage(t *testing.T) {
+	dir := t.TempDir()
+
+	layouts, err := createOCIImageLayoutsForPackage(dir)
+	require.NoError(t, err)
+
+	assert.False(t, layouts.HasImages(), "freshly created layout must have no images before any append")
+
+	img := upfake.NewImageBuilder().
+		WithFile("version.json", `{"version":"v1.0.0"}`).
+		MustBuild()
+	err = layouts.Packages.Path().AppendImage(img,
+		golayout.WithAnnotations(map[string]string{"io.deckhouse.image.short_tag": "v1.0.0"}))
+	require.NoError(t, err)
+
+	assert.True(t, layouts.HasImages(),
+		"HasImages must return true after at least one image is appended")
+}
+
+// =============================================================================
+// Tests: version channel download list & LTS channel
+// =============================================================================
+
+// TestPackageVersionChannelDownloadList_FilledCorrectly verifies that
+// PullPackages populates packagesDownloadList with the expected version-channel
+// image reference keys. Each key is constructed by discoverChannelVersions as:
+//
+//	rootURL + "/packages/" + packageName + "/version:" + channel
+func TestPackageVersionChannelDownloadList_FilledCorrectly(t *testing.T) {
+	const channelVer = "v1.45.0"
+
+	reg := singlePackageRegistry(testPackageName, channelVer, []string{channelVer})
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+		DryRun:        true,
+		SkipVexImages: true,
+	})
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	packageDL := svc.packagesDownloadList.Package(testPackageName)
+	require.NotNil(t, packageDL, "packagesDownloadList must have an entry for package %q", testPackageName)
+
+	for _, channel := range internal.GetAllDefaultReleaseChannels() {
+		expectedRef := packageVersionChannelRef(testPackageName, channel)
+		_, ok := packageDL.PackageVersionChannels[expectedRef]
+		assert.True(t, ok,
+			"packagesDownloadList[%q].PackageVersionChannels should contain ref %q; actual keys: %v",
+			testPackageName, expectedRef, packageDL.PackageVersionChannels)
+	}
+}
+
+// TestPullPackages_LTSChannel verifies the optional LTS version channel (CSE
+// editions) is detected by discoverChannelVersions and included in the pull.
+func TestPullPackages_LTSChannel(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+	addLTSVersionChannel(reg, testPackageName, channelVersion)
+
+	bundleDir := t.TempDir()
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+	svc.options.BundleDir = bundleDir
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	packageDL := svc.packagesDownloadList.Package(testPackageName)
+	require.NotNil(t, packageDL, "packagesDownloadList must have an entry for package %q", testPackageName)
+
+	ltsRef := packageVersionChannelRef(testPackageName, internal.LTSChannel)
+	_, ok := packageDL.PackageVersionChannels[ltsRef]
+	assert.True(t, ok,
+		"PackageVersionChannels should contain LTS ref %q; actual keys: %v",
+		ltsRef, packageDL.PackageVersionChannels)
+
+	assert.Contains(t, pulledPackageVersionRefs(t, svc, testPackageName), packageRef(testPackageName, channelVersion),
+		"LTS channel must contribute %s to the pulled package versions", channelVersion)
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "bundle dir must contain a tar when LTS channel pull succeeds")
+}
+
+// =============================================================================
+// Tests: dry-run never writes bundles
+// =============================================================================
+
+// TestDryRun_NoBundleFilesWritten verifies that PullPackages in dry-run mode does
+// not write any tar bundles to the bundle directory.
+func TestDryRun_NoBundleFilesWritten(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+	bundleDir := t.TempDir()
+
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+		BundleDir:     bundleDir,
+		DryRun:        true,
+		SkipVexImages: true,
+	})
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "dry-run must not write any files to the bundle directory; found: %v", entries)
+}
+
+// =============================================================================
+// Tests: validate packages access
+// =============================================================================
+
+func TestValidatePackagesAccess(t *testing.T) {
+	t.Run("packages present in registry returns no error", func(t *testing.T) {
+		reg := upfake.NewRegistry(testHost)
+		placeholder := upfake.NewImageBuilder().MustBuild()
+		reg.MustAddImage(internal.PackagesSegment, "console", placeholder)
+		reg.MustAddImage(internal.PackagesSegment, "scanner", placeholder)
+
+		svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+		require.NoError(t, svc.validatePackagesAccess(context.Background()))
+	})
+
+	t.Run("packages repository absent in registry returns no error", func(t *testing.T) {
+		// Empty registry – the "packages" repo does not exist; access check
+		// must treat this as a graceful skip rather than a hard failure.
+		reg := upfake.NewRegistry(testHost)
+		svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+		require.NoError(t, svc.validatePackagesAccess(context.Background()))
+	})
+
+	t.Run("proxy registry skips the listing access check", func(t *testing.T) {
+		reg := upfake.NewRegistry(testHost)
+		svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+			ProxyRegistry: true,
+			Filter:        mustNewFilter(t, modules.FilterTypeWhitelist, testPackageName+"@1.0.0"),
+		})
+		require.NoError(t, svc.validatePackagesAccess(context.Background()))
+	})
+}
+
+// TestPullPackages_NoPackagesFound is a smoke test: an empty registry must
+// finish without error and write nothing into the bundle directory.
+func TestPullPackages_NoPackagesFound(t *testing.T) {
+	reg := upfake.NewRegistry(testHost)
+	bundleDir := t.TempDir()
+
+	svc := newService(t, pkgclient.Adapt(upfake.NewClient(reg)), nil)
+	svc.options.BundleDir = bundleDir
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "empty registry must not produce any bundle files; found: %v", entries)
+}
+
+// =============================================================================
+// Tests: edition-scoped rootURL
+// =============================================================================
+
+// TestPackagesService_RootURL_UsesEditionSegment is the regression for the
+// "missing edition segment" report applied to the packages service: the rootURL
+// used to compose per-package registry paths must include the edition segment.
+func TestPackagesService_RootURL_UsesEditionSegment(t *testing.T) {
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+
+	const bareRoot = "registry.deckhouse.ru/deckhouse"
+	c := pkgclient.NewFromOptions(bareRoot)
+	regSvc := registryservice.NewService(c, pkg.FEEdition, logger)
+
+	svc := NewService(
+		regSvc,
+		t.TempDir(),
+		&Options{BundleDir: t.TempDir(), DryRun: true},
+		logger,
+		userLogger,
+	)
+
+	const editionRoot = bareRoot + "/fe"
+	assert.Equal(t, editionRoot, svc.rootURL,
+		"packages Service.rootURL must be the edition-scoped root")
+
+	composed := svc.packageRef(testPackageName, channelVersion)
+	assert.Equal(t, editionRoot+"/packages/"+testPackageName+":"+channelVersion, composed,
+		"per-package registry path must live under the edition sub-tree")
+}
+
+// TestPackagesService_RootURL_NoEdition pins down that with no edition the
+// rootURL collapses to the bare host.
+func TestPackagesService_RootURL_NoEdition(t *testing.T) {
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+
+	const bareRoot = "registry.example.com/deckhouse"
+	c := pkgclient.NewFromOptions(bareRoot)
+	regSvc := registryservice.NewService(c, pkg.NoEdition, logger)
+
+	svc := NewService(
+		regSvc,
+		t.TempDir(),
+		&Options{BundleDir: t.TempDir(), DryRun: true},
+		logger,
+		userLogger,
+	)
+
+	assert.Equal(t, bareRoot, svc.rootURL,
+		"packages Service.rootURL must equal the bare root when no edition is set")
+}
+
+// =============================================================================
+// Tests: PullPackageVersions (shared package-versions.tar)
+// =============================================================================
+
+// TestPullPackageVersions_PacksReleaseImages verifies that PullPackageVersions
+// clones the version/release-image catalog of every package into a single
+// shared package-versions.tar.
+func TestPullPackageVersions_PacksReleaseImages(t *testing.T) {
+	reg := upfake.NewRegistry(testHost)
+	addPackage(reg, "console", channelVersion, defaultRegistryVersions)
+	addPackage(reg, "scanner", "v0.5.0", []string{"v0.5.0"})
+
+	bundleDir := t.TempDir()
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+		BundleDir:     bundleDir,
+		SkipVexImages: true,
+	})
+
+	require.NoError(t, svc.PullPackageVersions(context.Background()))
+
+	assert.FileExists(t, filepath.Join(bundleDir, "package-versions.tar"),
+		"PullPackageVersions must produce a package-versions.tar with the release images")
+}
+
+// TestPullPackageVersions_NoPackagesIsNoop verifies that a registry without a
+// packages catalog produces no package-versions.tar and no error.
+func TestPullPackageVersions_NoPackagesIsNoop(t *testing.T) {
+	reg := upfake.NewRegistry(testHost)
+	bundleDir := t.TempDir()
+
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+		BundleDir:     bundleDir,
+		SkipVexImages: true,
+	})
+
+	require.NoError(t, svc.PullPackageVersions(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no packages must produce no package-versions.tar; found: %v", entries)
+}
+
+// TestPullPackageVersions_DryRun verifies that PullPackageVersions in dry-run
+// mode writes nothing into the bundle directory.
+func TestPullPackageVersions_DryRun(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, defaultRegistryVersions)
+	bundleDir := t.TempDir()
+
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{
+		BundleDir:     bundleDir,
+		DryRun:        true,
+		SkipVexImages: true,
+	})
+
+	require.NoError(t, svc.PullPackageVersions(context.Background()))
+
+	entries, err := os.ReadDir(bundleDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "dry-run PullPackageVersions must not write any files; found: %v", entries)
+}
+
+// =============================================================================
+// Tests: proxy-registry tag probing
+// =============================================================================
+
+// TestPullPackages_ProxyRegistryProbesTags verifies that with --proxy-registry
+// the package names come straight from the whitelist and per-tag probing
+// (CheckImageExists) replaces catalog enumeration. The registry root catalog is
+// never listed.
+func TestPullPackages_ProxyRegistryProbesTags(t *testing.T) {
+	reg := upfake.NewRegistry(testHost)
+	// Only the per-package main images exist; the registry refuses catalog
+	// enumeration (no "packages" list entry, no version channels).
+	for _, v := range []string{"v1.40.0", "v1.40.1", "v1.41.0"} {
+		reg.MustAddImage(internal.PackagesSegment+"/"+testPackageName, v, versionImage(v))
+	}
+
+	counter := newListTagsCounter(upfake.NewClient(reg))
+	svc := newServiceOpts(t, pkgclient.Adapt(counter), &Options{
+		ProxyRegistry: true,
+		SkipVexImages: true,
+		Filter:        mustNewFilter(t, modules.FilterTypeWhitelist, testPackageName+"@>=1.40.0"),
+	})
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	assert.Zero(t, counter.calls.Load(),
+		"proxy-registry mode must never enumerate the registry catalog via ListTags")
+
+	got := pulledPackageVersionRefs(t, svc, testPackageName)
+	assert.ElementsMatch(t,
+		packageRefs(testPackageName, []string{"v1.40.0", "v1.40.1", "v1.41.0"}),
+		got,
+		"proxy probe must discover every served tag satisfying the constraint (with >= anchor restored)")
+}
+
+// =============================================================================
+// Service & filter builders
+// =============================================================================
+
+// newServiceOpts wires a Service against the given fake client, with logs muted.
+// A default BundleDir is supplied when the caller leaves it empty.
+func newServiceOpts(t *testing.T, client dkpreg.Client, opts *Options) *Service {
+	t.Helper()
+
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+	regSvc := registryservice.NewService(client, pkg.NoEdition, logger)
+
+	if opts == nil {
+		opts = &Options{}
+	}
+	if opts.BundleDir == "" {
+		opts.BundleDir = t.TempDir()
+	}
+
+	return NewService(regSvc, t.TempDir(), opts, logger, userLogger)
+}
+
+// newService wires a Service with a filter and VEX pulls disabled.
+func newService(t *testing.T, client dkpreg.Client, filter *modules.Filter) *Service {
+	t.Helper()
+	return newServiceOpts(t, client, &Options{Filter: filter, SkipVexImages: true})
+}
+
+func mustNewFilter(t *testing.T, ftype modules.FilterType, exprs ...string) *modules.Filter {
+	t.Helper()
+	f, err := modules.NewFilter(exprs, ftype)
+	require.NoError(t, err)
+	return f
+}
+
+// =============================================================================
+// Registry fixture builders
+// =============================================================================
+
+// addPackage populates a fake registry with one package's worth of refs:
+//
+//	packages:<name>                    - packages-list entry, points at channelVer
+//	packages/<name>:<v>                - one main image per version
+//	packages/<name>/version:<v>        - version-tagged release metadata
+//	packages/<name>/version:<channel>  - 5 version channels, all pointing at channelVer
+func addPackage(reg *upfake.Registry, name, channelVer string, versions []string) {
+	reg.MustAddImage(internal.PackagesSegment, name, versionImage(channelVer))
+	for _, v := range versions {
+		reg.MustAddImage(internal.PackagesSegment+"/"+name, v, versionImage(v))
+		reg.MustAddImage(internal.PackagesSegment+"/"+name+"/"+internal.PackagesVersionSegment, v, versionImage(v))
+	}
+	for _, ch := range internal.GetAllDefaultReleaseChannels() {
+		reg.MustAddImage(internal.PackagesSegment+"/"+name+"/"+internal.PackagesVersionSegment, ch, versionImage(channelVer))
+	}
+}
+
+// singlePackageRegistry builds a fake registry containing exactly one package.
+func singlePackageRegistry(name, channelVer string, versions []string) *upfake.Registry {
+	reg := upfake.NewRegistry(testHost)
+	addPackage(reg, name, channelVer, versions)
+	return reg
+}
+
+// addLTSVersionChannel adds the optional LTS version channel (CSE editions).
+func addLTSVersionChannel(reg *upfake.Registry, name, channelVer string) {
+	reg.MustAddImage(internal.PackagesSegment+"/"+name+"/"+internal.PackagesVersionSegment, internal.LTSChannel, versionImage(channelVer))
+}
+
+// versionImage builds a v1.Image carrying only version.json. Missing
+// images_digests.json / extra_images.json is tolerated downstream.
+func versionImage(version string) v1.Image {
+	return upfake.NewImageBuilder().
+		WithFile("version.json", `{"version":"`+version+`"}`).
+		WithLabel("org.opencontainers.image.version", version).
+		MustBuild()
+}
+
+// =============================================================================
+// Assertion helpers
+// =============================================================================
+
+// packageRef is the registry URL the production code uses for a single
+// version-tagged main package image.
+func packageRef(packageName, version string) string {
+	return testHost + "/" + internal.PackagesSegment + "/" + packageName + ":" + version
+}
+
+// packageVersionChannelRef is the registry URL for a package version-channel.
+func packageVersionChannelRef(packageName, channel string) string {
+	return testHost + "/" + internal.PackagesSegment + "/" + packageName + "/" + internal.PackagesVersionSegment + ":" + channel
+}
+
+func packageRefs(packageName string, versions []string) []string {
+	refs := make([]string, 0, len(versions))
+	for _, v := range versions {
+		refs = append(refs, packageRef(packageName, v))
+	}
+	return refs
+}
+
+// pulledPackageVersionRefs returns the version-tagged refs the service recorded
+// for the given package, dropping @sha256: refs (these are added by extra-image
+// and internal-digest resolution and are not relevant to constraint tests).
+func pulledPackageVersionRefs(t *testing.T, svc *Service, packageName string) []string {
+	t.Helper()
+	dl := svc.packagesDownloadList.Package(packageName)
+	require.NotNil(t, dl, "no download list recorded for package %s", packageName)
+
+	refs := make([]string, 0, len(dl.Package))
+	for ref := range dl.Package {
+		if strings.Contains(ref, "@sha256:") {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// =============================================================================
+// Test doubles
+// =============================================================================
+
+// listTagsCounter counts every ListTags call on this client and on any
+// sub-client spawned via WithSegment (the counter is shared across the chain).
+type listTagsCounter struct {
+	dkpreg.Client
+	calls *atomic.Int64
+}
+
+func newListTagsCounter(c dkpreg.Client) *listTagsCounter {
+	return &listTagsCounter{Client: c, calls: new(atomic.Int64)}
+}
+
+func (c *listTagsCounter) WithSegment(segments ...string) dkpreg.Client {
+	return &listTagsCounter{Client: c.Client.WithSegment(segments...), calls: c.calls}
+}
+
+func (c *listTagsCounter) ListTags(ctx context.Context, opts ...dkpreg.ListTagsOption) ([]string, error) {
+	c.calls.Add(1)
+	return c.Client.ListTags(ctx, opts...)
+}
+
+// listTagsErrAtPackage returns the configured error from ListTags only at the
+// per-package path (packages/<name>, two segments below root). Root-level
+// ListTags - validatePackagesAccess and package-name enumeration - pass through.
+type listTagsErrAtPackage struct {
+	dkpreg.Client
+	depth int
+	err   error
+}
+
+// perPackageDepth is the WithSegment depth at which a client points at
+// packages/<name>: root -> "packages" -> "<name>".
+const perPackageDepth = 2
+
+func newListTagsErrAtPackage(c dkpreg.Client, err error) *listTagsErrAtPackage {
+	return &listTagsErrAtPackage{Client: c, depth: 0, err: err}
+}
+
+func (c *listTagsErrAtPackage) WithSegment(segments ...string) dkpreg.Client {
+	return &listTagsErrAtPackage{
+		Client: c.Client.WithSegment(segments...),
+		depth:  c.depth + len(segments),
+		err:    c.err,
+	}
+}
+
+func (c *listTagsErrAtPackage) ListTags(ctx context.Context, opts ...dkpreg.ListTagsOption) ([]string, error) {
+	if c.depth == perPackageDepth {
+		return nil, c.err
+	}
+	return c.Client.ListTags(ctx, opts...)
+}
+
+// cancelOnSecondPackage is a registry client wrapper that fires the supplied
+// cancel func the first time a method touches the configured trigger path.
+// Used by the interrupted-pull regression to simulate a user hitting Ctrl+C
+// at a well-defined point in the pull sequence.
+type cancelOnSecondPackage struct {
+	dkpreg.Client
+	cancel   context.CancelFunc
+	trigger  string
+	scope    string
+	canceled *atomic.Bool
+}
+
+func (c *cancelOnSecondPackage) WithSegment(segments ...string) dkpreg.Client {
+	next := c.scope
+	for _, s := range segments {
+		if next == "" {
+			next = s
+		} else {
+			next = next + "/" + s
+		}
+	}
+	return &cancelOnSecondPackage{
+		Client:   c.Client.WithSegment(segments...),
+		cancel:   c.cancel,
+		trigger:  c.trigger,
+		scope:    next,
+		canceled: c.canceled,
+	}
+}
+
+func (c *cancelOnSecondPackage) maybeCancel() {
+	if c.canceled.Load() {
+		return
+	}
+	if strings.HasPrefix(c.scope, c.trigger) {
+		c.canceled.Store(true)
+		c.cancel()
+	}
+}
+
+func (c *cancelOnSecondPackage) GetDigest(ctx context.Context, tag string) (*v1.Hash, error) {
+	c.maybeCancel()
+	return c.Client.GetDigest(ctx, tag)
+}
+
+func (c *cancelOnSecondPackage) GetImage(ctx context.Context, tag string, opts ...dkpreg.ImageGetOption) (dkpreg.Image, error) {
+	c.maybeCancel()
+	return c.Client.GetImage(ctx, tag, opts...)
+}
+
+func (c *cancelOnSecondPackage) CheckImageExists(ctx context.Context, tag string) error {
+	c.maybeCancel()
+	return c.Client.CheckImageExists(ctx, tag)
+}
+
+func (c *cancelOnSecondPackage) ListTags(ctx context.Context, opts ...dkpreg.ListTagsOption) ([]string, error) {
+	c.maybeCancel()
+	return c.Client.ListTags(ctx, opts...)
+}

--- a/internal/mirror/pull.go
+++ b/internal/mirror/pull.go
@@ -238,5 +238,13 @@ func (svc *PullService) Pull(ctx context.Context) error {
 		}
 	}
 
+	// The package release-image catalog (package-versions) is always cloned
+	// into the bundle, regardless of which components are mirrored or whether
+	// packages are skipped via --no-packages. This keeps the bundle's package
+	// release metadata in sync on every mirror operation.
+	if err := svc.packagesService.PullPackageVersions(ctx); err != nil {
+		return fmt.Errorf("pull package release images: %w", err)
+	}
+
 	return nil
 }

--- a/internal/mirror/pull.go
+++ b/internal/mirror/pull.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/installer"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/packages"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/platform"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/security"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
@@ -39,6 +40,8 @@ type PullServiceOptions struct {
 	SkipSecurity bool
 	// SkipModules skips pulling module images
 	SkipModules bool
+	// SkipPackages skips pulling package images
+	SkipPackages bool
 	// SkipInstaller skips pulling installer images
 	SkipInstaller bool
 	// InstallerTag is the tag for the installer image
@@ -54,6 +57,9 @@ type PullServiceOptions struct {
 	PlatformConstraint modules.VersionConstraint
 	// ModuleFilter is the filter for module selection (whitelist/blacklist)
 	ModuleFilter *modules.Filter
+	// PackageFilter is the filter for package selection (whitelist/blacklist).
+	// Packages reuse the modules filter because selection logic is identical.
+	PackageFilter *modules.Filter
 	// BundleDir is the directory to store the bundle
 	BundleDir string
 	// BundleChunkSize is the max size of bundle chunks in bytes (0 = no chunking)
@@ -78,6 +84,7 @@ type PullService struct {
 	platformService  *platform.Service
 	securityService  *security.Service
 	modulesService   *modules.Service
+	packagesService  *packages.Service
 	installerService *installer.Service
 
 	options *PullServiceOptions
@@ -151,6 +158,22 @@ func NewPullService(
 			logger,
 			userLogger,
 		),
+		packagesService: packages.NewService(
+			registryService,
+			tmpDir,
+			&packages.Options{
+				Filter:          options.PackageFilter,
+				OnlyExtraImages: options.OnlyExtraImages,
+				SkipVexImages:   options.SkipVexImages,
+				BundleDir:       options.BundleDir,
+				BundleChunkSize: options.BundleChunkSize,
+				Timeout:         options.Timeout,
+				DryRun:          options.DryRun,
+				ProxyRegistry:   options.ProxyRegistry,
+			},
+			logger,
+			userLogger,
+		),
 		installerService: installer.NewService(
 			registryService,
 			tmpDir,
@@ -205,6 +228,13 @@ func (svc *PullService) Pull(ctx context.Context) error {
 		err := svc.modulesService.PullModules(ctx)
 		if err != nil {
 			return fmt.Errorf("pull modules: %w", err)
+		}
+	}
+
+	if !svc.options.SkipPackages || svc.options.OnlyExtraImages {
+		err := svc.packagesService.PullPackages(ctx)
+		if err != nil {
+			return fmt.Errorf("pull packages: %w", err)
 		}
 	}
 

--- a/internal/mirror/push.go
+++ b/internal/mirror/push.go
@@ -71,10 +71,15 @@ type PushServiceOptions struct {
 //	│   ├── trivy-bdu/
 //	│   ├── trivy-java-db/
 //	│   └── trivy-checks/
-//	└── modules/                       # Modules
-//	    └── <module-name>/
+//	├── modules/                       # Modules
+//	│   └── <module-name>/
+//	│       ├── index.json
+//	│       ├── release/
+//	│       └── <extra-name>/
+//	└── packages/                      # Packages
+//	    └── <package-name>/
 //	        ├── index.json
-//	        ├── release/
+//	        ├── version/
 //	        └── <extra-name>/
 type PushService struct {
 	client     client.Client
@@ -138,8 +143,15 @@ func (svc *PushService) Push(ctx context.Context) error {
 	}
 
 	// Create modules index (deckhouse/modules:<module-name> tags for discovery)
-	return svc.userLogger.Process("Create modules index", func() error {
+	if err := svc.userLogger.Process("Create modules index", func() error {
 		return svc.createModulesIndex(ctx, dirPath)
+	}); err != nil {
+		return err
+	}
+
+	// Create packages index (deckhouse/packages:<package-name> tags for discovery)
+	return svc.userLogger.Process("Create packages index", func() error {
+		return svc.createPackagesIndex(ctx, dirPath)
 	})
 }
 
@@ -413,6 +425,68 @@ func (svc *PushService) createModulesIndex(ctx context.Context, rootDir string) 
 	}
 
 	svc.userLogger.Infof("Modules index created successfully")
+
+	return nil
+}
+
+// createPackagesIndex creates the packages index in the registry.
+// This pushes a small random image for each package with tag = package name
+// to deckhouse/packages repo, enabling package discovery via ListTags.
+func (svc *PushService) createPackagesIndex(ctx context.Context, rootDir string) error {
+	packagesDir := filepath.Join(rootDir, internal.PackagesSegment)
+
+	// Check if packages directory exists
+	entries, err := os.ReadDir(packagesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			svc.userLogger.InfoLn("No packages directory found, skipping packages index")
+			return nil
+		}
+
+		return fmt.Errorf("read packages directory %q: %w", packagesDir, err)
+	}
+
+	// Find all package directories
+	var packageNames []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			packageNames = append(packageNames, entry.Name())
+		}
+	}
+
+	if len(packageNames) == 0 {
+		svc.userLogger.InfoLn("No packages found, skipping packages index")
+		return nil
+	}
+
+	slices.Sort(packageNames)
+	svc.userLogger.Infof("Creating packages index with %d packages", len(packageNames))
+
+	// Get client scoped to packages repo
+	packagesClient := svc.client.WithSegment(internal.PackagesSegment)
+
+	// Push a small random image for each package with tag = package name
+	for _, packageName := range packageNames {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		svc.userLogger.Infof("Creating index tag: %s:%s", packagesClient.GetRegistry(), packageName)
+
+		// Create minimal random image (32 bytes, 1 layer)
+		img, err := random.Image(32, 1)
+		if err != nil {
+			return fmt.Errorf("create random image for package discovery tag %s: %w", packageName, err)
+		}
+
+		// Push with package name as tag
+		if err := packagesClient.PushImage(ctx, packageName, img); err != nil {
+			return fmt.Errorf("push package index tag %s to registry %s: %w", packageName, packagesClient.GetRegistry(), err)
+		}
+	}
+
+	svc.userLogger.Infof("Packages index created successfully")
 
 	return nil
 }

--- a/pkg/libmirror/bundle/bundle.go
+++ b/pkg/libmirror/bundle/bundle.go
@@ -122,9 +122,33 @@ func Pack(ctx context.Context, sourcePath string, sink io.Writer) error {
 // For example, PackWithPrefix(ctx, "/tmp/module", "modules/stronghold", sink) will create
 // tar entries like "modules/stronghold/index.json" instead of just "index.json".
 func PackWithPrefix(ctx context.Context, sourcePath string, prefix string, sink io.Writer) error {
+	return PackSourcesWithPrefix(ctx, sink, PackSource{Dir: sourcePath, Prefix: prefix})
+}
+
+// PackSource describes one directory to be packed into a tar stream.
+type PackSource struct {
+	// Dir is the source directory on disk whose contents are packed.
+	Dir string
+	// Prefix is prepended to every entry's path inside the tar.
+	Prefix string
+	// ExcludeDirs lists directories (by path) to skip together with their
+	// descendants. It is used to keep a nested OCI layout (e.g. a package's
+	// version/ sub-layout) out of an archive that is produced separately.
+	ExcludeDirs []string
+}
+
+// PackSourcesWithPrefix packs several (dir, prefix) sources into a single tar
+// stream written to sink. It is the multi-source counterpart of
+// PackWithPrefix and is used to aggregate layouts from many packages into one
+// archive (e.g. package-versions.tar).
+func PackSourcesWithPrefix(ctx context.Context, sink io.Writer, sources ...PackSource) error {
 	tarWriter := tar.NewWriter(sink)
-	if err := filepath.Walk(sourcePath, packFuncWithPrefix(ctx, sourcePath, prefix, tarWriter)); err != nil {
-		return fmt.Errorf("pack mirrored images into tar: %w", err)
+
+	for _, src := range sources {
+		walkFn := packFuncWithPrefix(ctx, src.Dir, src.Prefix, src.ExcludeDirs, tarWriter)
+		if err := filepath.Walk(src.Dir, walkFn); err != nil {
+			return fmt.Errorf("pack mirrored images into tar: %w", err)
+		}
 	}
 
 	if err := tarWriter.Close(); err != nil {
@@ -134,8 +158,13 @@ func PackWithPrefix(ctx context.Context, sourcePath string, prefix string, sink 
 	return nil
 }
 
-func packFuncWithPrefix(ctx context.Context, pathPrefix string, tarPrefix string, writer *tar.Writer) filepath.WalkFunc {
+func packFuncWithPrefix(ctx context.Context, pathPrefix string, tarPrefix string, excludeDirs []string, writer *tar.Writer) filepath.WalkFunc {
 	unixEpochStart := time.Unix(0, 0)
+
+	excluded := make(map[string]struct{}, len(excludeDirs))
+	for _, d := range excludeDirs {
+		excluded[filepath.Clean(d)] = struct{}{}
+	}
 
 	return func(path string, info fs.FileInfo, err error) error {
 		if ctx.Err() != nil {
@@ -144,6 +173,12 @@ func packFuncWithPrefix(ctx context.Context, pathPrefix string, tarPrefix string
 
 		if err != nil {
 			return err
+		}
+
+		if info.IsDir() {
+			if _, skip := excluded[filepath.Clean(path)]; skip {
+				return filepath.SkipDir
+			}
 		}
 
 		if path == pathPrefix || info.IsDir() {

--- a/pkg/libmirror/bundle/bundle.go
+++ b/pkg/libmirror/bundle/bundle.go
@@ -20,14 +20,29 @@ import (
 	"archive/tar"
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+const (
+	// indexFileName is the OCI image index file name. Multiple bundle archives may
+	// carry the same layout path (e.g. packages/<name>/version) while exposing
+	// different tag subsets, so colliding index.json files must be merged rather
+	// than overwritten when unpacking into a shared directory.
+	indexFileName = "index.json"
+
+	refNameAnnotation = "org.opencontainers.image.ref.name"
 )
 
 func Unpack(ctx context.Context, source io.Reader, targetPath string, pkgName string) error {
@@ -249,6 +264,27 @@ func moveFiles(from, to string) error {
 		fromPath := filepath.Join(from, file.Name())
 		toPath := filepath.Join(to, file.Name())
 
+		// Two archives can target the same OCI layout: they share blobs (named by
+		// unique content hash, so no collision) but each carries its own index.json.
+		// A plain rename would let the last archive's index overwrite the previous
+		// one, dropping the tags it didn't include even though their blobs are
+		// already on disk. Merge the manifests instead to keep every tag.
+		if file.Name() == indexFileName {
+			if _, statErr := os.Stat(toPath); statErr == nil {
+				if err = mergeIndexJSON(fromPath, toPath); err != nil {
+					return fmt.Errorf("merge index.json: %w", err)
+				}
+
+				if err = os.Remove(fromPath); err != nil {
+					return fmt.Errorf("remove merged source index: %w", err)
+				}
+
+				continue
+			} else if !errors.Is(statErr, fs.ErrNotExist) {
+				return fmt.Errorf("stat destination index: %w", statErr)
+			}
+		}
+
 		err = os.Rename(fromPath, toPath)
 		if err != nil {
 			return fmt.Errorf("move file: %w", err)
@@ -256,4 +292,89 @@ func moveFiles(from, to string) error {
 	}
 
 	return nil
+}
+
+// ociIndex is a minimal representation of an OCI image index (index.json)
+// sufficient to merge manifest lists from multiple archives.
+type ociIndex struct {
+	SchemaVersion int64             `json:"schemaVersion"`
+	MediaType     types.MediaType   `json:"mediaType,omitempty"`
+	Manifests     []v1.Descriptor   `json:"manifests"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+	Subject       *v1.Descriptor    `json:"subject,omitempty"`
+}
+
+// mergeIndexJSON merges the OCI image index at srcPath into the one at dstPath,
+// writing the union back to dstPath. Manifests are deduplicated by digest paired
+// with their ref.name annotation so layouts that share blobs but expose different
+// tag subsets don't lose tags when unpacked into the same directory.
+func mergeIndexJSON(srcPath, dstPath string) error {
+	srcIndex, err := readOCIIndex(srcPath)
+	if err != nil {
+		return fmt.Errorf("read source index %q: %w", srcPath, err)
+	}
+
+	dstIndex, err := readOCIIndex(dstPath)
+	if err != nil {
+		return fmt.Errorf("read destination index %q: %w", dstPath, err)
+	}
+
+	if dstIndex.SchemaVersion == 0 {
+		dstIndex.SchemaVersion = srcIndex.SchemaVersion
+	}
+
+	if dstIndex.MediaType == "" {
+		dstIndex.MediaType = srcIndex.MediaType
+	}
+
+	manifestKey := func(d v1.Descriptor) string {
+		return d.Digest.String() + "\x00" + d.Annotations[refNameAnnotation]
+	}
+
+	seen := make(map[string]struct{}, len(dstIndex.Manifests)+len(srcIndex.Manifests))
+	merged := make([]v1.Descriptor, 0, len(dstIndex.Manifests)+len(srcIndex.Manifests))
+
+	for _, list := range [][]v1.Descriptor{dstIndex.Manifests, srcIndex.Manifests} {
+		for _, descriptor := range list {
+			key := manifestKey(descriptor)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+
+			seen[key] = struct{}{}
+
+			merged = append(merged, descriptor)
+		}
+	}
+
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Annotations[refNameAnnotation] < merged[j].Annotations[refNameAnnotation]
+	})
+
+	dstIndex.Manifests = merged
+
+	raw, err := json.MarshalIndent(dstIndex, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal merged index: %w", err)
+	}
+
+	if err = os.WriteFile(dstPath, raw, 0o600); err != nil {
+		return fmt.Errorf("write merged index %q: %w", dstPath, err)
+	}
+
+	return nil
+}
+
+func readOCIIndex(path string) (*ociIndex, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	index := &ociIndex{}
+	if err = json.Unmarshal(raw, index); err != nil {
+		return nil, fmt.Errorf("parse index: %w", err)
+	}
+
+	return index, nil
 }

--- a/pkg/libmirror/bundle/bundle_test.go
+++ b/pkg/libmirror/bundle/bundle_test.go
@@ -96,6 +96,200 @@ func TestUnpackMergesCollidingIndexes(t *testing.T) {
 	require.ElementsMatch(t, fullTags, gotTags, "all tags must survive the merge of colliding index.json files")
 }
 
+// TestUnpackMergesThreeArchives verifies the merge accumulates across more than
+// two archives unpacked into the same layout path.
+func TestUnpackMergesThreeArchives(t *testing.T) {
+	unpackDir, err := os.MkdirTemp(os.TempDir(), "unpack_merge3_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(unpackDir) })
+
+	const layoutPath = "packages/foo/version/index.json"
+
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, []string{"v1.0.0"})), unpackDir, "package-a"))
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, []string{"v1.1.0"})), unpackDir, "package-b"))
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, []string{"v1.2.0"})), unpackDir, "package-c"))
+
+	gotTags := readIndexTags(t, filepath.Join(unpackDir, layoutPath))
+	require.ElementsMatch(t, []string{"v1.0.0", "v1.1.0", "v1.2.0"}, gotTags)
+}
+
+// TestUnpackSubsetFirstThenFull verifies that the truncated archive arriving
+// first does not prevent the full archive's extra tags from being added.
+func TestUnpackSubsetFirstThenFull(t *testing.T) {
+	unpackDir, err := os.MkdirTemp(os.TempDir(), "unpack_subset_first_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(unpackDir) })
+
+	const layoutPath = "packages/foo/version/index.json"
+
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, []string{"stable", "v1.2.0"})), unpackDir, "package-versions"))
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, []string{"stable", "v1.0.0", "v1.1.0", "v1.2.0"})), unpackDir, "package-foo"))
+
+	gotTags := readIndexTags(t, filepath.Join(unpackDir, layoutPath))
+	require.ElementsMatch(t, []string{"stable", "v1.0.0", "v1.1.0", "v1.2.0"}, gotTags)
+}
+
+// TestUnpackNoCollisionKeepsSingleIndex verifies the common case where a layout
+// path appears in only one archive: the index is moved as-is.
+func TestUnpackNoCollisionKeepsSingleIndex(t *testing.T) {
+	unpackDir, err := os.MkdirTemp(os.TempDir(), "unpack_no_collision_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(unpackDir) })
+
+	const layoutPath = "packages/foo/version/index.json"
+
+	tags := []string{"stable", "v2.0.0"}
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(makeIndexTar(t, layoutPath, tags)), unpackDir, "package-foo"))
+
+	gotTags := readIndexTags(t, filepath.Join(unpackDir, layoutPath))
+	require.ElementsMatch(t, tags, gotTags)
+}
+
+func TestMergeIndexJSON(t *testing.T) {
+	t.Run("union deduplicates identical descriptors", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		src := filepath.Join(dir, "src.json")
+
+		writeIndexFile(t, dst, []string{"stable", "v1.0.0", "v1.1.0", "v1.2.0"})
+		writeIndexFile(t, src, []string{"stable", "v1.2.0"})
+
+		require.NoError(t, mergeIndexJSON(src, dst))
+
+		merged := readOCIIndexFile(t, dst)
+		require.Len(t, merged.Manifests, 4, "shared tags must not be duplicated")
+		require.ElementsMatch(t, []string{"stable", "v1.0.0", "v1.1.0", "v1.2.0"}, tagsOf(merged))
+	})
+
+	t.Run("same tag with distinct digests are both kept", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		src := filepath.Join(dir, "src.json")
+
+		writeIndexWithDescriptors(t, dst, []v1.Descriptor{descriptorFor("stable", "aaaa")})
+		writeIndexWithDescriptors(t, src, []v1.Descriptor{descriptorFor("stable", "bbbb")})
+
+		require.NoError(t, mergeIndexJSON(src, dst))
+
+		merged := readOCIIndexFile(t, dst)
+		require.Len(t, merged.Manifests, 2, "same tag pointing at different digests must both survive")
+	})
+
+	t.Run("result is sorted by ref name", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		src := filepath.Join(dir, "src.json")
+
+		writeIndexFile(t, dst, []string{"v1.2.0", "stable"})
+		writeIndexFile(t, src, []string{"v1.0.0", "v1.1.0"})
+
+		require.NoError(t, mergeIndexJSON(src, dst))
+
+		refs := make([]string, 0)
+		for _, m := range readOCIIndexFile(t, dst).Manifests {
+			refs = append(refs, m.Annotations[refNameAnnotation])
+		}
+
+		require.IsIncreasing(t, refs, "manifests must be deterministically sorted by ref name")
+	})
+
+	t.Run("schema and media type fall back to source when destination lacks them", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		src := filepath.Join(dir, "src.json")
+
+		// Destination missing schemaVersion/mediaType.
+		require.NoError(t, os.WriteFile(dst, []byte(`{"manifests":[]}`), 0o600))
+		writeIndexFile(t, src, []string{"v1.0.0"})
+
+		require.NoError(t, mergeIndexJSON(src, dst))
+
+		merged := readOCIIndexFile(t, dst)
+		require.Equal(t, int64(2), merged.SchemaVersion)
+		require.Equal(t, "application/vnd.oci.image.index.v1+json", string(merged.MediaType))
+		require.ElementsMatch(t, []string{"v1.0.0"}, tagsOf(merged))
+	})
+
+	t.Run("invalid source json returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		src := filepath.Join(dir, "src.json")
+
+		writeIndexFile(t, dst, []string{"v1.0.0"})
+		require.NoError(t, os.WriteFile(src, []byte("{not json"), 0o600))
+
+		require.Error(t, mergeIndexJSON(src, dst))
+	})
+
+	t.Run("missing source file returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst.json")
+		writeIndexFile(t, dst, []string{"v1.0.0"})
+
+		require.Error(t, mergeIndexJSON(filepath.Join(dir, "does-not-exist.json"), dst))
+	})
+}
+
+func descriptorFor(tag, hexSeed string) v1.Descriptor {
+	hex := hexSeed
+	for len(hex) < 64 {
+		hex += "0"
+	}
+
+	return v1.Descriptor{
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Size:      123,
+		Digest:    v1.Hash{Algorithm: "sha256", Hex: hex[:64]},
+		Annotations: map[string]string{
+			refNameAnnotation: "example.com/packages/foo/version:" + tag,
+		},
+	}
+}
+
+func writeIndexFile(t *testing.T, path string, tags []string) {
+	t.Helper()
+
+	descriptors := make([]v1.Descriptor, 0, len(tags))
+	for _, tag := range tags {
+		descriptors = append(descriptors, descriptorFor(tag, hexDigestForTag(tag)))
+	}
+
+	writeIndexWithDescriptors(t, path, descriptors)
+}
+
+func writeIndexWithDescriptors(t *testing.T, path string, descriptors []v1.Descriptor) {
+	t.Helper()
+
+	index := ociIndex{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+		Manifests:     descriptors,
+	}
+
+	raw, err := json.MarshalIndent(index, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+}
+
+func readOCIIndexFile(t *testing.T, path string) *ociIndex {
+	t.Helper()
+
+	index, err := readOCIIndex(path)
+	require.NoError(t, err)
+
+	return index
+}
+
+func tagsOf(index *ociIndex) []string {
+	tags := make([]string, 0, len(index.Manifests))
+	for _, m := range index.Manifests {
+		_, tag, _ := strings.Cut(m.Annotations[refNameAnnotation], ":")
+		tags = append(tags, tag)
+	}
+
+	return tags
+}
+
 // makeIndexTar builds an in-memory tar with a single OCI index.json at indexPath,
 // containing one manifest per tag (distinct digests).
 func makeIndexTar(t *testing.T, indexPath string, tags []string) []byte {

--- a/pkg/libmirror/bundle/bundle_test.go
+++ b/pkg/libmirror/bundle/bundle_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package bundle
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"io"
 	"io/fs"
 	"os"
@@ -26,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,6 +67,108 @@ func TestBundlePackingAndUnpacking(t *testing.T) {
 
 	resultingFiles := findAllPaths(t, unpackToDir)
 	require.Equal(t, expectedFiles, resultingFiles, "Expected to find same file trees under source and target dirs")
+}
+
+// TestUnpackMergesCollidingIndexes reproduces the bundle bug where two archives
+// carry the same OCI layout path (packages/foo/version) but expose different tag
+// subsets. The first archive holds the full set of tags; the second (built from
+// channels only) holds a subset. Unpacking both into a shared directory must keep
+// every tag instead of letting the second archive's index.json overwrite the first.
+func TestUnpackMergesCollidingIndexes(t *testing.T) {
+	unpackDir, err := os.MkdirTemp(os.TempDir(), "unpack_merge_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(unpackDir) })
+
+	const layoutPath = "packages/foo/version/index.json"
+
+	fullTags := []string{"stable", "v1.0.0", "v1.1.0", "v1.2.0"}
+	subsetTags := []string{"stable", "v1.2.0"}
+
+	// package-foo.tar: full index. Unpacked first (alphabetical order).
+	fooTar := makeIndexTar(t, layoutPath, fullTags)
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(fooTar), unpackDir, "package-foo"))
+
+	// package-versions.tar: truncated index sharing the same path.
+	versionsTar := makeIndexTar(t, layoutPath, subsetTags)
+	require.NoError(t, Unpack(context.TODO(), bytes.NewReader(versionsTar), unpackDir, "package-versions"))
+
+	gotTags := readIndexTags(t, filepath.Join(unpackDir, layoutPath))
+	require.ElementsMatch(t, fullTags, gotTags, "all tags must survive the merge of colliding index.json files")
+}
+
+// makeIndexTar builds an in-memory tar with a single OCI index.json at indexPath,
+// containing one manifest per tag (distinct digests).
+func makeIndexTar(t *testing.T, indexPath string, tags []string) []byte {
+	t.Helper()
+
+	manifests := make([]v1.Descriptor, 0, len(tags))
+	for i, tag := range tags {
+		manifests = append(manifests, v1.Descriptor{
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Size:      int64(100 + i),
+			Digest:    v1.Hash{Algorithm: "sha256", Hex: hexDigestForTag(tag)},
+			Annotations: map[string]string{
+				refNameAnnotation: "example.com/packages/foo/version:" + tag,
+			},
+		})
+	}
+
+	index := ociIndex{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+		Manifests:     manifests,
+	}
+
+	raw, err := json.MarshalIndent(index, "", "  ")
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     indexPath,
+		Size:     int64(len(raw)),
+		Mode:     0o644,
+	}))
+	_, err = tw.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	return buf.Bytes()
+}
+
+func readIndexTags(t *testing.T, path string) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	index := &ociIndex{}
+	require.NoError(t, json.Unmarshal(raw, index))
+
+	tags := make([]string, 0, len(index.Manifests))
+	for _, m := range index.Manifests {
+		ref := m.Annotations[refNameAnnotation]
+		_, tag, found := strings.Cut(ref, ":")
+		require.True(t, found, "manifest ref %q must contain a tag", ref)
+		tags = append(tags, tag)
+	}
+
+	return tags
+}
+
+func hexDigestForTag(tag string) string {
+	const hexLen = 64
+	out := make([]byte, hexLen)
+	for i := range out {
+		out[i] = '0'
+	}
+
+	for i := 0; i < len(tag) && i < hexLen; i++ {
+		out[hexLen-1-i] = "0123456789abcdef"[tag[len(tag)-1-i]%16]
+	}
+
+	return string(out)
 }
 
 func fillTestFileTree(t *testing.T, packFromDir string) {

--- a/pkg/libmirror/bundle/validation.go
+++ b/pkg/libmirror/bundle/validation.go
@@ -46,6 +46,13 @@ func MandatoryLayoutsForModule(modulePkgDir string) map[string]string {
 	}
 }
 
+func MandatoryLayoutsForPackage(packagePkgDir string) map[string]string {
+	return map[string]string{
+		"package root layout":             packagePkgDir,
+		"package version channels layout": filepath.Join(packagePkgDir, "version"),
+	}
+}
+
 func ValidateUnpackedPackage(mandatoryLayouts map[string]string) error {
 	for layoutDescription, fsPath := range mandatoryLayouts {
 		l, err := layout.FromPath(fsPath)

--- a/pkg/libmirror/operations/params/base.go
+++ b/pkg/libmirror/operations/params/base.go
@@ -36,10 +36,11 @@ type Logger interface {
 // BaseParams hold data related to pending registry mirroring operation.
 type BaseParams struct {
 	// --registry-login + --registry-password (can be nil in this case, means anonymous) or --license depending on the operation requested
-	RegistryAuth      authn.Authenticator
-	RegistryHost      string // --registry (FQDN with port, if one is provided)
-	RegistryPath      string // --registry (path)
-	ModulesPathSuffix string // --modules-path-suffix
+	RegistryAuth       authn.Authenticator
+	RegistryHost       string // --registry (FQDN with port, if one is provided)
+	RegistryPath       string // --registry (path)
+	ModulesPathSuffix  string // --modules-path-suffix
+	PackagesPathSuffix string // --packages-path-suffix
 
 	DeckhouseRegistryRepo string // --source during pull
 

--- a/pkg/libmirror/operations/params/base.go
+++ b/pkg/libmirror/operations/params/base.go
@@ -36,11 +36,10 @@ type Logger interface {
 // BaseParams hold data related to pending registry mirroring operation.
 type BaseParams struct {
 	// --registry-login + --registry-password (can be nil in this case, means anonymous) or --license depending on the operation requested
-	RegistryAuth       authn.Authenticator
-	RegistryHost       string // --registry (FQDN with port, if one is provided)
-	RegistryPath       string // --registry (path)
-	ModulesPathSuffix  string // --modules-path-suffix
-	PackagesPathSuffix string // --packages-path-suffix
+	RegistryAuth      authn.Authenticator
+	RegistryHost      string // --registry (FQDN with port, if one is provided)
+	RegistryPath      string // --registry (path)
+	ModulesPathSuffix string // --modules-path-suffix
 
 	DeckhouseRegistryRepo string // --source during pull
 

--- a/pkg/libmirror/operations/params/pull.go
+++ b/pkg/libmirror/operations/params/pull.go
@@ -28,6 +28,7 @@ type PullParams struct {
 	SkipPlatform          bool  // --no-platform
 	SkipSecurityDatabases bool  // --no-security-db
 	SkipModules           bool  // --no-modules
+	SkipPackages          bool  // --no-packages
 	SkipInstaller         bool  // --no-installer
 	OnlyExtraImages       bool  // --only-extra-images
 	IgnoreSuspend         bool  // --ignore-suspend

--- a/pkg/registry/service/package_service.go
+++ b/pkg/registry/service/package_service.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"github.com/deckhouse/deckhouse/pkg/log"
+	client "github.com/deckhouse/deckhouse/pkg/registry"
+)
+
+// Packages are structurally identical to modules, but they live under the
+// packages/ catalog segment and expose their release-channel metadata under a
+// version/ segment instead of release/.
+const (
+	packageVersionChannelsSegment = "version"
+	packageExtraSegment           = "extra"
+
+	packagesServiceName               = "packages"
+	packageServiceName                = "package"
+	packageVersionChannelsServiceName = "package_version_channel"
+	packageExtraServiceName           = "package_extra"
+)
+
+// PackageService provides high-level operations for a single package.
+type PackageService struct {
+	client client.Client
+
+	*BasicService
+	packageVersionChannels *PackageVersionService
+	extra                  *BasicService
+	extraImages            map[string]*BasicService
+
+	logger *log.Logger
+}
+
+// NewPackageService creates a new package service.
+func NewPackageService(client client.Client, logger *log.Logger) *PackageService {
+	return &PackageService{
+		client: client,
+
+		BasicService:           NewBasicService(packageServiceName, client, logger),
+		packageVersionChannels: NewPackageVersionService(NewBasicService(packageVersionChannelsServiceName, client.WithSegment(packageVersionChannelsSegment), logger)),
+		extra:                  NewBasicService(packageExtraServiceName, client.WithSegment(packageExtraSegment), logger),
+		extraImages:            make(map[string]*BasicService),
+
+		logger: logger,
+	}
+}
+
+// VersionChannels returns the service scoped to packages/<package>/version.
+func (s *PackageService) VersionChannels() *PackageVersionService {
+	return s.packageVersionChannels
+}
+
+func (s *PackageService) Extra() *BasicService {
+	return s.extra
+}
+
+// ExtraImage returns a BasicService scoped to a specific extra image (e.g., packages/<package>/extra/<extraName>).
+func (s *PackageService) ExtraImage(extraName string) *BasicService {
+	if s.extraImages == nil {
+		s.extraImages = make(map[string]*BasicService)
+	}
+
+	if _, exists := s.extraImages[extraName]; !exists {
+		extraClient := s.client.WithSegment(packageExtraSegment).WithSegment(extraName)
+		s.extraImages[extraName] = NewBasicService(packageExtraServiceName+"/"+extraName, extraClient, s.logger)
+	}
+
+	return s.extraImages[extraName]
+}
+
+type PackagesService struct {
+	client client.Client
+
+	*BasicService
+
+	services map[string]*PackageService
+
+	logger *log.Logger
+}
+
+func NewPackagesService(client client.Client, logger *log.Logger) *PackagesService {
+	return &PackagesService{
+		client: client,
+
+		BasicService: NewBasicService(packagesServiceName, client, logger),
+		services:     make(map[string]*PackageService),
+
+		logger: logger,
+	}
+}
+
+func (s *PackagesService) Package(packageName string) *PackageService {
+	if s.services == nil {
+		s.services = make(map[string]*PackageService)
+	}
+
+	if _, exists := s.services[packageName]; !exists {
+		packageClient := s.client.WithSegment(packageName)
+		s.services[packageName] = NewPackageService(packageClient, s.logger)
+	}
+
+	return s.services[packageName]
+}
+
+type PackageVersionService struct {
+	*BasicService
+}
+
+func NewPackageVersionService(basicService *BasicService) *PackageVersionService {
+	return &PackageVersionService{
+		BasicService: basicService,
+	}
+}

--- a/pkg/registry/service/service.go
+++ b/pkg/registry/service/service.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	moduleSegment   = "modules"
+	packageSegment  = "packages"
 	pluginSegment   = "plugins"
 	securitySegment = "security"
 
@@ -42,6 +43,7 @@ type Service struct {
 	editionBase client.Client
 
 	modulesService   *ModulesService
+	packagesService  *PackagesService
 	pluginService    *PluginService
 	deckhouseService *DeckhouseService
 	security         *SecurityServices
@@ -69,6 +71,7 @@ func NewService(c client.Client, edition pkg.Edition, logger *log.Logger) *Servi
 	s.editionBase = base
 
 	s.modulesService = NewModulesService(base.WithSegment(moduleSegment), logger.Named("modules"))
+	s.packagesService = NewPackagesService(base.WithSegment(packageSegment), logger.Named("packages"))
 	s.deckhouseService = NewDeckhouseService(base, logger.Named("deckhouse"))
 	s.security = NewSecurityServices(securityServiceName, base.WithSegment(securitySegment), logger.Named("security"))
 
@@ -97,6 +100,11 @@ func (s *Service) GetEditionRoot() string {
 // ModuleService returns the module service
 func (s *Service) ModuleService() *ModulesService {
 	return s.modulesService
+}
+
+// PackageService returns the packages service
+func (s *Service) PackageService() *PackagesService {
+	return s.packagesService
 }
 
 // PluginService returns the plugin service


### PR DESCRIPTION
### Summary

Adds `packages` mirroring to `d8 mirror pull` / `push`, parallel to the existing `modules` support.

Packages follow the same registry structure as modules, but under different path segments:

| | Modules | Packages |
|---|---|---|
| Catalog | `…/modules` | `…/packages` |
| Main image | `…/modules/<name>:<ver>` | `…/packages/<name>:<ver>` |
| Release images | `…/modules/<name>/release` | `…/packages/<name>/version` |
| Extras | `…/modules/<name>/extra/<n>` | `…/packages/<name>/extra/<n>` |

#### New archives produced

- **`package-<name>.tar`** — one per package, full content (main image + version channel images + extra images). Identical structure to `module-<name>.tar`.
- **`package-versions.tar`** — aggregates the `version/` release images of **all** packages into a single archive. Produced on **every** mirror pull, regardless of which components are mirrored or whether `--no-packages` is set — so the package release catalog is always cloned into the bundle.

#### New CLI flags (`d8 mirror pull`)

```
--include-package <name>[@constraint]   whitelist packages (same constraint dialect as --include-module)
--exclude-package <name>[@constraint]   blacklist packages
--no-packages                           skip per-package pull (package-versions.tar is still produced)
--packages-path-suffix                  registry path suffix (default /packages)
```

`--include-package` and `--exclude-package` are mutually exclusive.

#### New files (separate package, matching existing layout conventions)

- `internal/mirror/packages/packages.go` — pull pipeline (discovery, channel/version/extra/vex images, channel-alias propagation, per-package packing)
- `internal/mirror/packages/layout.go` — OCI layout structs

#### Other changes

- `pkg/libmirror/bundle/bundle.go` — added `PackSourcesWithPrefix` (multi-source tar packer used for `package-versions`) and `PackSource.ExcludeDirs` walk option; `PackWithPrefix` delegates to it, no callers changed.
- `pkg/registry/service/package_service.go` — `PackagesService` / `PackageService` / `PackageVersionService` (mirror of module service with `version` segment).
- `pkg/libmirror/bundle/validation.go` — `MandatoryLayoutsForPackage`.
- `internal/mirror/push.go` — `createPackagesIndex` for post-push discovery.
- `internal/layout.go`, `internal/mirror.go` — `PackagesSegment`, `PackagesVersionSegment`, `MirrorTypePackages*` constants.
- `pkg/libmirror/operations/params` — `SkipPackages`, `PackagesPathSuffix` fields.

#### Design notes

- Packages reuse the modules version-selection vocabulary (`Filter`, `Module`, `VersionConstraint`, `ProbeAvailableVersions`) rather than duplicating it — the same pattern already used by `platform`.
- Registries without a packages catalog degrade gracefully (warn + skip), so this never interrupts platform/security/modules mirroring.
- Release images are intentionally duplicated between `package-<name>.tar` and `package-versions.tar`; the per-package archive stays fully self-contained.
