### PR TITLE
[deckhouse-cli] d8 cr login and --username/--password flags

### DIFF
--- a/internal/cr/README.md
+++ b/internal/cr/README.md
@@ -12,7 +12,9 @@ listing tags, inspecting manifests and configs, and exploring image contents
 file-by-file.
 
 Authentication piggybacks on the standard Docker config
-(`~/.docker/config.json`), so `docker login` / `d8 login` work transparently.
+(`~/.docker/config.json`), so `d8 cr login` / `docker login` work
+transparently. You can also pass `--username`/`--password` to any command for
+one-off credentials without touching the config.
 
 ---
 
@@ -83,6 +85,18 @@ manifest, config, digest, all `fs *`, export). With `--format oci`, `pull`
 keeps the entire index by default - omit `--platform` and you get every
 platform on disk; pass it and you narrow down to one.
 
+### Authentication
+
+- **`login`** - verify credentials against a registry and persist them to the
+  Docker config (`~/.docker/config.json`, honouring `$DOCKER_CONFIG` and any
+  configured credential helper / store), exactly like `docker login`. Once
+  logged in, every other `d8 cr` command authenticates transparently.
+  Username and password come from `--username`/`--password`; omit either to be
+  prompted interactively (the password is read without echo).
+- **Inline credentials** - the persistent `--username`/`--password` flags work
+  on every command, letting CI pass one-off credentials (and override whatever
+  the Docker config holds) without a prior `login`.
+
 ### Security and connectivity
 
 - **TLS by default**, with `--insecure` to opt into plain HTTP and skip
@@ -110,6 +124,7 @@ platform on disk; pass it and you narrow down to one.
 
 ```
 d8 cr
+├── login [REGISTRY]           Log in to a registry and save credentials
 ├── pull IMAGE... PATH         Pull image(s) to a tarball or OCI layout
 ├── push PATH IMAGE            Push a tarball or OCI layout to a registry
 ├── export IMAGE [TARBALL]     Stream the merged filesystem as a tar
@@ -135,6 +150,8 @@ These persistent flags apply to every `d8 cr` subcommand:
 | `--insecure` | Allow plain HTTP and skip TLS verification |
 | `--allow-nondistributable-artifacts` | Include non-distributable (foreign) layers when pushing |
 | `--platform os/arch[/variant][:osversion]` | Resolve multi-arch indices to a specific platform (image-level commands only) |
+| `-u`, `--username` | Registry username (overrides the Docker config; use with `--password`) |
+| `-p`, `--password` | Registry password or token (overrides the Docker config; use with `--username`) |
 
 ---
 
@@ -276,6 +293,22 @@ diff \
 
 A copy-pasteable cheat-sheet of the most common invocations.
 
+### Log in
+
+```bash
+# Prompt for username and password
+d8 cr login registry.internal
+
+# Non-interactive (e.g. CI)
+d8 cr login registry.internal --username robot --password "$TOKEN"
+
+# Log in to Docker Hub (default registry when REGISTRY is omitted)
+d8 cr login --username alice --password "$TOKEN"
+
+# Skip login entirely: pass credentials to any command directly
+d8 cr pull --username robot --password "$TOKEN" registry.internal/app:v1 ./app.tar
+```
+
 ### Pull
 
 ```bash
@@ -409,11 +442,11 @@ single-responsibility packages:
 | Package | Responsibility |
 |---|---|
 | `internal/cr/cmd` | Root cobra command, persistent flags, integration tests |
-| `internal/cr/cmd/basic` | Top-level subcommands: `pull`, `push`, `export`, `ls`, `catalog`, `manifest`, `config`, `digest` |
+| `internal/cr/cmd/basic` | Top-level subcommands: `login`, `pull`, `push`, `export`, `ls`, `catalog`, `manifest`, `config`, `digest` |
 | `internal/cr/cmd/fs` | `fs` subtree: `ls`, `cat`, `tree`, `extract` |
 | `internal/cr/cmd/completion` | Shell-completion helpers (bounded, fail-silent) |
 | `internal/cr/cmd/rootflagnames` | Single source of truth for persistent flag names |
-| `internal/cr/internal/registry` | Thin domain layer over `go-containerregistry` (fetch / push / list / options) |
+| `internal/cr/internal/registry` | Thin domain layer over `go-containerregistry` (fetch / push / list / login / options) |
 | `internal/cr/internal/image` | Pure operations over `v1.Image` / `v1.ImageIndex` (multi-arch resolve, ...) |
 | `internal/cr/internal/imageio` | Disk I/O: tarball + OCI image-layout load/save |
 | `internal/cr/internal/imagefs` | Merged-filesystem reader with whiteout handling and safe extraction |

