### PR TITLE
[deckhouse-cli] mirror: support multiple version constraints for the same module/package

### DIFF
--- a/internal/mirror/modules/constraints.go
+++ b/internal/mirror/modules/constraints.go
@@ -257,3 +257,101 @@ func (e *ExactTagConstraint) IsExact() bool {
 func (e *ExactTagConstraint) HasChannelAlias() bool {
 	return e.channel != ""
 }
+
+// MultiConstraint is the OR-combination of several constraints declared for
+// the same name. It is produced when a user repeats a name on the command
+// line, e.g. `--include-package test@=v0.0.2 --include-package test@=v0.0.3`,
+// so that all of the named versions are pulled instead of only the last one.
+//
+// A value Match-es when ANY sub-constraint matches. It is considered exact
+// only when EVERY sub-constraint is exact (so a set of pinned tags keeps the
+// "no release-channel discovery, no tag listing" fast paths), and it advertises
+// a channel alias when ANY sub-constraint does.
+type MultiConstraint struct {
+	constraints []VersionConstraint
+}
+
+// Constraints returns the sub-constraints in declaration order.
+func (m *MultiConstraint) Constraints() []VersionConstraint {
+	return m.constraints
+}
+
+func (m *MultiConstraint) Match(version interface{}) bool {
+	for _, c := range m.constraints {
+		if c.Match(version) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *MultiConstraint) IsExact() bool {
+	for _, c := range m.constraints {
+		if !c.IsExact() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m *MultiConstraint) HasChannelAlias() bool {
+	for _, c := range m.constraints {
+		if c.HasChannelAlias() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// mergeConstraints OR-combines an already-registered constraint with an
+// additional one declared for the same name, flattening nested
+// MultiConstraints so repeated declarations stay a single flat list.
+func mergeConstraints(existing, additional VersionConstraint) VersionConstraint {
+	if multi, ok := existing.(*MultiConstraint); ok {
+		multi.constraints = append(multi.constraints, additional)
+		return multi
+	}
+
+	return &MultiConstraint{constraints: []VersionConstraint{existing, additional}}
+}
+
+// ExactConstraintsOf flattens a constraint into the exact-tag constraints it
+// contains. A plain ExactTagConstraint yields itself; a MultiConstraint yields
+// every exact sub-constraint; anything else yields nothing.
+func ExactConstraintsOf(c VersionConstraint) []*ExactTagConstraint {
+	switch t := c.(type) {
+	case *ExactTagConstraint:
+		return []*ExactTagConstraint{t}
+	case *MultiConstraint:
+		var out []*ExactTagConstraint
+		for _, sub := range t.constraints {
+			out = append(out, ExactConstraintsOf(sub)...)
+		}
+
+		return out
+	default:
+		return nil
+	}
+}
+
+// SemverConstraintsOf flattens a constraint into the semantic-version
+// constraints it contains, used by the proxy-registry probe which can only
+// walk semver ranges.
+func SemverConstraintsOf(c VersionConstraint) []*SemanticVersionConstraint {
+	switch t := c.(type) {
+	case *SemanticVersionConstraint:
+		return []*SemanticVersionConstraint{t}
+	case *MultiConstraint:
+		var out []*SemanticVersionConstraint
+		for _, sub := range t.constraints {
+			out = append(out, SemverConstraintsOf(sub)...)
+		}
+
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -58,30 +58,34 @@ func NewFilter(filterExpressions []string, filterType FilterType) (*Filter, erro
 	}
 
 	for _, filterExpr := range filterExpressions {
-		moduleName, versionStr, hasVersion := strings.Cut(strings.TrimSpace(filterExpr), "@")
+		name, versionStr, hasVersion := strings.Cut(strings.TrimSpace(filterExpr), "@")
 
-		moduleName = strings.TrimSpace(moduleName)
-		if moduleName == "" {
-			return nil, fmt.Errorf("Malformed filter expression %q: empty module name", filterExpr)
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("Malformed filter expression %q: empty name", filterExpr)
 		}
 
-		if _, moduleRedeclared := filter.modules[moduleName]; moduleRedeclared {
-			return nil, fmt.Errorf("Malformed filter expression: module %s is declared multiple times", moduleName)
-		}
-
+		var constraint VersionConstraint
 		if !hasVersion {
-			constraint, _ := NewSemanticVersionConstraint(">=0.0.0")
-			filter.modules[moduleName] = constraint
+			constraint, _ = NewSemanticVersionConstraint(">=0.0.0")
+		} else {
+			var err error
+			constraint, err = parseVersionConstraint(versionStr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Repeating a name is allowed and OR-combines the constraints, so a
+		// user can pull several pinned versions at once, e.g.
+		// `--include-package test@=v0.0.2 --include-package test@=v0.0.3`.
+		if existing, redeclared := filter.modules[name]; redeclared {
+			filter.modules[name] = mergeConstraints(existing, constraint)
 
 			continue
 		}
 
-		constraint, err := parseVersionConstraint(versionStr)
-		if err != nil {
-			return nil, err
-		}
-
-		filter.modules[moduleName] = constraint
+		filter.modules[name] = constraint
 	}
 
 	return filter, nil
@@ -237,6 +241,21 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 		return nil
 	}
 
+	return deduplicateTags(versionsForConstraint(constraint, mod))
+}
+
+// versionsForConstraint resolves a single constraint (or, recursively, every
+// sub-constraint of a MultiConstraint) into concrete tags to pull.
+func versionsForConstraint(constraint VersionConstraint, mod *Module) []string {
+	if multi, ok := constraint.(*MultiConstraint); ok {
+		var tags []string
+		for _, sub := range multi.constraints {
+			tags = append(tags, versionsForConstraint(sub, mod)...)
+		}
+
+		return tags
+	}
+
 	if constraint.IsExact() {
 		exact, isExactTag := constraint.(*ExactTagConstraint)
 		if !isExactTag {
@@ -268,6 +287,28 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 	}
 
 	return tags
+}
+
+// deduplicateTags removes duplicate tags while preserving first-seen order,
+// so overlapping sub-constraints of a MultiConstraint don't yield repeats.
+func deduplicateTags(tags []string) []string {
+	if len(tags) == 0 {
+		return tags
+	}
+
+	seen := make(map[string]struct{}, len(tags))
+	out := make([]string, 0, len(tags))
+
+	for _, tag := range tags {
+		if _, dup := seen[tag]; dup {
+			continue
+		}
+
+		seen[tag] = struct{}{}
+		out = append(out, tag)
+	}
+
+	return out
 }
 
 // restoreInclusiveAnchors re-introduces any anchor versions (named via >=/<=

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -70,6 +70,7 @@ func NewFilter(filterExpressions []string, filterType FilterType) (*Filter, erro
 			constraint, _ = NewSemanticVersionConstraint(">=0.0.0")
 		} else {
 			var err error
+
 			constraint, err = parseVersionConstraint(versionStr)
 			if err != nil {
 				return nil, err
@@ -248,7 +249,7 @@ func (f *Filter) VersionsToMirror(mod *Module) []string {
 // sub-constraint of a MultiConstraint) into concrete tags to pull.
 func versionsForConstraint(constraint VersionConstraint, mod *Module) []string {
 	if multi, ok := constraint.(*MultiConstraint); ok {
-		var tags []string
+		var tags = make([]string, 0, len(multi.constraints))
 		for _, sub := range multi.constraints {
 			tags = append(tags, versionsForConstraint(sub, mod)...)
 		}

--- a/internal/mirror/modules/filter_test.go
+++ b/internal/mirror/modules/filter_test.go
@@ -61,9 +61,9 @@ func TestNewFilter(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "duplicate module",
+			name:        "duplicate module is merged, not rejected",
 			expressions: []string{"module@1.2.3", "module@2.3.4"},
-			wantErr:     true,
+			wantErr:     false,
 		},
 	}
 
@@ -554,6 +554,33 @@ func TestFilter_VersionsToMirror(t *testing.T) {
 					"v1.0.0", "v1.1.0", "v1.2.0", "v1.3.0", "v1.3.3", "v1.4.1"},
 			},
 			want: []string{"v1.3.0"},
+		},
+		{
+			// Several exact tags pinned for the same name (the user repeated
+			// --include-package test@=vX). They merge into a MultiConstraint
+			// of exacts, which stays exact so no release channels are added,
+			// and every pinned tag is pulled.
+			name: "multiple exact tags pinned for the same name pull all of them",
+			filter: Filter{
+				logger: logger,
+				modules: map[string]VersionConstraint{
+					"module1": mergeConstraints(
+						mergeConstraints(
+							NewExactTagConstraint("v0.0.2"),
+							NewExactTagConstraint("v0.0.3"),
+						),
+						NewExactTagConstraint("v0.0.8"),
+					),
+				},
+			},
+			mod: &Module{
+				Name: "module1",
+				Releases: []string{
+					internal.AlphaChannel,
+					internal.StableChannel,
+					"v0.0.1", "v0.0.2", "v0.0.3", "v0.0.4", "v0.0.8"},
+			},
+			want: []string{"v0.0.2", "v0.0.3", "v0.0.8"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/mirror/modules/modules.go
+++ b/internal/mirror/modules/modules.go
@@ -509,8 +509,8 @@ func (svc *Service) listTagsIfConstrained(ctx context.Context, moduleName string
 // this function, and a future constraint type would need its own
 // proxy-aware code path.
 func (svc *Service) probeModuleTags(ctx context.Context, moduleName string, constraint VersionConstraint) ([]string, error) {
-	semverConstraint, ok := constraint.(*SemanticVersionConstraint)
-	if !ok {
+	semverConstraints := SemverConstraintsOf(constraint)
+	if len(semverConstraints) == 0 {
 		// Be loud — silently falling back to ListTags here would defeat
 		// the whole purpose of --proxy-registry on a registry that
 		// refuses catalog access.
@@ -532,14 +532,17 @@ func (svc *Service) probeModuleTags(ctx context.Context, moduleName string, cons
 		return false, fmt.Errorf("check module %s tag %q: %w", moduleName, tag, err)
 	}
 
-	versions, err := ProbeAvailableVersions(ctx, semverConstraint, check)
-	if err != nil {
-		return nil, fmt.Errorf("probe tags for module %s: %w", moduleName, err)
-	}
+	tags := make([]string, 0)
 
-	tags := make([]string, 0, len(versions))
-	for _, v := range versions {
-		tags = append(tags, "v"+v.String())
+	for _, semverConstraint := range semverConstraints {
+		versions, err := ProbeAvailableVersions(ctx, semverConstraint, check)
+		if err != nil {
+			return nil, fmt.Errorf("probe tags for module %s: %w", moduleName, err)
+		}
+
+		for _, v := range versions {
+			tags = append(tags, "v"+v.String())
+		}
 	}
 
 	return tags, nil
@@ -1028,32 +1031,40 @@ func (svc *Service) applyChannelAliases(moduleName string) error {
 		return nil
 	}
 
-	exact, ok := constraint.(*ExactTagConstraint)
-	if !ok {
-		return nil
-	}
-
 	moduleLayout := svc.layout.Module(moduleName)
 	if moduleLayout == nil || moduleLayout.ModulesReleaseChannels == nil {
 		return nil
 	}
 
-	desc, err := layouts.FindImageDescriptorByTag(moduleLayout.ModulesReleaseChannels.Path(), exact.Tag())
-	if err != nil {
-		if errors.Is(err, layouts.ErrImageNotFound) {
-			return nil
-		}
+	exacts := ExactConstraintsOf(constraint)
 
-		return err
-	}
+	// A single pinned tag without an explicit +channel suffix is published to
+	// every release channel (the historical --deckhouse-tag-like behaviour).
+	// When several tags are pinned at once, propagating each to all channels
+	// would just clobber one another, so only tags that name their own channel
+	// (=vX.Y.Z+stable) are aliased; the rest are simply pulled as-is.
+	propagateToAllChannels := len(exacts) == 1 && !exacts[0].HasChannelAlias()
 
-	if exact.HasChannelAlias() {
-		if err := layouts.TagImage(moduleLayout.ModulesReleaseChannels.Path(), desc.Digest, exact.Channel()); err != nil {
+	for _, exact := range exacts {
+		desc, err := layouts.FindImageDescriptorByTag(moduleLayout.ModulesReleaseChannels.Path(), exact.Tag())
+		if err != nil {
+			if errors.Is(err, layouts.ErrImageNotFound) {
+				continue
+			}
+
 			return err
 		}
-	} else {
-		// Tag all channels with this version
-		for _, channel := range append(internal.GetAllDefaultReleaseChannels(), internal.LTSChannel) {
+
+		var channels []string
+
+		switch {
+		case exact.HasChannelAlias():
+			channels = []string{exact.Channel()}
+		case propagateToAllChannels:
+			channels = append(internal.GetAllDefaultReleaseChannels(), internal.LTSChannel)
+		}
+
+		for _, channel := range channels {
 			if err := layouts.TagImage(moduleLayout.ModulesReleaseChannels.Path(), desc.Digest, channel); err != nil {
 				return err
 			}

--- a/internal/mirror/packages/packages.go
+++ b/internal/mirror/packages/packages.go
@@ -269,6 +269,15 @@ func (svc *Service) pullAllVersionImages(ctx context.Context, packageName string
 		imageSet[svc.versionRef(packageName, version)] = nil
 	}
 
+	// Every tag served under packages/<name>/version, so that all version
+	// images are cloned regardless of the --include-package filter and even
+	// when the package publishes no release channels (e.g. dev packages that
+	// only have a packages/<name>/version:vX.Y.Z tag). Channel-only discovery
+	// above would otherwise miss those and skip the package entirely.
+	for _, tag := range svc.listAllVersionTags(ctx, packageName) {
+		imageSet[svc.versionRef(packageName, tag)] = nil
+	}
+
 	if len(imageSet) == 0 {
 		return nil
 	}
@@ -282,6 +291,25 @@ func (svc *Service) pullAllVersionImages(ctx context.Context, packageName string
 	}
 
 	return svc.pullerService.PullImages(ctx, config)
+}
+
+// listAllVersionTags enumerates every tag published under
+// packages/<name>/version (both release channels and vX.Y.Z version tags).
+//
+// The package-versions archive must clone all version images independently of
+// the --include-package filter, so this intentionally does not consult the
+// filter constraint. A registry that refuses to enumerate the version repo
+// (missing repo or a proxy registry without catalog support) is not fatal: the
+// channel-based discovery in pullAllVersionImages still applies and we just
+// skip the extra tags here.
+func (svc *Service) listAllVersionTags(ctx context.Context, packageName string) []string {
+	tags, err := svc.packagesService.Package(packageName).VersionChannels().ListTags(ctx)
+	if err != nil {
+		svc.logger.Debug(fmt.Sprintf("Failed to list version tags for package %s: %v", packageName, err))
+		return nil
+	}
+
+	return tags
 }
 
 // validatePackagesAccess validates access to the packages registry.
@@ -580,8 +608,8 @@ func (svc *Service) listTagsIfConstrained(ctx context.Context, packageName strin
 // probePackageTags walks tags for a single package via HEAD requests instead
 // of asking the registry to enumerate them.
 func (svc *Service) probePackageTags(ctx context.Context, packageName string, constraint modules.VersionConstraint) ([]string, error) {
-	semverConstraint, ok := constraint.(*modules.SemanticVersionConstraint)
-	if !ok {
+	semverConstraints := modules.SemverConstraintsOf(constraint)
+	if len(semverConstraints) == 0 {
 		return nil, fmt.Errorf("package %s: --proxy-registry only supports semver-style constraints, got %T", packageName, constraint)
 	}
 
@@ -600,14 +628,17 @@ func (svc *Service) probePackageTags(ctx context.Context, packageName string, co
 		return false, fmt.Errorf("check package %s tag %q: %w", packageName, tag, err)
 	}
 
-	versions, err := modules.ProbeAvailableVersions(ctx, semverConstraint, check)
-	if err != nil {
-		return nil, fmt.Errorf("probe tags for package %s: %w", packageName, err)
-	}
+	tags := make([]string, 0)
 
-	tags := make([]string, 0, len(versions))
-	for _, v := range versions {
-		tags = append(tags, "v"+v.String())
+	for _, semverConstraint := range semverConstraints {
+		versions, err := modules.ProbeAvailableVersions(ctx, semverConstraint, check)
+		if err != nil {
+			return nil, fmt.Errorf("probe tags for package %s: %w", packageName, err)
+		}
+
+		for _, v := range versions {
+			tags = append(tags, "v"+v.String())
+		}
 	}
 
 	return tags, nil
@@ -1070,31 +1101,39 @@ func (svc *Service) applyChannelAliases(packageName string) error {
 		return nil
 	}
 
-	exact, ok := constraint.(*modules.ExactTagConstraint)
-	if !ok {
-		return nil
-	}
-
 	packageLayout := svc.layout.Package(packageName)
 	if packageLayout == nil || packageLayout.PackageVersionChannels == nil {
 		return nil
 	}
 
-	desc, err := layouts.FindImageDescriptorByTag(packageLayout.PackageVersionChannels.Path(), exact.Tag())
-	if err != nil {
-		if errors.Is(err, layouts.ErrImageNotFound) {
-			return nil
-		}
+	exacts := modules.ExactConstraintsOf(constraint)
 
-		return err
-	}
+	// A single pinned tag without an explicit +channel suffix is published to
+	// every release channel. When several tags are pinned at once, propagating
+	// each to all channels would clobber one another, so only tags that name
+	// their own channel (=vX.Y.Z+stable) are aliased; the rest are pulled as-is.
+	propagateToAllChannels := len(exacts) == 1 && !exacts[0].HasChannelAlias()
 
-	if exact.HasChannelAlias() {
-		if err := layouts.TagImage(packageLayout.PackageVersionChannels.Path(), desc.Digest, exact.Channel()); err != nil {
+	for _, exact := range exacts {
+		desc, err := layouts.FindImageDescriptorByTag(packageLayout.PackageVersionChannels.Path(), exact.Tag())
+		if err != nil {
+			if errors.Is(err, layouts.ErrImageNotFound) {
+				continue
+			}
+
 			return err
 		}
-	} else {
-		for _, channel := range append(internal.GetAllDefaultReleaseChannels(), internal.LTSChannel) {
+
+		var channels []string
+
+		switch {
+		case exact.HasChannelAlias():
+			channels = []string{exact.Channel()}
+		case propagateToAllChannels:
+			channels = append(internal.GetAllDefaultReleaseChannels(), internal.LTSChannel)
+		}
+
+		for _, channel := range channels {
 			if err := layouts.TagImage(packageLayout.PackageVersionChannels.Path(), desc.Digest, channel); err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently repeating a module or package name in a filter expression (e.g. `--include-module foo@=v1.0.0 --include-module foo@=v1.1.0`) errors out or silently drops all but the last declaration. This change makes it possible to pin multiple versions of the same name in a single `mirror pull` invocation.

**What changed**

- Added `MultiConstraint` — an OR-combination of constraints for the same name. It is produced automatically when a name is repeated on the command line and is transparent to all existing code paths.
- Replaced the "module redeclared" error in `NewFilter` with `mergeConstraints`, which folds repeated declarations into a `MultiConstraint`.
- Added `ExactConstraintsOf` and `SemverConstraintsOf` helpers that flatten a `MultiConstraint` into typed slices, used by `applyChannelAliases` and the proxy-registry probe path respectively.
- `VersionsToMirror` now recursively resolves `MultiConstraint` sub-constraints and deduplicates the resulting tag list so overlapping ranges don't cause redundant pulls.
- `applyChannelAliases` (modules and packages) now iterates over all pinned tags. The historical behaviour — a single pinned tag without an explicit `+channel` suffix is propagated to every release channel — is preserved only when exactly one version is pinned; when several are pinned simultaneously each one is aliased only to its own explicitly named channel (if any) to avoid them overwriting one another.
- `probeModuleTags` / `probePackageTags` now iterate over every semver sub-constraint so proxy-registry probing works correctly with a `MultiConstraint`.
- Added `listAllVersionTags` to package mirroring so `vX.Y.Z`-only tags (e.g. dev packages that publish no release channels) are discovered and cloned even when they wouldn't be reached by channel-based discovery.

**Example**

```
d8 mirror pull \
  --include-package myapp@=v1.2.0 \
  --include-package myapp@=v1.3.0 \
  ...
```

Both `v1.2.0` and `v1.3.0` are now pulled instead of only the last declaration winning.