### PR TITLE
[deckhouse-cli] Add maintenance switcher for modules

### DIFF
--- a/internal/system/cmd/module/cmd/maintenance/maintenance.go
+++ b/internal/system/cmd/module/cmd/maintenance/maintenance.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maintenance
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cli"
+	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/moduleconfig"
+)
+
+var maintenanceLong = templates.LongDesc(`
+Enable or disable maintenance mode for a module via its ModuleConfig resource.
+
+While maintenance mode is enabled, Deckhouse stops reconciling the module's
+resources (it sets 'spec.maintenance="NoResourceReconciliation"' on the
+ModuleConfig). This lets you develop or tweak the module's resources.
+
+Disabling maintenance mode removes the 'spec.maintenance' field and lets
+Deckhouse resume normal reconciliation.
+
+The module's ModuleConfig must already exist. If it does not enable it first.
+
+© Flant JSC 2026`)
+
+var maintenanceEnableExample = templates.Examples(`
+  # Enable maintenance mode
+  d8 system module maintenance enable <module-name>
+`)
+
+var maintenanceDisableExample = templates.Examples(`
+  # Disable maintenance mode
+  d8 system module maintenance disable <module-name>
+`)
+
+func NewCommand() *cobra.Command {
+	maintenanceCmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "Enable or disable module maintenance mode.",
+		Long:  maintenanceLong,
+	}
+
+	maintenanceCmd.AddCommand(
+		newSwitchCommand(
+			"enable",
+			"Enable maintenance mode for a module using ModuleConfig resource.",
+			maintenanceEnableExample,
+			moduleconfig.NoResourceReconciliation,
+		),
+		newSwitchCommand(
+			"disable",
+			"Disable maintenance mode for a module using ModuleConfig resource.",
+			maintenanceDisableExample,
+			moduleconfig.DefaultReconciliation,
+		),
+	)
+
+	return maintenanceCmd
+}
+
+func newSwitchCommand(use, short, example string, state moduleconfig.MaintenanceState) *cobra.Command {
+	return &cobra.Command{
+		Use:           use + " <module-name>",
+		Short:         short,
+		Example:       example,
+		Args:          cobra.ExactArgs(1),
+		ValidArgs:     []string{"module_name"},
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return switchMaintenance(cmd, args[0], state)
+		},
+	}
+}
+
+func switchMaintenance(cmd *cobra.Command, moduleName string, state moduleconfig.MaintenanceState) error {
+	dynamicClient, err := cli.GetDynamicClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, err := moduleconfig.SetMaintenanceState(dynamicClient, moduleName, state)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Fprintf(os.Stderr, "%s ModuleConfig '%s' does not exist.\n", cli.MsgError, moduleName)
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Create it first by enabling the module:")
+			fmt.Fprintf(os.Stderr, "  d8 system module enable %s\n\n", moduleName)
+
+			return fmt.Errorf("module config '%s' does not exist", moduleName)
+		}
+
+		return fmt.Errorf("failed to switch maintenance mode: %w", err)
+	}
+
+	enabling := state == moduleconfig.NoResourceReconciliation
+
+	switch result.Status {
+	case moduleconfig.AlreadyInState:
+		if enabling {
+			fmt.Fprintf(os.Stderr, "%s Maintenance mode is already enabled for module '%s'.\n", cli.MsgInfo, moduleName)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s Maintenance mode is already disabled for module '%s'.\n", cli.MsgInfo, moduleName)
+		}
+	case moduleconfig.Changed:
+		if enabling {
+			fmt.Printf("%s Maintenance mode enabled for module '%s'.\n", cli.MsgInfo, moduleName)
+		} else {
+			fmt.Printf("%s Maintenance mode disabled for module '%s'.\n", cli.MsgInfo, moduleName)
+		}
+	}
+
+	return nil
+}

--- a/internal/system/cmd/module/cmd/module.go
+++ b/internal/system/cmd/module/cmd/module.go
@@ -25,6 +25,7 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/disable"
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/enable"
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/list"
+	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/maintenance"
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/snapshots"
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/cmd/values"
 )