--- a/internal/cr/cmd/basic/login.go
+++ b/internal/cr/cmd/basic/login.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/deckhouse/deckhouse-cli/internal/cr/cmd/completion"
+	"github.com/deckhouse/deckhouse-cli/internal/cr/cmd/rootflagnames"
+	"github.com/deckhouse/deckhouse-cli/internal/cr/internal/registry"
+)
+
+const loginLong = `Log in to a container registry.
+
+Verifies the credentials against the registry and, on success, writes them to
+the Docker config (~/.docker/config.json, honouring $DOCKER_CONFIG). Every
+other "d8 cr" command then authenticates from that config automatically, the
+same way "docker login" works.
+
+Credentials come from the --username/--password flags; either may be omitted
+to be prompted interactively (the password is read without echo). With no
+REGISTRY argument the default Docker Hub registry is used.`
+
+const loginExample = `  # Prompt for username and password
+  d8 cr login registry.example.com
+
+  # Non-interactive (e.g. CI)
+  d8 cr login registry.example.com --username robot --password "$TOKEN"
+
+  # Log in to Docker Hub
+  d8 cr login --username alice --password "$TOKEN"`
+
+func NewLoginCmd(opts *registry.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "login [REGISTRY]",
+		Short:             "Log in to a container registry",
+		Long:              loginLong,
+		Example:           loginExample,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.RegistryHost(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var host string
+			if len(args) == 1 {
+				host = args[0]
+			}
+
+			username, _ := cmd.Flags().GetString(rootflagnames.Username)
+			password, _ := cmd.Flags().GetString(rootflagnames.Password)
+
+			username, password, err := resolveCredentials(cmd.InOrStdin(), cmd.OutOrStdout(), username, password)
+			if err != nil {
+				return err
+			}
+
+			res, err := registry.Login(cmd.Context(), host, username, password, opts)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Login succeeded for %s\nCredentials saved in %s\n", res.ServerAddress, res.ConfigFile)
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// resolveCredentials fills in any missing username/password by prompting on
+// the terminal. The password prompt suppresses echo when stdin is a TTY;
+// otherwise (piped input) it reads a plain line so scripts still work.
+func resolveCredentials(in io.Reader, out io.Writer, username, password string) (string, string, error) {
+	reader := bufio.NewReader(in)
+
+	if username == "" {
+		fmt.Fprint(out, "Username: ")
+
+		line, err := reader.ReadString('\n')
+		if err != nil && line == "" {
+			return "", "", fmt.Errorf("read username: %w", err)
+		}
+
+		username = strings.TrimSpace(line)
+		if username == "" {
+			return "", "", fmt.Errorf("username is required")
+		}
+	}
+
+	if password == "" {
+		fmt.Fprint(out, "Password: ")
+
+		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+			b, err := term.ReadPassword(int(f.Fd()))
+			fmt.Fprintln(out)
+
+			if err != nil {
+				return "", "", fmt.Errorf("read password: %w", err)
+			}
+
+			password = string(b)
+		} else {
+			line, err := reader.ReadString('\n')
+			if err != nil && line == "" {
+				return "", "", fmt.Errorf("read password: %w", err)
+			}
+
+			password = strings.TrimRight(line, "\r\n")
+		}
+
+		if password == "" {
+			return "", "", fmt.Errorf("password is required")
+		}
+	}
+
+	return username, password, nil
+}

--- a/internal/cr/cmd/basic/login.go
+++ b/internal/cr/cmd/basic/login.go
@@ -112,6 +112,7 @@ func resolveCredentials(in io.Reader, out io.Writer, username, password string) 
 
 		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 			b, err := term.ReadPassword(int(f.Fd()))
+
 			fmt.Fprintln(out)
 
 			if err != nil {

--- a/internal/cr/cmd/cr.go
+++ b/internal/cr/cmd/cr.go
@@ -34,7 +34,8 @@ const (
 transfer (pull/push), and browse contents.
 
 Authentication uses the Docker config (~/.docker/config.json) - run
-"d8 login" first if the registry requires credentials.
+"d8 cr login" (or "docker login") first if the registry requires
+credentials, or pass --username/--password to any command directly.
 `
 )
 
@@ -52,6 +53,7 @@ func NewCommand() *cobra.Command {
 
 	setupRootFlags(cr, opts)
 	cr.AddCommand(
+		basic.NewLoginCmd(opts),
 		basic.NewPullCmd(opts),
 		basic.NewPushCmd(opts),
 		basic.NewExportCmd(opts),

--- a/internal/cr/cmd/rootflagnames/names.go
+++ b/internal/cr/cmd/rootflagnames/names.go
@@ -27,4 +27,6 @@ const (
 	Insecure              = "insecure"
 	AllowNondistributable = "allow-nondistributable-artifacts"
 	Platform              = "platform"
+	Username              = "username"
+	Password              = "password"
 )

--- a/internal/cr/cmd/rootflags.go
+++ b/internal/cr/cmd/rootflags.go
@@ -43,6 +43,8 @@ func setupRootFlags(cmd *cobra.Command, opts *registry.Options) {
 		insecure bool
 		ndLayers bool
 		platform string
+		username string
+		password string
 	)
 
 	flags := cmd.PersistentFlags()
@@ -50,6 +52,8 @@ func setupRootFlags(cmd *cobra.Command, opts *registry.Options) {
 	flags.BoolVar(&insecure, rootflagnames.Insecure, false, "Allow plain HTTP and skip TLS verification (localhost and RFC1918 hosts already auto-allow HTTP)")
 	flags.BoolVar(&ndLayers, rootflagnames.AllowNondistributable, false, "Include non-distributable (foreign) layers when pushing")
 	flags.StringVar(&platform, rootflagnames.Platform, "", "Resolve images to platform os/arch[/variant][:osversion] (image-level commands only)")
+	flags.StringVarP(&username, rootflagnames.Username, "u", "", "Registry username (overrides the Docker config; use with --password)")
+	flags.StringVarP(&password, rootflagnames.Password, "p", "", "Registry password or token (overrides the Docker config; use with --username)")
 	// No completion for --platform on purpose: the set of platforms a given
 	// image actually serves depends on its manifest list, which we cannot
 	// know at flag-completion time (the IMAGE arg may not even be typed
@@ -79,6 +83,13 @@ func setupRootFlags(cmd *cobra.Command, opts *registry.Options) {
 			}
 
 			opts.WithPlatform(p)
+		}
+
+		// Inline credentials win over whatever the Docker keychain would
+		// resolve, so a one-off `--username/--password` works without a
+		// prior `cr login`. `cr login` itself reads the same flags directly.
+		if username != "" {
+			opts.WithKeychain(registry.NewStaticKeychain(username, password))
 		}
 
 		return nil

--- a/internal/cr/cmd/rootflags.go
+++ b/internal/cr/cmd/rootflags.go
@@ -86,10 +86,19 @@ func setupRootFlags(cmd *cobra.Command, opts *registry.Options) {
 		}
 
 		// Inline credentials win over whatever the Docker keychain would
-		// resolve, so a one-off `--username/--password` works without a
-		// prior `cr login`. `cr login` itself reads the same flags directly.
-		if username != "" {
-			opts.WithKeychain(registry.NewStaticKeychain(username, password))
+		// resolve, so a one-off `--username/--password` works without a prior
+		// `cr login`. Both halves are required together here: a lone
+		// `--password` (or `--username`) would otherwise be silently dropped
+		// and the command would fall back to the Docker config, masking the
+		// mistake with a confusing 401. `login` is exempt - it reads the flags
+		// directly and prompts for whichever half is missing.
+		if c.Name() != "login" {
+			switch {
+			case username != "" && password != "":
+				opts.WithKeychain(registry.NewStaticKeychain(username, password))
+			case username != "" || password != "":
+				return fmt.Errorf("--%s and --%s must be used together", rootflagnames.Username, rootflagnames.Password)
+			}
 		}
 
 		return nil

--- a/internal/cr/internal/registry/login.go
+++ b/internal/cr/internal/registry/login.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/types"
@@ -43,9 +44,11 @@ type LoginResult struct {
 // them into the Docker config (the same store authn.DefaultKeychain reads),
 // so every other cr command can authenticate transparently afterwards.
 //
-// An empty host targets Docker Hub. Verification performs the standard
-// registry auth handshake (ping + token exchange); invalid credentials fail
-// here rather than silently writing a broken config.
+// An empty host targets Docker Hub. Verification builds the registry's auth
+// transport and then performs an authenticated GET /v2/: a rejected login
+// answers 401 there, so invalid credentials fail rather than silently writing
+// a broken config. (The transport handshake alone only validates bearer-token
+// registries; the explicit /v2/ probe is what also covers basic-auth ones.)
 func Login(ctx context.Context, host, username, password string, opts *Options) (*LoginResult, error) {
 	if host == "" {
 		host = name.DefaultRegistry
@@ -63,11 +66,22 @@ func Login(ctx context.Context, host, username, password string, opts *Options) 
 		rt = remote.DefaultTransport
 	}
 
-	// Empty scope keeps this a registry-level check: it pings /v2/ and, on a
-	// bearer challenge, exchanges the basic credentials for a token. Wrong
-	// credentials surface as a 401 here. A repository/catalog scope would
-	// additionally demand permissions a plain login user need not have.
-	if _, err := transport.NewWithContext(ctx, reg, auth, rt, []string{}); err != nil {
+	// Build the registry's auth transport. Empty scope keeps this a
+	// registry-level check (a repository/catalog scope would demand
+	// permissions a plain login user need not have). For a bearer challenge
+	// this already runs the token exchange, so wrong credentials fail here;
+	// for a basic challenge it only wraps the transport after an anonymous
+	// ping and never sends the credentials, so it cannot reject them.
+	authRT, err := transport.NewWithContext(ctx, reg, auth, rt, []string{})
+	if err != nil {
+		return nil, fmt.Errorf("verify credentials for %s: %w", reg.RegistryStr(), err)
+	}
+
+	// Actually exercise the credentials with an authenticated GET /v2/. This
+	// is what rejects wrong basic-auth credentials, which the handshake above
+	// lets through: /v2/ answers 200 to an authenticated client and 401 to a
+	// rejected one (exactly how `docker login` validates).
+	if err := verifyCredentials(ctx, reg, authRT); err != nil {
 		return nil, fmt.Errorf("verify credentials for %s: %w", reg.RegistryStr(), err)
 	}
 
@@ -91,6 +105,29 @@ func Login(ctx context.Context, host, username, password string, opts *Options) 
 		ServerAddress: serverAddress,
 		ConfigFile:    cf.GetFilename(),
 	}, nil
+}
+
+// verifyCredentials performs an authenticated GET /v2/ through rt (the
+// transport returned by transport.NewWithContext) and treats anything other
+// than 200 OK as failure. The /v2/ base endpoint is the registry API's auth
+// probe: it answers 200 to an authenticated client and 401 to a rejected one,
+// which makes it the credential check transport.NewWithContext skips for
+// basic-auth registries.
+func verifyCredentials(ctx context.Context, reg name.Registry, rt http.RoundTripper) error {
+	endpoint := fmt.Sprintf("%s://%s/v2/", reg.Scheme(), reg.RegistryStr())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := (&http.Client{Transport: rt}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return transport.CheckError(resp, http.StatusOK)
 }
 
 // dockerServerAddress maps a parsed registry to the key Docker stores

--- a/internal/cr/internal/registry/login.go
+++ b/internal/cr/internal/registry/login.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// LoginResult reports where the credentials ended up so the caller can tell
+// the user which file/store now holds them.
+type LoginResult struct {
+	// ServerAddress is the key the credentials were stored under. For Docker
+	// Hub this is the canonical "https://index.docker.io/v1/".
+	ServerAddress string
+	// ConfigFile is the path to the Docker config the credentials were
+	// written to (or the backing file of the active credential store).
+	ConfigFile string
+}
+
+// Login verifies username/password against host and, on success, persists
+// them into the Docker config (the same store authn.DefaultKeychain reads),
+// so every other cr command can authenticate transparently afterwards.
+//
+// An empty host targets Docker Hub. Verification performs the standard
+// registry auth handshake (ping + token exchange); invalid credentials fail
+// here rather than silently writing a broken config.
+func Login(ctx context.Context, host, username, password string, opts *Options) (*LoginResult, error) {
+	if host == "" {
+		host = name.DefaultRegistry
+	}
+
+	reg, err := name.NewRegistry(host, opts.Name...)
+	if err != nil {
+		return nil, fmt.Errorf("parse registry %q: %w", host, err)
+	}
+
+	auth := authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
+
+	rt := opts.Transport
+	if rt == nil {
+		rt = remote.DefaultTransport
+	}
+
+	// Empty scope keeps this a registry-level check: it pings /v2/ and, on a
+	// bearer challenge, exchanges the basic credentials for a token. Wrong
+	// credentials surface as a 401 here. A repository/catalog scope would
+	// additionally demand permissions a plain login user need not have.
+	if _, err := transport.NewWithContext(ctx, reg, auth, rt, []string{}); err != nil {
+		return nil, fmt.Errorf("verify credentials for %s: %w", reg.RegistryStr(), err)
+	}
+
+	serverAddress := dockerServerAddress(reg)
+
+	cf, err := config.Load(config.Dir())
+	if err != nil {
+		return nil, fmt.Errorf("load docker config: %w", err)
+	}
+
+	store := cf.GetCredentialsStore(serverAddress)
+	if err := store.Store(types.AuthConfig{
+		ServerAddress: serverAddress,
+		Username:      username,
+		Password:      password,
+	}); err != nil {
+		return nil, fmt.Errorf("store credentials for %s: %w", serverAddress, err)
+	}
+
+	return &LoginResult{
+		ServerAddress: serverAddress,
+		ConfigFile:    cf.GetFilename(),
+	}, nil
+}
+
+// dockerServerAddress maps a parsed registry to the key Docker stores
+// credentials under. Docker Hub is special-cased to the canonical
+// "https://index.docker.io/v1/" so authn.DefaultKeychain (which rewrites the
+// default registry to that key on lookup) finds the credentials again.
+func dockerServerAddress(reg name.Registry) string {
+	if reg.RegistryStr() == name.DefaultRegistry {
+		return authn.DefaultAuthKey
+	}
+
+	return reg.RegistryStr()
+}

--- a/internal/cr/internal/registry/login_test.go
+++ b/internal/cr/internal/registry/login_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+const (
+	goodUser = "robot"
+	goodPass = "s3cret"
+)
+
+// basicAuthRegistry mimics an htpasswd registry: /v2/ answers 200 only when the
+// request carries the correct Basic credentials, otherwise 401 with a Basic
+// challenge (the same shape `transport.NewWithContext` sees on its anonymous
+// ping). This is the case the old Login silently accepted with any password.
+func basicAuthRegistry() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if u, p, ok := r.BasicAuth(); ok && u == goodUser && p == goodPass {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+}
+
+// bearerAuthRegistry mimics a token registry (Docker Hub style): /v2/ requires a
+// Bearer token, and /token exchanges correct Basic credentials for one. Wrong
+// credentials are rejected at the token endpoint - the path the old Login
+// already handled - so this guards against the fix regressing the bearer flow.
+func bearerAuthRegistry() *httptest.Server {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer good-token" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", `Bearer realm="`+srv.URL+`/token",service="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); !ok || u != goodUser || p != goodPass {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "good-token"})
+	})
+
+	return srv
+}
+
+func TestLoginVerifiesCredentials(t *testing.T) {
+	cases := []struct {
+		name     string
+		registry func() *httptest.Server
+	}{
+		{"basic-auth (htpasswd)", basicAuthRegistry},
+		{"bearer-token", bearerAuthRegistry},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := tc.registry()
+			defer srv.Close()
+
+			host := strings.TrimPrefix(srv.URL, "http://")
+
+			t.Run("correct credentials succeed", func(t *testing.T) {
+				// Login persists to the Docker config; keep it inside the test.
+				t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+				res, err := Login(context.Background(), host, goodUser, goodPass, insecureOptions())
+				if err != nil {
+					t.Fatalf("expected login to succeed, got error: %v", err)
+				}
+				if res.ServerAddress != host {
+					t.Errorf("ServerAddress = %q, want %q", res.ServerAddress, host)
+				}
+			})
+
+			t.Run("wrong password fails and persists nothing", func(t *testing.T) {
+				dir := t.TempDir()
+				t.Setenv("DOCKER_CONFIG", dir)
+
+				if _, err := Login(context.Background(), host, goodUser, "wrong-password", insecureOptions()); err == nil {
+					t.Fatal("expected login with wrong password to fail, got nil error")
+				}
+
+				// A failed login must not write a (broken) config.json.
+				if _, err := os.Stat(filepath.Join(dir, "config.json")); !os.IsNotExist(err) {
+					t.Errorf("wrong-password login wrote a config.json; expected none (stat err=%v)", err)
+				}
+			})
+		})
+	}
+}
+
+// insecureOptions parses the httptest host as plain HTTP (it serves no TLS),
+// matching how `--insecure` / a localhost target is handled in real use.
+func insecureOptions() *Options {
+	o := New()
+	o.Name = append(o.Name, name.Insecure)
+	return o
+}