@@ -48,6 +49,7 @@ func NewCommand() *cobra.Command {
 		// Module state (ModuleConfig)
 		enable.NewCommand(),
 		disable.NewCommand(),
+		maintenance.NewCommand(),
 
 		// Inspection
 		list.NewCommand(),

--- a/internal/system/cmd/module/moduleconfig/maintenance_state.go
+++ b/internal/system/cmd/module/moduleconfig/maintenance_state.go
@@ -1,0 +1,101 @@
+package moduleconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	constants "github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/const"
+)
+
+// MaintenanceState represents the desired maintenance state of a module.
+type MaintenanceState string
+
+const (
+	// NoResourceReconciliation switches the module into maintenance mode.
+	NoResourceReconciliation MaintenanceState = "NoResourceReconciliation"
+	// DefaultReconciliation is the normal state; the spec.maintenance field is absent.
+	DefaultReconciliation MaintenanceState = ""
+)
+
+// SetMaintenanceState sets the maintenance state of a module via its ModuleConfig resource.
+// The ModuleConfig must already exist; if it does not, the underlying Kubernetes NotFound
+// error is returned and can be detected by the caller with errors.IsNotFound.
+func SetMaintenanceState(dynamicClient dynamic.Interface, name string, state MaintenanceState) (*Result, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout)
+	defer cancel()
+
+	resourceClient := dynamicClient.Resource(
+		schema.GroupVersionResource{
+			Group:    "deckhouse.io",
+			Version:  "v1alpha1",
+			Resource: "moduleconfigs",
+		},
+	)
+
+	existing, err := resourceClient.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get module config '%s': %w", name, err)
+	}
+
+	// Check if module is already in the desired state
+	if isMaintenanceState(existing, state) {
+		return &Result{Status: AlreadyInState}, nil
+	}
+
+	patch, err := maintenancePatch(state)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = resourceClient.Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return nil, parseOperationError(name, err)
+	}
+
+	return &Result{Status: Changed}, nil
+}
+
+// maintenancePatch builds a JSON merge patch for spec.maintenance.
+// DefaultReconciliation marshals the field as null, which removes it (back to normal).
+func maintenancePatch(state MaintenanceState) ([]byte, error) {
+	// DefaultReconciliation maps to JSON null, which removes the field;
+	// any other state is written as its string value.
+	var maintenance any
+	if state != DefaultReconciliation {
+		maintenance = string(state)
+	}
+
+	patchData := map[string]any{
+		"spec": map[string]any{
+			"maintenance": maintenance,
+		},
+	}
+
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal patch data: %w", err)
+	}
+
+	return patchBytes, nil
+}
+
+// isMaintenanceState reports whether the module is already in the desired
+// maintenance state. An absent spec.maintenance field means module with DefaultReconciliation.
+func isMaintenanceState(obj *unstructured.Unstructured, desiredState MaintenanceState) bool {
+	maintenanceMode, found, err := unstructured.NestedString(obj.Object, "spec", "maintenance")
+	if err != nil {
+		return false
+	}
+
+	if !found {
+		return desiredState == DefaultReconciliation
+	}
+
+	return MaintenanceState(maintenanceMode) == desiredState
+}


### PR DESCRIPTION
# Summary

Added switcher for module's maintenance mode, commands added:

```bash
d8 s module maintenance # With wide description about purpose of that
d8 s module maintenance enable <module-name>
d8 s module maintenance disable <module-name>
```

```bash
➜ /bin/d8 p module maintenance disable csi-nfs
[INFO] Maintenance mode is already disabled for module 'csi-nfs'.
➜ /bin/d8 p module maintenance enable ingress-nginx
[INFO] Maintenance mode enabled for module 'ingress-nginx'.
➜ /bin/d8 p module maintenance enable not-enabled 
[ERROR] ModuleConfig 'not-enabled' does not exist.

Create it first by enabling the module:
  d8 system module enable not-enabled

Error executing command: module config 'not-enabled' does not exist
```