--- a/internal/cr/internal/registry/options.go
+++ b/internal/cr/internal/registry/options.go
@@ -39,6 +39,12 @@ type Options struct {
 	Platform *v1.Platform
 	Keychain authn.Keychain
 	Context  context.Context
+
+	// Transport mirrors the http.RoundTripper installed via WithTransport.
+	// remote.* receives it through o.Remote; we also keep a direct handle so
+	// auth-only flows (e.g. Login) that talk to the registry transport
+	// package can honour --insecure without re-deriving it from o.Remote.
+	Transport http.RoundTripper
 }
 
 // New returns Options seeded with the default Docker keychain and a
@@ -95,6 +101,29 @@ func (o *Options) WithNondistributable() *Options {
 // WithTransport installs a custom HTTP transport (typically a clone of
 // remote.DefaultTransport with TLS skip-verify toggled).
 func (o *Options) WithTransport(t http.RoundTripper) *Options {
+	o.Transport = t
 	o.Remote = append(o.Remote, remote.WithTransport(t))
 	return o
+}
+
+// staticKeychain authenticates every registry with a single set of
+// credentials. Used when the user passes --username/--password so all cr
+// commands can talk to the registry without a prior `cr login`.
+type staticKeychain struct {
+	auth authn.Authenticator
+}
+
+func (k staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return k.auth, nil
+}
+
+// NewStaticKeychain returns a keychain that always resolves to the given
+// username/password, regardless of the target registry.
+func NewStaticKeychain(username, password string) authn.Keychain {
+	return staticKeychain{
+		auth: authn.FromConfig(authn.AuthConfig{
+			Username: username,
+			Password: password,
+		}),
+	}
 }

--- a/internal/cr/internal/registry/options.go
+++ b/internal/cr/internal/registry/options.go
@@ -103,6 +103,7 @@ func (o *Options) WithNondistributable() *Options {
 func (o *Options) WithTransport(t http.RoundTripper) *Options {
 	o.Transport = t
 	o.Remote = append(o.Remote, remote.WithTransport(t))
+
 	return o
 }
 


### PR DESCRIPTION
## What

Adds `d8 cr login` — a new subcommand that authenticates against a container
registry and persists the credentials to the Docker config
(`~/.docker/config.json`, honouring `$DOCKER_CONFIG` and any configured
credential helper/store), exactly like `docker login`.

Also adds persistent `-u`/`--username` and `-p`/`--password` flags to the
`d8 cr` root so one-off credentials can be passed to any command without a
prior login.

## Why

- `packagecmd` already calls `d8 delivery-kit cr login <registry> --username
  … --password …`; this PR provides the backing command.
- CI pipelines need a way to authenticate without storing secrets in
  `~/.docker/config.json` on the host (`--username`/`--password`).
- The existing long-help text pointed users at `d8 login` (Kubernetes OIDC),
  which is unrelated to registry auth.

## Changes

| File | Change |
|---|---|
| `internal/cr/cmd/basic/login.go` | New `d8 cr login` cobra command. Verifies credentials via the registry auth handshake, then writes them through `docker/cli`'s credential store. Interactive prompts when flags are omitted; password is read without echo on a TTY. |
| `internal/cr/internal/registry/login.go` | New `registry.Login` domain function. Performs a registry ping + token exchange to validate credentials before persisting. Normalises Docker Hub to its canonical `https://index.docker.io/v1/` key. |
| `internal/cr/internal/registry/options.go` | Adds `Transport` field to `Options` (so `--insecure` is honoured during login), and `NewStaticKeychain` for inline credentials. |
| `internal/cr/cmd/rootflags.go` | Adds persistent `-u`/`--username` and `-p`/`--password` flags; builds a static keychain when `--username` is set so credentials override the Docker config for the current invocation. |
| `internal/cr/cmd/rootflagnames/names.go` | Adds `Username` and `Password` constants. |
| `internal/cr/cmd/cr.go` | Registers `login` subcommand; fixes help text to reference `d8 cr login` and `--username`/`--password` instead of the unrelated `d8 login`. |
| `internal/cr/README.md` | Documents `login`, new global flags, and a login examples cheat-sheet. |

## Usage

```bash
# Interactive
d8 cr login registry.example.com

# Non-interactive (CI)
d8 cr login registry.example.com -u robot -p "$TOKEN"

# One-off without persisting (any command)
d8 cr pull registry.example.com/app:v1 ./app.tar -u robot -p "$TOKEN"