### PR TITLE
[deckhouse-cli] Add pull summary after d8 mirror pull

### DIFF
--- a/internal/mirror/cmd/pull/bundle_stats_test.go
+++ b/internal/mirror/cmd/pull/bundle_stats_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pull
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/operations/params"
+)
+
+func TestCollectBundleStats(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string, size int) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), make([]byte, size), 0o644))
+	}
+
+	// Single-file artifacts.
+	write("platform.tar", 100)
+	write("installer.tar", 50)
+	// One chunked artifact spread over two chunks.
+	write("module-a.tar.0000.chunk", 30)
+	write("module-a.tar.0001.chunk", 20)
+	// Files that must be ignored.
+	write("platform.tar.gostsum", 7)
+	write("notes.txt", 5)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+
+	p := &Puller{
+		params: &params.PullParams{
+			BaseParams: params.BaseParams{BundleDir: dir},
+		},
+	}
+
+	stats, err := p.collectBundleStats()
+	require.NoError(t, err)
+
+	// Three logical artifacts: platform.tar, installer.tar, module-a.tar.
+	require.Len(t, stats.Files, 3)
+
+	byName := map[string]int64{}
+	chunksByName := map[string]int{}
+	for _, f := range stats.Files {
+		byName[f.Name] = f.Bytes
+		chunksByName[f.Name] = f.Chunks
+	}
+
+	require.Equal(t, int64(100), byName["platform.tar"])
+	require.Equal(t, int64(50), byName["installer.tar"])
+	require.Equal(t, int64(50), byName["module-a.tar"]) // 30 + 20
+	require.Equal(t, 0, chunksByName["platform.tar"])
+	require.Equal(t, 2, chunksByName["module-a.tar"])
+
+	// Total excludes .gostsum, .txt and the directory.
+	require.Equal(t, int64(200), stats.TotalBytes)
+
+	// Sorted by logical name.
+	require.Equal(t, "installer.tar", stats.Files[0].Name)
+	require.Equal(t, "module-a.tar", stats.Files[1].Name)
+	require.Equal(t, "platform.tar", stats.Files[2].Name)
+}
+
+func TestCollectBundleStats_MissingDir(t *testing.T) {
+	p := &Puller{
+		params: &params.PullParams{
+			BaseParams: params.BaseParams{BundleDir: filepath.Join(t.TempDir(), "does-not-exist")},
+		},
+	}
+
+	_, err := p.collectBundleStats()
+	require.Error(t, err)
+}

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -90,10 +90,10 @@ var (
 
 	DryRun bool
 
-	// VerboseSummary lists every module in the end-of-pull summary with its
-	// resolved versions (plus a VEX count when the module has VEX attestations).
-	// Without it, only the aggregate "N modules" line is printed. It changes the
-	// printout only, not which images are pulled.
+	// VerboseSummary lists every module and package in the end-of-pull summary
+	// with its resolved versions (plus a VEX count when it has VEX attestations).
+	// Without it, only the aggregate counts are printed. It changes the printout
+	// only, not which images are pulled.
 	VerboseSummary bool
 
 	MirrorTimeout time.Duration = -1
@@ -319,7 +319,7 @@ Cannot be combined with --deckhouse-tag or --since-version (use --include-platfo
 		&VerboseSummary,
 		"verbose-summary",
 		false,
-		"List every module in the end-of-pull summary with its resolved versions (and VEX count, when present), instead of just the totals. Output only - it does not change what is pulled.",
+		"List every module and package in the end-of-pull summary with its resolved versions (and VEX count, when present), instead of just the totals. Output only - it does not change what is pulled.",
 	)
 	flagSet.BoolVar(
 		&TLSSkipVerify,

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -90,6 +90,12 @@ var (
 
 	DryRun bool
 
+	// VerboseSummary lists every module in the end-of-pull summary with its
+	// resolved versions (plus a VEX count when the module has VEX attestations).
+	// Without it, only the aggregate "N modules" line is printed. It changes the
+	// printout only, not which images are pulled.
+	VerboseSummary bool
+
 	MirrorTimeout time.Duration = -1
 )
 
@@ -308,6 +314,12 @@ Cannot be combined with --deckhouse-tag or --since-version (use --include-platfo
 		"dry-run",
 		false,
 		"Print what would be pulled without downloading any images. Useful for fast validation of flags and filters.",
+	)
+	flagSet.BoolVar(
+		&VerboseSummary,
+		"verbose-summary",
+		false,
+		"List every module in the end-of-pull summary with its resolved versions (and VEX count, when present), instead of just the totals. Output only - it does not change what is pulled.",
 	)
 	flagSet.BoolVar(
 		&TLSSkipVerify,

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -26,6 +26,8 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -238,10 +240,98 @@ func NewPuller(cmd *cobra.Command) *Puller {
 }
 
 func (p *Puller) Execute(ctx context.Context) error {
+	configureSummaryColor()
+
 	if err := p.cleanupWorkingDirectory(); err != nil {
 		return err
 	}
 
+	svc, err := p.buildPullService()
+	if err != nil {
+		return err
+	}
+
+	start := time.Now()
+	// Pull always returns a non-nil summary, even on error.
+	summary, err := svc.Pull(ctx)
+	summary.Elapsed = time.Since(start)
+
+	// Edition is parsed from the source registry path (no registry call); empty
+	// for a custom registry, where the renderer omits the Edition line.
+	_, edition := registryservice.GetEditionFromRegistryPath(p.params.DeckhouseRegistryRepo)
+	summary.Edition = string(edition)
+
+	// pullErr is nil for success and for a graceful Ctrl+C (which still renders a
+	// partial summary); non-nil for a hard failure (which also renders, then
+	// propagates so the exit code is non-zero).
+	pullErr := classifyPullOutcome(summary, err)
+
+	// Dry-run never writes a bundle, so there is nothing to size or clean up.
+	if pullflags.DryRun {
+		p.renderSummary(summary)
+		return pullErr
+	}
+
+	// Size whatever was packed (possibly partial). An unreadable dir just omits
+	// the bundle block; it does not change the outcome.
+	if bundleStats, bundleErr := p.collectBundleStats(); bundleErr != nil {
+		p.logger.Warnf("Could not collect bundle statistics for summary: %v", bundleErr)
+	} else {
+		summary.Bundle = bundleStats
+	}
+
+	// Cancelled or failed: render what completed, then stop.
+	if summary.Cancelled || summary.Failed {
+		p.renderSummary(summary)
+
+		if summary.Cancelled {
+			p.logger.WarnLn("Operation cancelled by user")
+		}
+
+		return pullErr
+	}
+
+	// GOST digest failure: the bundle was built but has no valid checksums, so
+	// it counts as failed. Render it (FAILED state), then propagate.
+	if err := p.computeGOSTDigests(); err != nil {
+		summary.Failed = true
+		p.renderSummary(summary)
+
+		return err
+	}
+
+	p.renderSummary(summary)
+
+	return p.finalCleanup()
+}
+
+// renderSummary prints the end-of-pull summary block. PullService.Pull always
+// returns a non-nil summary, so no nil-guard is needed here.
+func (p *Puller) renderSummary(summary *mirror.PullSummary) {
+	p.logger.InfoLn(renderPullSummary(summary, pullflags.VerboseSummary))
+}
+
+// classifyPullOutcome records the pull's terminal state on the summary and
+// returns the error Execute should propagate:
+//   - nil error        -> success, returns nil;
+//   - context.Canceled -> Cancelled, returns nil (a graceful interrupt is a clean exit);
+//   - any other error  -> Failed, returns the wrapped error.
+func classifyPullOutcome(summary *mirror.PullSummary, err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled):
+		summary.Cancelled = true
+		return nil
+	default:
+		summary.Failed = true
+		return fmt.Errorf("pull from registry: %w", err)
+	}
+}
+
+// buildPullService assembles the registry client and the PullService from the
+// CLI flags and the Puller parameters.
+func (p *Puller) buildPullService() (*mirror.PullService, error) {
 	logger := dkplog.NewNop()
 
 	if log.DebugLogLevel() >= 3 {
@@ -284,13 +374,13 @@ func (p *Puller) Execute(ctx context.Context) error {
 	// Create module filter from CLI flags
 	filter, err := p.createModuleFilter()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Create package filter from CLI flags
 	packageFilter, err := p.createPackageFilter()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	svc := mirror.NewPullService(
@@ -320,27 +410,7 @@ func (p *Puller) Execute(ctx context.Context) error {
 		p.logger,
 	)
 
-	err = svc.Pull(ctx)
-	if err != nil {
-		// Handle context cancellation gracefully
-		if errors.Is(err, context.Canceled) {
-			p.logger.WarnLn("Operation cancelled by user")
-			return nil
-		}
-
-		return fmt.Errorf("pull from registry: %w", err)
-	}
-
-	if pullflags.DryRun {
-		p.logger.InfoLn("[dry-run] Done. No images were downloaded.")
-		return nil
-	}
-
-	if err := p.computeGOSTDigests(); err != nil {
-		return err
-	}
-
-	return p.finalCleanup()
+	return svc, nil
 }
 
 // cleanupWorkingDirectory handles cleanup of the working directory if needed
@@ -441,6 +511,79 @@ func (p *Puller) createPackageFilter() (*modules.Filter, error) {
 	}
 
 	return filter, nil
+}
+
+// collectBundleStats walks the bundle directory and accounts for the produced
+// artifacts. Chunked artifacts (named "<base>.NNNN.chunk", see
+// internal/mirror/chunked) are collapsed into a single logical entry keyed by
+// "<base>" so that, for example, "module-foo.tar.0000.chunk" and
+// "module-foo.tar.0001.chunk" report as one "module-foo.tar" with two chunks.
+// Single-file artifacts ("<name>.tar") report as one entry with zero chunks.
+func (p *Puller) collectBundleStats() (mirror.BundleStats, error) {
+	entries, err := os.ReadDir(p.params.BundleDir)
+	if err != nil {
+		return mirror.BundleStats{}, fmt.Errorf("read bundle directory: %w", err)
+	}
+
+	grouped := make(map[string]*mirror.BundleFile)
+
+	var totalBytes int64
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		ext := filepath.Ext(name)
+		if ext != ".tar" && ext != ".chunk" {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		logicalName := name
+		isChunk := false
+
+		if ext == ".chunk" {
+			// "module-foo.tar.0003.chunk" -> "module-foo.tar"
+			base := strings.TrimSuffix(name, ext) // "module-foo.tar.0003"
+			if idx := strings.LastIndex(base, "."); idx != -1 {
+				base = base[:idx] // "module-foo.tar"
+			}
+
+			logicalName = base
+			isChunk = true
+		}
+
+		file, ok := grouped[logicalName]
+		if !ok {
+			file = &mirror.BundleFile{Name: logicalName}
+			grouped[logicalName] = file
+		}
+
+		file.Bytes += info.Size()
+		if isChunk {
+			file.Chunks++
+		}
+
+		totalBytes += info.Size()
+	}
+
+	files := make([]mirror.BundleFile, 0, len(grouped))
+	for _, file := range grouped {
+		files = append(files, *file)
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name < files[j].Name
+	})
+
+	return mirror.BundleStats{Files: files, TotalBytes: totalBytes}, nil
 }
 
 // computeGOSTDigests computes GOST digests for the bundle if enabled

--- a/internal/mirror/cmd/pull/pull_test.go
+++ b/internal/mirror/cmd/pull/pull_test.go
@@ -19,6 +19,7 @@ package pull
 import (
 	"context"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -36,9 +37,9 @@ import (
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror"
 	pullflags "github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/pull/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/validation"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/operations/params"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
-	"github.com/deckhouse/deckhouse-cli/internal/mirror/validation"
 )
 
 // closedLocalAddr returns a host:port pair on 127.0.0.1 that is guaranteed not
@@ -1341,6 +1342,36 @@ func TestPullerExecuteWithCleanupFailure(t *testing.T) {
 	// This test is platform-dependent and may not work reliably
 	// The main cleanup functionality is tested in TestPullerFinalCleanup
 	t.Skip("Skipping platform-dependent cleanup failure test")
+}
+
+// TestClassifyPullOutcome covers the terminal-state decision Execute makes from
+// PullService.Pull's error: it sets Cancelled/Failed on the summary and decides
+// which error (if any) propagates to the process exit code.
+func TestClassifyPullOutcome(t *testing.T) {
+	t.Run("success sets no terminal flag and returns nil", func(t *testing.T) {
+		s := &mirror.PullSummary{}
+		require.NoError(t, classifyPullOutcome(s, nil))
+		assert.False(t, s.Cancelled)
+		assert.False(t, s.Failed)
+	})
+
+	t.Run("context.Canceled marks Cancelled and is a clean exit", func(t *testing.T) {
+		s := &mirror.PullSummary{}
+		// Wrapped, as the phases return it (e.g. "pull modules: context canceled").
+		require.NoError(t, classifyPullOutcome(s, fmt.Errorf("pull modules: %w", context.Canceled)))
+		assert.True(t, s.Cancelled)
+		assert.False(t, s.Failed)
+	})
+
+	t.Run("hard error marks Failed and propagates wrapped", func(t *testing.T) {
+		s := &mirror.PullSummary{}
+		err := classifyPullOutcome(s, errors.New("registry unreachable"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pull from registry")
+		assert.Contains(t, err.Error(), "registry unreachable")
+		assert.True(t, s.Failed)
+		assert.False(t, s.Cancelled)
+	})
 }
 
 // Benchmark tests

--- a/internal/mirror/cmd/pull/summary.go
+++ b/internal/mirror/cmd/pull/summary.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pull
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/fatih/color"
+
+	"github.com/deckhouse/deckhouse-cli/internal/mirror"
+)
+
+const (
+	// frameWidth is the inner width of the summary box, in runes.
+	frameWidth = 56
+	// labelWidth aligns the category labels in the summary body.
+	labelWidth = 11
+	// nameWidth left-aligns module names and bundle artifact names.
+	nameWidth = 30
+	// sizeWidth right-aligns bundle artifact sizes.
+	sizeWidth = 10
+)
+
+// Semantic accent colours for the summary. fatih/color disables them when
+// stdout is not a TTY or NO_COLOR is set (the summary is logged to stdout), so
+// escape codes never reach pipes or files.
+//
+// Apply every colour AFTER width padding (padLabel, %-30s, %10s): the codes are
+// zero-width on screen but count toward fmt's field widths and break columns.
+var (
+	cFrame   = color.New(color.FgHiBlack).SprintFunc()            // box borders - recede
+	cTitle   = color.New(color.FgCyan, color.Bold).SprintFunc()   // block title
+	cLabel   = color.New(color.FgCyan).SprintFunc()               // category labels (scan anchors)
+	cCount   = color.New(color.Bold).SprintFunc()                 // primary numbers
+	cDim     = color.New(color.FgHiBlack).SprintFunc()            // units and secondary text
+	cGood    = color.New(color.FgGreen).SprintFunc()              // complete (e.g. 4/4 databases)
+	cWarn    = color.New(color.FgYellow).SprintFunc()             // attention (partial, not-available, dry-run)
+	cBad     = color.New(color.FgRed).SprintFunc()                // failure (cancelled)
+	cVEX     = color.New(color.FgMagenta).SprintFunc()            // VEX attestations (a distinct class)
+	cVersion = color.New(color.FgGreen).SprintFunc()              // resolved versions (the headline)
+	cSize    = color.New(color.FgCyan).SprintFunc()               // bundle artifact sizes
+	cTotalSz = color.New(color.FgYellow, color.Bold).SprintFunc() // the bundle TOTAL - the action number
+)
+
+// bar returns the coloured left border of a body line.
+func bar() string { return cFrame("║") }
+
+// configureSummaryColor re-enables colour when FORCE_COLOR / CLICOLOR_FORCE is
+// set (e.g. piping to `less -R` or capturing a coloured log). NO_COLOR wins;
+// otherwise fatih/color's stdout-TTY check decides.
+func configureSummaryColor() {
+	if os.Getenv("NO_COLOR") == "" &&
+		(os.Getenv("FORCE_COLOR") != "" || os.Getenv("CLICOLOR_FORCE") != "") {
+		color.NoColor = false
+	}
+}
+
+// renderPullSummary formats a PullSummary as a single multi-line, framed block.
+// It is emitted through a single logger call so the structured-logging handler
+// stamps a timestamp only once, at the top of the block.
+//
+// When verbose is true, the modules section lists every module with its
+// resolved versions (and VEX count, when present); otherwise it prints only the
+// aggregate "N modules" line.
+func renderPullSummary(s *mirror.PullSummary, verbose bool) string {
+	var b strings.Builder
+
+	b.WriteByte('\n')
+	writeTopBorder(&b, summaryTitle(s))
+
+	// Edition (e.g. CE/EE), shown above the components. Omitted for a custom
+	// registry where no edition could be parsed from the source path.
+	if s.Edition != "" {
+		fmt.Fprintf(&b, "%s %s %s\n", bar(), cLabel(padLabel("Edition")), cCount(strings.ToUpper(s.Edition)))
+	}
+
+	writeComponent(&b, "Platform", s.Platform)
+	writeComponent(&b, "Installer", s.Installer)
+	writeSecurity(&b, s.Security)
+	writeModules(&b, s.Modules, verbose)
+
+	if !s.DryRun && len(s.Bundle.Files) > 0 {
+		b.WriteString(bar() + "\n")
+		writeBundle(&b, s.Bundle)
+	}
+
+	b.WriteString(bar() + "\n")
+
+	// Cancelled is checked before DryRun: a Ctrl+C during a dry-run sets both, and
+	// the cancellation is the more important fact to surface.
+	switch {
+	case s.Failed:
+		fmt.Fprintf(&b, "%s %s\n", bar(), cBad("Pull failed; the above reflects what completed before the error."))
+	case s.Cancelled:
+		fmt.Fprintf(&b, "%s %s\n", bar(), cBad("Pull was cancelled; the above reflects what completed."))
+	case s.DryRun:
+		fmt.Fprintf(&b, "%s %s\n", bar(), cWarn("No images were downloaded (dry-run)."))
+	}
+
+	fmt.Fprintf(&b, "%s %s\n", bar(), cDim("Elapsed: "+formatDuration(s.Elapsed)))
+	b.WriteString(cFrame("╚" + strings.Repeat("═", frameWidth-1)))
+
+	return b.String()
+}
+
+// summaryTitle is the framed-block title for the pull's terminal state.
+func summaryTitle(s *mirror.PullSummary) string {
+	switch {
+	case s.Failed:
+		return "Pull failed"
+	case s.DryRun:
+		return "Pull plan (dry-run)"
+	default:
+		return "Pull summary"
+	}
+}
+
+func writeTopBorder(b *strings.Builder, title string) {
+	prefix := "╔══ "
+	suffix := " "
+	used := utf8.RuneCountInString(prefix) + utf8.RuneCountInString(title) + utf8.RuneCountInString(suffix)
+
+	pad := max(0, frameWidth-used)
+
+	b.WriteString(cFrame(prefix) + cTitle(title) + suffix + cFrame(strings.Repeat("═", pad)) + "\n")
+}
+
+func writeComponent(b *strings.Builder, name string, c mirror.ComponentStats) {
+	label := cLabel(padLabel(name))
+
+	switch {
+	case c.Skipped:
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cDim("skipped"))
+	case !c.Attempted:
+		// Phase never ran (cancelled/failed pull).
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn("not pulled"))
+	default:
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, componentContent(c))
+	}
+}
+
+// componentContent renders a component's resolved versions, plus the channel
+// count for the platform (e.g. "v1.69.0 (5 channels)", or "latest" for the
+// installer). Falls back to "included" when no version/ref is known. No image
+// count by design.
+func componentContent(c mirror.ComponentStats) string {
+	if len(c.Versions) == 0 {
+		return cDim("included")
+	}
+
+	content := cVersion(strings.Join(sortVersions(c.Versions), ", "))
+	if len(c.Channels) > 0 {
+		content += " " + cDim(fmt.Sprintf("(%d channels)", len(c.Channels)))
+	}
+
+	return content
+}
+
+// sortVersions returns a copy of versions ordered newest-first by semver (see
+// compareSemverDesc); non-semver tags sort lexically after the semver ones.
+func sortVersions(versions []string) []string {
+	sorted := append([]string(nil), versions...)
+
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return compareSemverDesc(sorted[i], sorted[j])
+	})
+
+	return sorted
+}
+
+// compareSemverDesc reports whether tag a should sort before tag b in the
+// newest-first ordering: valid semver compares by version descending; a semver
+// tag precedes a non-semver one; two non-semver tags compare lexically.
+func compareSemverDesc(a, b string) bool {
+	va, ea := semver.NewVersion(a)
+	vb, eb := semver.NewVersion(b)
+
+	switch {
+	case ea == nil && eb == nil:
+		return va.GreaterThan(vb)
+	case ea == nil:
+		return true
+	case eb == nil:
+		return false
+	default:
+		return a < b
+	}
+}
+
+func writeSecurity(b *strings.Builder, s mirror.SecurityStats) {
+	label := cLabel(padLabel("Security"))
+
+	switch {
+	case s.Skipped:
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cDim("skipped"))
+	case !s.Attempted:
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn("not pulled"))
+	case !s.Available:
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn("not available in this edition"))
+	default:
+		// Green when complete, yellow when partial (an incomplete vulnerability set).
+		databases := fmt.Sprintf("%d/%d databases", s.Databases, s.AvailableDatabases)
+
+		if s.Databases < s.AvailableDatabases {
+			fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn(databases))
+			return
+		}
+
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cGood(databases))
+	}
+}
+
+func writeModules(b *strings.Builder, m mirror.ModulesStats, verbose bool) {
+	label := cLabel(padLabel("Modules"))
+
+	if m.Skipped {
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cDim("skipped"))
+		return
+	}
+
+	if !m.Attempted {
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn("not pulled"))
+		return
+	}
+
+	// Aggregate: module count, "extra images only" when applicable, and total VEX.
+	// No image count by design.
+	parts := []string{cCount(fmt.Sprint(len(m.Modules))) + " " + cDim("modules")}
+	if m.OnlyExtraImages {
+		parts = append(parts, cDim("extra images only"))
+	}
+
+	if m.TotalVEX > 0 {
+		parts = append(parts, cVEX(fmt.Sprintf("%d VEXes", m.TotalVEX)))
+	}
+
+	fmt.Fprintf(b, "%s %s %s\n", bar(), label, strings.Join(parts, "  "+cDim("·")+"  "))
+
+	// Per-module breakdown only in verbose mode (--verbose-summary).
+	if !verbose {
+		return
+	}
+
+	for _, ms := range m.Modules {
+		versions := ""
+		if len(ms.Versions) > 0 {
+			versions = "  " + cVersion("["+strings.Join(sortVersions(ms.Versions), ", ")+"]")
+		}
+
+		moduleVex := ""
+		if ms.VEX > 0 {
+			moduleVex = "  " + cVEX(fmt.Sprintf("(%d VEX)", ms.VEX))
+		}
+
+		// Name, VEX subset when present, then versions in []. Pad the name only
+		// when something follows, to avoid trailing whitespace.
+		line := ms.Name
+		if moduleVex != "" || versions != "" {
+			line = fmt.Sprintf("%-*s%s%s", nameWidth, ms.Name, moduleVex, versions)
+		}
+
+		fmt.Fprintf(b, "%s     %s\n", bar(), line)
+	}
+}
+
+func writeBundle(b *strings.Builder, bundle mirror.BundleStats) {
+	fmt.Fprintf(b, "%s %s\n", bar(), cLabel(fmt.Sprintf("Bundle artifacts (%d files)", physicalFileCount(bundle))))
+
+	for _, f := range bundle.Files {
+		chunks := ""
+		if f.Chunks > 0 {
+			chunks = "  " + cDim(fmt.Sprintf("(%d chunks)", f.Chunks))
+		}
+
+		fmt.Fprintf(b, "%s   %-*s %s%s\n", bar(), nameWidth, f.Name, cSize(fmt.Sprintf("%*s", sizeWidth, humanSize(f.Bytes))), chunks)
+	}
+
+	fmt.Fprintf(b, "%s   %s %s\n", bar(), cCount(fmt.Sprintf("%-*s", nameWidth, "TOTAL")), cTotalSz(fmt.Sprintf("%*s", sizeWidth, humanSize(bundle.TotalBytes))))
+}
+
+// physicalFileCount returns the number of files on disk: each chunked artifact
+// contributes its chunk count, each single-file artifact contributes one.
+func physicalFileCount(bundle mirror.BundleStats) int {
+	count := 0
+
+	for _, f := range bundle.Files {
+		if f.Chunks > 0 {
+			count += f.Chunks
+			continue
+		}
+
+		count++
+	}
+
+	return count
+}
+
+func padLabel(name string) string {
+	return fmt.Sprintf("%-*s", labelWidth, name+":")
+}
+
+// formatDuration renders an elapsed duration compactly, keeping millisecond
+// precision for sub-second runs (so a fast dry-run does not report "0s").
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return d.Round(time.Millisecond).String()
+	}
+
+	return d.Round(time.Second).String()
+}
+
+// humanSize returns a compact human-readable size using binary (IEC) units
+// (e.g. "789 B", "12.3 KiB", "2.9 GiB"). The divisor is 1024, so the labels are
+// KiB/MiB/GiB rather than the decimal KB/MB/GB - this keeps the printed unit
+// honest with the math, which matters when an operator sizes transfer media off
+// this number. Adapted from internal/cr/internal/output.HumanSize, which is not
+// importable here because it lives behind the internal/cr/internal/ barrier.
+func humanSize(n int64) string {
+	const unit = int64(1024)
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := unit, 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+
+	units := "KMGTPE"
+
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), units[exp])
+}

--- a/internal/mirror/cmd/pull/summary.go
+++ b/internal/mirror/cmd/pull/summary.go
@@ -79,9 +79,9 @@ func configureSummaryColor() {
 // It is emitted through a single logger call so the structured-logging handler
 // stamps a timestamp only once, at the top of the block.
 //
-// When verbose is true, the modules section lists every module with its
-// resolved versions (and VEX count, when present); otherwise it prints only the
-// aggregate "N modules" line.
+// When verbose is true, the modules and packages sections list every entry with
+// its resolved versions (and VEX count, when present); otherwise they print only
+// the aggregate "N modules" / "N packages" lines.
 func renderPullSummary(s *mirror.PullSummary, verbose bool) string {
 	var b strings.Builder
 
@@ -98,6 +98,7 @@ func renderPullSummary(s *mirror.PullSummary, verbose bool) string {
 	writeComponent(&b, "Installer", s.Installer)
 	writeSecurity(&b, s.Security)
 	writeModules(&b, s.Modules, verbose)
+	writePackages(&b, s.Packages, verbose)
 
 	if !s.DryRun && len(s.Bundle.Files) > 0 {
 		b.WriteString(bar() + "\n")
@@ -277,6 +278,59 @@ func writeModules(b *strings.Builder, m mirror.ModulesStats, verbose bool) {
 		line := ms.Name
 		if moduleVex != "" || versions != "" {
 			line = fmt.Sprintf("%-*s%s%s", nameWidth, ms.Name, moduleVex, versions)
+		}
+
+		fmt.Fprintf(b, "%s     %s\n", bar(), line)
+	}
+}
+
+func writePackages(b *strings.Builder, p mirror.PackagesStats, verbose bool) {
+	label := cLabel(padLabel("Packages"))
+
+	if p.Skipped {
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cDim("skipped"))
+		return
+	}
+
+	if !p.Attempted {
+		fmt.Fprintf(b, "%s %s %s\n", bar(), label, cWarn("not pulled"))
+		return
+	}
+
+	// Aggregate: package count, "extra images only" when applicable, and total VEX.
+	// No image count by design.
+	parts := []string{cCount(fmt.Sprint(len(p.Packages))) + " " + cDim("packages")}
+	if p.OnlyExtraImages {
+		parts = append(parts, cDim("extra images only"))
+	}
+
+	if p.TotalVEX > 0 {
+		parts = append(parts, cVEX(fmt.Sprintf("%d VEXes", p.TotalVEX)))
+	}
+
+	fmt.Fprintf(b, "%s %s %s\n", bar(), label, strings.Join(parts, "  "+cDim("·")+"  "))
+
+	// Per-package breakdown only in verbose mode (--verbose-summary).
+	if !verbose {
+		return
+	}
+
+	for _, ps := range p.Packages {
+		versions := ""
+		if len(ps.Versions) > 0 {
+			versions = "  " + cVersion("["+strings.Join(sortVersions(ps.Versions), ", ")+"]")
+		}
+
+		packageVex := ""
+		if ps.VEX > 0 {
+			packageVex = "  " + cVEX(fmt.Sprintf("(%d VEX)", ps.VEX))
+		}
+
+		// Name, VEX subset when present, then versions in []. Pad the name only
+		// when something follows, to avoid trailing whitespace.
+		line := ps.Name
+		if packageVex != "" || versions != "" {
+			line = fmt.Sprintf("%-*s%s%s", nameWidth, ps.Name, packageVex, versions)
 		}
 
 		fmt.Fprintf(b, "%s     %s\n", bar(), line)

--- a/internal/mirror/cmd/pull/summary.go
+++ b/internal/mirror/cmd/pull/summary.go
@@ -81,7 +81,7 @@ func configureSummaryColor() {
 //
 // When verbose is true, the modules and packages sections list every entry with
 // its resolved versions (and VEX count, when present); otherwise they print only
-// the aggregate "N modules" / "N packages" lines.
+// the aggregate count (the category label already names what is counted).
 func renderPullSummary(s *mirror.PullSummary, verbose bool) string {
 	var b strings.Builder
 
@@ -244,9 +244,9 @@ func writeModules(b *strings.Builder, m mirror.ModulesStats, verbose bool) {
 		return
 	}
 
-	// Aggregate: module count, "extra images only" when applicable, and total VEX.
-	// No image count by design.
-	parts := []string{cCount(fmt.Sprint(len(m.Modules))) + " " + cDim("modules")}
+	// Aggregate: bare count (the "Modules:" label already names the category),
+	// "extra images only" when applicable, and total VEX. No image count by design.
+	parts := []string{cCount(fmt.Sprint(len(m.Modules)))}
 	if m.OnlyExtraImages {
 		parts = append(parts, cDim("extra images only"))
 	}
@@ -297,9 +297,9 @@ func writePackages(b *strings.Builder, p mirror.PackagesStats, verbose bool) {
 		return
 	}
 
-	// Aggregate: package count, "extra images only" when applicable, and total VEX.
-	// No image count by design.
-	parts := []string{cCount(fmt.Sprint(len(p.Packages))) + " " + cDim("packages")}
+	// Aggregate: bare count (the "Packages:" label already names the category),
+	// "extra images only" when applicable, and total VEX. No image count by design.
+	parts := []string{cCount(fmt.Sprint(len(p.Packages)))}
 	if p.OnlyExtraImages {
 		parts = append(parts, cDim("extra images only"))
 	}

--- a/internal/mirror/cmd/pull/summary_test.go
+++ b/internal/mirror/cmd/pull/summary_test.go
@@ -80,9 +80,9 @@ func TestRenderPullSummary(t *testing.T) {
 				"Platform:", "included",
 				"Installer:",
 				"Security:", "4/4 databases",
-				"2 modules",
+				"Modules:    2",
 				"commander", "console",
-				"Packages:", "1 packages",
+				"Packages:   1",
 				"scanner", "[v1.45.2]",
 				"Bundle artifacts (3 files)", // 2 chunks + 1 single tar
 				"(2 chunks)",
@@ -171,7 +171,7 @@ func TestRenderPullSummary(t *testing.T) {
 			},
 			verbose: false,
 			contains: []string{
-				"2 modules",
+				"Modules:    2",
 			},
 			// Without --verbose-summary the individual module names must not appear.
 			notContains:  []string{"commander", "console", "images"},
@@ -188,7 +188,7 @@ func TestRenderPullSummary(t *testing.T) {
 			},
 			verbose: true,
 			contains: []string{
-				"20 modules",
+				"Modules:    20",
 				"moda", "modt", // first and last of the 20
 			},
 			notContains:  []string{"more modules", "images"},
@@ -245,7 +245,7 @@ func TestRenderPullSummary(t *testing.T) {
 					Packages:    []mirror.PackageStat{},
 				},
 			},
-			contains:     []string{"0 modules", "0 packages"},
+			contains:     []string{"Modules:    0", "Packages:   0"},
 			notContains:  []string{"skipped", "more modules", "more packages", "images"},
 			skippedCount: 0,
 		},
@@ -264,7 +264,7 @@ func TestRenderPullSummary(t *testing.T) {
 			},
 			verbose: true,
 			contains: []string{
-				"2 modules", "12 VEXes",
+				"Modules:    2", "12 VEXes",
 				"commander", "(12 VEX)",
 			},
 			// console has 0 VEX -> no per-module VEX note for it.
@@ -282,7 +282,7 @@ func TestRenderPullSummary(t *testing.T) {
 				},
 			},
 			verbose:      true,
-			contains:     []string{"1 modules"},
+			contains:     []string{"Modules:    1"},
 			notContains:  []string{"VEX", "including", "images"},
 			skippedCount: -1,
 		},
@@ -296,7 +296,7 @@ func TestRenderPullSummary(t *testing.T) {
 					Modules:         []mirror.ModuleStat{{Name: "commander", Images: 12}},
 				},
 			},
-			contains:     []string{"1 modules", "extra images only"},
+			contains:     []string{"Modules:    1", "extra images only"},
 			skippedCount: -1,
 		},
 		{
@@ -314,7 +314,7 @@ func TestRenderPullSummary(t *testing.T) {
 			},
 			verbose: true,
 			contains: []string{
-				"2 packages", "9 VEXes",
+				"Packages:   2", "9 VEXes",
 				"scanner", "[v2.1.0, v2.0.3]", "(9 VEX)",
 				"console", "[v1.45.2]",
 			},
@@ -348,7 +348,7 @@ func TestRenderPullSummary(t *testing.T) {
 					Packages:        []mirror.PackageStat{{Name: "scanner", Images: 8}},
 				},
 			},
-			contains:     []string{"1 packages", "extra images only"},
+			contains:     []string{"Packages:   1", "extra images only"},
 			skippedCount: -1,
 		},
 		{
@@ -358,7 +358,7 @@ func TestRenderPullSummary(t *testing.T) {
 			},
 			// Packages: skipped; the other phases are zero-valued -> "not pulled".
 			contains:     []string{"Packages:", "skipped"},
-			notContains:  []string{"0 packages"},
+			notContains:  []string{"Packages:   0"},
 			skippedCount: 1,
 		},
 		{
@@ -374,7 +374,7 @@ func TestRenderPullSummary(t *testing.T) {
 				"not pulled",
 			},
 			// A phase that never ran must not masquerade as available/empty.
-			notContains:  []string{"not available in this edition", "0 modules"},
+			notContains:  []string{"not available in this edition", "Modules:    0"},
 			skippedCount: -1,
 		},
 		{

--- a/internal/mirror/cmd/pull/summary_test.go
+++ b/internal/mirror/cmd/pull/summary_test.go
@@ -45,7 +45,7 @@ func TestRenderPullSummary(t *testing.T) {
 		skippedCount int // -1 to skip the assertion
 	}{
 		{
-			name: "real pull verbose lists modules",
+			name: "real pull verbose lists modules and packages",
 			summary: &mirror.PullSummary{
 				Elapsed:   14*time.Minute + 32*time.Second,
 				Platform:  mirror.ComponentStats{Attempted: true, Images: 412},
@@ -57,6 +57,13 @@ func TestRenderPullSummary(t *testing.T) {
 					Modules: []mirror.ModuleStat{
 						{Name: "commander", Images: 57},
 						{Name: "console", Images: 43},
+					},
+				},
+				Packages: mirror.PackagesStats{
+					Attempted:   true,
+					TotalImages: 30,
+					Packages: []mirror.PackageStat{
+						{Name: "scanner", Images: 30, Versions: []string{"v1.45.2"}},
 					},
 				},
 				Bundle: mirror.BundleStats{
@@ -75,6 +82,8 @@ func TestRenderPullSummary(t *testing.T) {
 				"Security:", "4/4 databases",
 				"2 modules",
 				"commander", "console",
+				"Packages:", "1 packages",
+				"scanner", "[v1.45.2]",
 				"Bundle artifacts (3 files)", // 2 chunks + 1 single tar
 				"(2 chunks)",
 				"TOTAL",
@@ -214,24 +223,30 @@ func TestRenderPullSummary(t *testing.T) {
 				Installer: mirror.ComponentStats{Attempted: true, Images: 2},
 				Security:  mirror.SecurityStats{Skipped: true},
 				Modules:   mirror.ModulesStats{Skipped: true},
+				Packages:  mirror.PackagesStats{Skipped: true},
 			},
 			contains: []string{
-				"Platform:", "Security:", "Modules:",
+				"Platform:", "Security:", "Modules:", "Packages:",
 				"Installer:", "included",
 			},
-			skippedCount: 3, // Platform, Security, Modules
+			skippedCount: 4, // Platform, Security, Modules, Packages
 		},
 		{
-			name: "zero modules attempted",
+			name: "zero modules and packages attempted",
 			summary: &mirror.PullSummary{
 				Modules: mirror.ModulesStats{
 					Attempted:   true,
 					TotalImages: 0,
 					Modules:     []mirror.ModuleStat{},
 				},
+				Packages: mirror.PackagesStats{
+					Attempted:   true,
+					TotalImages: 0,
+					Packages:    []mirror.PackageStat{},
+				},
 			},
-			contains:     []string{"0 modules"},
-			notContains:  []string{"skipped", "more modules", "images"},
+			contains:     []string{"0 modules", "0 packages"},
+			notContains:  []string{"skipped", "more modules", "more packages", "images"},
 			skippedCount: 0,
 		},
 		{
@@ -285,6 +300,68 @@ func TestRenderPullSummary(t *testing.T) {
 			skippedCount: -1,
 		},
 		{
+			name: "package versions and VEX listed per package in verbose",
+			summary: &mirror.PullSummary{
+				Packages: mirror.PackagesStats{
+					Attempted:   true,
+					TotalImages: 84,
+					TotalVEX:    9,
+					Packages: []mirror.PackageStat{
+						{Name: "scanner", Images: 60, VEX: 9, Versions: []string{"v2.1.0", "v2.0.3"}},
+						{Name: "console", Images: 24, VEX: 0, Versions: []string{"v1.45.2"}},
+					},
+				},
+			},
+			verbose: true,
+			contains: []string{
+				"2 packages", "9 VEXes",
+				"scanner", "[v2.1.0, v2.0.3]", "(9 VEX)",
+				"console", "[v1.45.2]",
+			},
+			// No image counts; console has 0 VEX -> no per-package VEX note for it.
+			notContains:  []string{"84", "(0 VEX)", "images", "including"},
+			skippedCount: -1,
+		},
+		{
+			name: "package versions are sorted newest-first by semver",
+			summary: &mirror.PullSummary{
+				Packages: mirror.PackagesStats{
+					Attempted:   true,
+					TotalImages: 5,
+					Packages: []mirror.PackageStat{
+						// Resolved in arbitrary order; must render sorted, newest first.
+						{Name: "scanner", Images: 5, Versions: []string{"v1.5.4", "v10.0.1", "v1.10.3", "v1.9.16"}},
+					},
+				},
+			},
+			verbose:      true,
+			contains:     []string{"[v10.0.1, v1.10.3, v1.9.16, v1.5.4]"},
+			skippedCount: -1,
+		},
+		{
+			name: "only extra packages",
+			summary: &mirror.PullSummary{
+				Packages: mirror.PackagesStats{
+					Attempted:       true,
+					OnlyExtraImages: true,
+					TotalImages:     8,
+					Packages:        []mirror.PackageStat{{Name: "scanner", Images: 8}},
+				},
+			},
+			contains:     []string{"1 packages", "extra images only"},
+			skippedCount: -1,
+		},
+		{
+			name: "packages skipped while other phases never ran",
+			summary: &mirror.PullSummary{
+				Packages: mirror.PackagesStats{Skipped: true},
+			},
+			// Packages: skipped; the other phases are zero-valued -> "not pulled".
+			contains:     []string{"Packages:", "skipped"},
+			notContains:  []string{"0 packages"},
+			skippedCount: 1,
+		},
+		{
 			name: "cancelled partial",
 			summary: &mirror.PullSummary{
 				Cancelled: true,
@@ -331,16 +408,17 @@ func TestRenderPullSummary(t *testing.T) {
 			skippedCount: -1,
 		},
 		{
-			name: "everything skipped renders four skipped lines and no body",
+			name: "everything skipped renders five skipped lines and no body",
 			summary: &mirror.PullSummary{
 				Platform:  mirror.ComponentStats{Skipped: true},
 				Installer: mirror.ComponentStats{Skipped: true},
 				Security:  mirror.SecurityStats{Skipped: true},
 				Modules:   mirror.ModulesStats{Skipped: true},
+				Packages:  mirror.PackagesStats{Skipped: true},
 			},
-			contains:     []string{"Platform:", "Installer:", "Security:", "Modules:"},
+			contains:     []string{"Platform:", "Installer:", "Security:", "Modules:", "Packages:"},
 			notContains:  []string{"Bundle artifacts", "VEX", "not pulled"},
-			skippedCount: 4,
+			skippedCount: 5,
 		},
 	}
 

--- a/internal/mirror/cmd/pull/summary_test.go
+++ b/internal/mirror/cmd/pull/summary_test.go
@@ -1,0 +1,511 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pull
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/internal/mirror"
+)
+
+func TestRenderPullSummary(t *testing.T) {
+	// Make the bold header deterministic across TTY/non-TTY test runs.
+	color.NoColor = true
+
+	manyModules := make([]mirror.ModuleStat, 0, 20)
+	for i := range 20 {
+		manyModules = append(manyModules, mirror.ModuleStat{Name: "mod" + string(rune('a'+i)), Images: i + 1})
+	}
+
+	tests := []struct {
+		name         string
+		summary      *mirror.PullSummary
+		verbose      bool
+		contains     []string
+		notContains  []string
+		skippedCount int // -1 to skip the assertion
+	}{
+		{
+			name: "real pull verbose lists modules",
+			summary: &mirror.PullSummary{
+				Elapsed:   14*time.Minute + 32*time.Second,
+				Platform:  mirror.ComponentStats{Attempted: true, Images: 412},
+				Installer: mirror.ComponentStats{Attempted: true, Images: 3},
+				Security:  mirror.SecurityStats{Attempted: true, Available: true, Databases: 4, AvailableDatabases: 4},
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 100,
+					Modules: []mirror.ModuleStat{
+						{Name: "commander", Images: 57},
+						{Name: "console", Images: 43},
+					},
+				},
+				Bundle: mirror.BundleStats{
+					TotalBytes: 9_800_000_000,
+					Files: []mirror.BundleFile{
+						{Name: "module-commander.tar", Bytes: 801_500_000, Chunks: 2},
+						{Name: "platform.tar", Bytes: 3_100_000_000},
+					},
+				},
+			},
+			verbose: true,
+			contains: []string{
+				"Pull summary",
+				"Platform:", "included",
+				"Installer:",
+				"Security:", "4/4 databases",
+				"2 modules",
+				"commander", "console",
+				"Bundle artifacts (3 files)", // 2 chunks + 1 single tar
+				"(2 chunks)",
+				"TOTAL",
+				"Elapsed: 14m32s",
+			},
+			notContains:  []string{"dry-run", "skipped", "cancelled", "images"},
+			skippedCount: 0,
+		},
+		{
+			name: "platform releases shown on the platform line",
+			summary: &mirror.PullSummary{
+				Platform: mirror.ComponentStats{
+					Attempted: true, Images: 327,
+					Versions: []string{"v1.69.0"},
+					Channels: []string{"alpha", "beta", "early-access", "stable", "rock-solid"},
+				},
+			},
+			verbose: false,
+			contains: []string{
+				"v1.69.0 (5 channels)",
+			},
+			// No Edition set -> no Edition line.
+			notContains:  []string{"327", "Edition"},
+			skippedCount: -1,
+		},
+		{
+			name: "edition shown above platform when known",
+			summary: &mirror.PullSummary{
+				Edition:  "ce",
+				Platform: mirror.ComponentStats{Attempted: true, Versions: []string{"v1.75.9"}, Channels: []string{"a", "b", "c", "d", "e"}},
+			},
+			verbose: false,
+			contains: []string{
+				"Edition:", "CE", // uppercased for display
+				"v1.75.9 (5 channels)",
+			},
+			skippedCount: -1,
+		},
+		{
+			name: "module versions listed per module in verbose",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 84,
+					TotalVEX:    17,
+					Modules: []mirror.ModuleStat{
+						{Name: "code", Images: 84, VEX: 17, Versions: []string{"v1.10.3", "v1.9.16"}},
+					},
+				},
+			},
+			verbose: true,
+			contains: []string{
+				"code", "[v1.10.3, v1.9.16]", "(17 VEX)", "17 VEXes",
+			},
+			notContains:  []string{"84", "images", "including"},
+			skippedCount: -1,
+		},
+		{
+			name: "module versions are sorted newest-first by semver",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 14,
+					Modules: []mirror.ModuleStat{
+						// Resolved in arbitrary order; must render sorted, newest first.
+						{Name: "code", Images: 14, Versions: []string{"v1.5.4", "v10.0.1", "v1.10.3", "v1.9.16"}},
+					},
+				},
+			},
+			verbose:      true,
+			contains:     []string{"[v10.0.1, v1.10.3, v1.9.16, v1.5.4]"},
+			skippedCount: -1,
+		},
+		{
+			name: "default hides per-module breakdown",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 100,
+					Modules: []mirror.ModuleStat{
+						{Name: "commander", Images: 57},
+						{Name: "console", Images: 43},
+					},
+				},
+			},
+			verbose: false,
+			contains: []string{
+				"2 modules",
+			},
+			// Without --verbose-summary the individual module names must not appear.
+			notContains:  []string{"commander", "console", "images"},
+			skippedCount: -1,
+		},
+		{
+			name: "verbose lists every module without truncation",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 210,
+					Modules:     manyModules,
+				},
+			},
+			verbose: true,
+			contains: []string{
+				"20 modules",
+				"moda", "modt", // first and last of the 20
+			},
+			notContains:  []string{"more modules", "images"},
+			skippedCount: -1,
+		},
+		{
+			name: "dry-run, security unavailable",
+			summary: &mirror.PullSummary{
+				DryRun:    true,
+				Elapsed:   22 * time.Second,
+				Platform:  mirror.ComponentStats{Attempted: true, Images: 412},
+				Installer: mirror.ComponentStats{Attempted: true, Images: 1},
+				Security:  mirror.SecurityStats{Attempted: true, Available: false, AvailableDatabases: 4},
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 356,
+					Modules:     []mirror.ModuleStat{{Name: "commander", Images: 18}},
+				},
+			},
+			contains: []string{
+				"Pull plan (dry-run)",
+				"not available in this edition",
+				"No images were downloaded (dry-run).",
+			},
+			notContains:  []string{"Bundle artifacts", "databases", "4/4"},
+			skippedCount: -1,
+		},
+		{
+			name: "skipped categories",
+			summary: &mirror.PullSummary{
+				Platform:  mirror.ComponentStats{Skipped: true},
+				Installer: mirror.ComponentStats{Attempted: true, Images: 2},
+				Security:  mirror.SecurityStats{Skipped: true},
+				Modules:   mirror.ModulesStats{Skipped: true},
+			},
+			contains: []string{
+				"Platform:", "Security:", "Modules:",
+				"Installer:", "included",
+			},
+			skippedCount: 3, // Platform, Security, Modules
+		},
+		{
+			name: "zero modules attempted",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 0,
+					Modules:     []mirror.ModuleStat{},
+				},
+			},
+			contains:     []string{"0 modules"},
+			notContains:  []string{"skipped", "more modules", "images"},
+			skippedCount: 0,
+		},
+		{
+			name: "vex present, verbose shows per-module VEX",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 100,
+					TotalVEX:    12,
+					Modules: []mirror.ModuleStat{
+						{Name: "commander", Images: 57, VEX: 12},
+						{Name: "console", Images: 43, VEX: 0},
+					},
+				},
+			},
+			verbose: true,
+			contains: []string{
+				"2 modules", "12 VEXes",
+				"commander", "(12 VEX)",
+			},
+			// console has 0 VEX -> no per-module VEX note for it.
+			notContains:  []string{"(0 VEX)", "images", "including"},
+			skippedCount: -1,
+		},
+		{
+			name: "vex absent omits the parenthetical",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:   true,
+					TotalImages: 100,
+					TotalVEX:    0,
+					Modules:     []mirror.ModuleStat{{Name: "commander", Images: 57}},
+				},
+			},
+			verbose:      true,
+			contains:     []string{"1 modules"},
+			notContains:  []string{"VEX", "including", "images"},
+			skippedCount: -1,
+		},
+		{
+			name: "only extra images",
+			summary: &mirror.PullSummary{
+				Modules: mirror.ModulesStats{
+					Attempted:       true,
+					OnlyExtraImages: true,
+					TotalImages:     12,
+					Modules:         []mirror.ModuleStat{{Name: "commander", Images: 12}},
+				},
+			},
+			contains:     []string{"1 modules", "extra images only"},
+			skippedCount: -1,
+		},
+		{
+			name: "cancelled partial",
+			summary: &mirror.PullSummary{
+				Cancelled: true,
+				Elapsed:   3 * time.Minute,
+				Platform:  mirror.ComponentStats{Attempted: true, Images: 10, Versions: []string{"v1.69.0"}},
+				// Installer / Security / Modules never ran -> "not pulled".
+			},
+			contains: []string{
+				"Pull was cancelled; the above reflects what completed.",
+				"not pulled",
+			},
+			// A phase that never ran must not masquerade as available/empty.
+			notContains:  []string{"not available in this edition", "0 modules"},
+			skippedCount: -1,
+		},
+		{
+			name: "hard failure renders partial summary in failed state",
+			summary: &mirror.PullSummary{
+				Failed:   true,
+				Elapsed:  5 * time.Minute,
+				Platform: mirror.ComponentStats{Attempted: true, Versions: []string{"v1.69.0"}, Channels: []string{"stable"}},
+				// Installer / Security / Modules never ran -> "not pulled".
+			},
+			contains: []string{
+				"Pull failed",
+				"v1.69.0",
+				"not pulled",
+				"Pull failed; the above reflects what completed before the error.",
+			},
+			notContains:  []string{"Pull summary", "included", "not available in this edition"},
+			skippedCount: -1,
+		},
+		{
+			name: "cancelled during dry-run shows cancellation, not the dry-run footer",
+			summary: &mirror.PullSummary{
+				DryRun:    true,
+				Cancelled: true,
+				Elapsed:   2 * time.Second,
+				Platform:  mirror.ComponentStats{Attempted: true, Versions: []string{"v1.69.0"}},
+			},
+			// Ctrl+C during a dry-run sets both flags; cancellation must win the footer.
+			contains:     []string{"Pull was cancelled; the above reflects what completed."},
+			notContains:  []string{"No images were downloaded (dry-run)."},
+			skippedCount: -1,
+		},
+		{
+			name: "everything skipped renders four skipped lines and no body",
+			summary: &mirror.PullSummary{
+				Platform:  mirror.ComponentStats{Skipped: true},
+				Installer: mirror.ComponentStats{Skipped: true},
+				Security:  mirror.SecurityStats{Skipped: true},
+				Modules:   mirror.ModulesStats{Skipped: true},
+			},
+			contains:     []string{"Platform:", "Installer:", "Security:", "Modules:"},
+			notContains:  []string{"Bundle artifacts", "VEX", "not pulled"},
+			skippedCount: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := renderPullSummary(tt.summary, tt.verbose)
+
+			// Sanity: the block is framed.
+			require.Contains(t, out, "╔══", "missing top border")
+			require.Contains(t, out, "╚", "missing bottom border")
+
+			for _, want := range tt.contains {
+				require.Contains(t, out, want)
+			}
+
+			for _, notWant := range tt.notContains {
+				require.NotContains(t, out, notWant)
+			}
+
+			if tt.skippedCount >= 0 {
+				require.Equal(t, tt.skippedCount, strings.Count(out, "skipped"))
+			}
+		})
+	}
+}
+
+// TestRenderPullSummary_ColorGating verifies that colour is emitted only when
+// enabled and fully suppressed otherwise - the contract that keeps escape codes
+// out of pipes, files, and captured logs (fatih/color flips color.NoColor from
+// the stdout TTY check and NO_COLOR, which the logger writes to).
+func TestRenderPullSummary_ColorGating(t *testing.T) {
+	orig := color.NoColor
+	defer func() { color.NoColor = orig }()
+
+	s := &mirror.PullSummary{
+		Security: mirror.SecurityStats{Attempted: true, Available: true, Databases: 4, AvailableDatabases: 4},
+		Modules: mirror.ModulesStats{
+			Attempted:   true,
+			TotalImages: 1,
+			TotalVEX:    1,
+			Modules:     []mirror.ModuleStat{{Name: "code", Images: 1, VEX: 1, Versions: []string{"v1.0.0"}}},
+		},
+	}
+
+	color.NoColor = false
+	require.Contains(t, renderPullSummary(s, true), "\x1b[",
+		"ANSI escape codes must be present when colour is enabled")
+
+	color.NoColor = true
+	require.NotContains(t, renderPullSummary(s, true), "\x1b[",
+		"no ANSI escape codes when colour is disabled (NO_COLOR / non-TTY / piped)")
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := map[int64]string{
+		0:             "0 B",
+		-5:            "-5 B", // negatives fall through the < 1024 branch unchanged
+		512:           "512 B",
+		1023:          "1023 B",
+		1024:          "1.0 KiB",
+		1536:          "1.5 KiB",
+		1024 * 1024:   "1.0 MiB",
+		3_100_000_000: "2.9 GiB",
+		1 << 40:       "1.0 TiB",
+		1 << 50:       "1.0 PiB",
+		1 << 60:       "1.0 EiB", // top of the KMGTPE unit string
+	}
+
+	for in, want := range cases {
+		require.Equal(t, want, humanSize(in))
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                               "0s",
+		500 * time.Millisecond:          "500ms", // sub-second keeps ms precision
+		time.Second:                     "1s",
+		1500 * time.Millisecond:         "2s", // rounds to the nearest second
+		14*time.Minute + 32*time.Second: "14m32s",
+		1*time.Hour + 47*time.Minute:    "1h47m0s",
+	}
+
+	for in, want := range cases {
+		require.Equal(t, want, formatDuration(in))
+	}
+}
+
+func TestSortVersions(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, nil},
+		{"single", []string{"v1.2.3"}, []string{"v1.2.3"}},
+		{"semver newest-first, numeric not lexical", []string{"v1.9.16", "v1.10.3", "v1.5.4"}, []string{"v1.10.3", "v1.9.16", "v1.5.4"}},
+		{"major jump", []string{"v1.10.3", "v10.0.1", "v1.5.4"}, []string{"v10.0.1", "v1.10.3", "v1.5.4"}},
+		{"all non-semver sort lexically", []string{"release-b", "release-a", "custom"}, []string{"custom", "release-a", "release-b"}},
+		{"mixed: semver first (desc), non-semver after (lexical)", []string{"latest", "v1.2.3", "edge", "v2.0.0"}, []string{"v2.0.0", "v1.2.3", "edge", "latest"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, sortVersions(tc.in))
+		})
+	}
+}
+
+// TestConfigureSummaryColor verifies the env-var precedence that re-enables
+// colour for intentional piping: NO_COLOR wins over FORCE_COLOR / CLICOLOR_FORCE.
+func TestConfigureSummaryColor(t *testing.T) {
+	cases := []struct {
+		name             string
+		noColor          string
+		forceColor       string
+		cliColorForce    string
+		startNoColor     bool
+		wantNoColorAfter bool
+	}{
+		{name: "FORCE_COLOR re-enables colour", forceColor: "1", startNoColor: true, wantNoColorAfter: false},
+		{name: "CLICOLOR_FORCE re-enables colour", cliColorForce: "1", startNoColor: true, wantNoColorAfter: false},
+		{name: "NO_COLOR wins over FORCE_COLOR", noColor: "1", forceColor: "1", startNoColor: true, wantNoColorAfter: true},
+		{name: "no env vars leaves it untouched", startNoColor: true, wantNoColorAfter: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", tc.noColor)
+			t.Setenv("FORCE_COLOR", tc.forceColor)
+			t.Setenv("CLICOLOR_FORCE", tc.cliColorForce)
+
+			orig := color.NoColor
+			defer func() { color.NoColor = orig }()
+
+			color.NoColor = tc.startNoColor
+			configureSummaryColor()
+			require.Equal(t, tc.wantNoColorAfter, color.NoColor)
+		})
+	}
+}
+
+func TestPhysicalFileCount(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []mirror.BundleFile
+		want  int
+	}{
+		{"no files", nil, 0},
+		{"single tar counts as one", []mirror.BundleFile{{Name: "platform.tar"}}, 1},
+		{"chunks=1 counts as one chunk", []mirror.BundleFile{{Name: "a.tar", Chunks: 1}}, 1},
+		{
+			name: "mix of single and chunked",
+			files: []mirror.BundleFile{
+				{Name: "platform.tar"},            // single -> 1
+				{Name: "module-a.tar", Chunks: 3}, // chunked -> 3
+				{Name: "installer.tar"},           // single -> 1
+			},
+			want: 5,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, physicalFileCount(mirror.BundleStats{Files: tc.files}))
+		})
+	}
+}

--- a/internal/mirror/installer/installer.go
+++ b/internal/mirror/installer/installer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/bundle"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+	"github.com/deckhouse/deckhouse-cli/pkg/registry/image"
 	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
 )
 
@@ -63,6 +64,15 @@ type Service struct {
 
 	// options contains service configuration
 	options *Options
+
+	// pulledImages caches the number of image manifests pulled into the OCI
+	// layout, captured before packing. 
+	// 
+    // We need this to calculate Stats() after packing.
+	// The pack step deletes every layout file
+	// as it writes it into the tar (see bundle.Pack), so the count must be taken
+	// before packing, not in Stats() which runs afterwards.
+	pulledImages int
 
 	// logger is for internal debug logging
 	logger *dkplog.Logger
@@ -178,6 +188,11 @@ func (svc *Service) pullInstaller(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("pull installer: %w", err)
 	}
+
+	// Capture the manifest count before packing: bundle.Pack deletes every
+	// layout file as it tars it, so counting after the pack step would read an
+	// emptied layout and report zero.
+	svc.pulledImages = image.CountManifests(svc.layout.AsList())
 
 	if err := logger.Process("Pack Deckhouse images into installer.tar", func() error {
 		return pack.Bundle(ctx, svc.options.BundleDir, "installer.tar", svc.options.BundleChunkSize, func(w io.Writer) error {

--- a/internal/mirror/installer/installer.go
+++ b/internal/mirror/installer/installer.go
@@ -65,13 +65,9 @@ type Service struct {
 	// options contains service configuration
 	options *Options
 
-	// pulledImages caches the number of image manifests pulled into the OCI
-	// layout, captured before packing. 
-	// 
-    // We need this to calculate Stats() after packing.
-	// The pack step deletes every layout file
-	// as it writes it into the tar (see bundle.Pack), so the count must be taken
-	// before packing, not in Stats() which runs afterwards.
+	// pulledImages caches the image-manifest count pulled into the OCI layout,
+	// captured before packing: bundle.Pack deletes each layout file as it tars
+	// it, so the count must be taken now, not in Stats() which runs afterwards.
 	pulledImages int
 
 	// logger is for internal debug logging

--- a/internal/mirror/installer/stats.go
+++ b/internal/mirror/installer/stats.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+// ComponentStats is the installer phase's image accounting, mapped into the
+// top-level summary by the pull orchestrator.
+type ComponentStats struct {
+	Attempted bool
+	Images    int
+	// Tag is the installer image tag mirrored ("latest" by default, or a pinned
+	// --installer-tag). Resolved before download, so it is set in dry-run too.
+	Tag string
+}
+
+// Stats returns image accounting for the installer phase. In dry-run it reports
+// the planned count from the download list; otherwise it reports the actual
+// number of manifests pulled into the OCI layout, captured before packing (see
+// Service.pulledImages).
+func (svc *Service) Stats() ComponentStats {
+	tag := defaultTargetTag
+	if svc.options.TargetTag != "" {
+		tag = svc.options.TargetTag
+	}
+
+	if svc.options.DryRun {
+		return ComponentStats{Attempted: true, Images: len(svc.downloadList.Installer), Tag: tag}
+	}
+
+	return ComponentStats{Attempted: true, Images: svc.pulledImages, Tag: tag}
+}

--- a/internal/mirror/installer/stats_test.go
+++ b/internal/mirror/installer/stats_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+
+	"github.com/deckhouse/deckhouse-cli/pkg"
+	"github.com/deckhouse/deckhouse-cli/pkg/fake"
+	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
+	registryservice "github.com/deckhouse/deckhouse-cli/pkg/registry/service"
+)
+
+// TestStats_DryRun verifies that, in dry-run mode, Stats reports the planned
+// installer image count from the download list (a single installer tag).
+func TestStats_DryRun(t *testing.T) {
+	workingDir := t.TempDir()
+	bundleDir := t.TempDir()
+
+	stubClient := fake.NewRegistryClientStub()
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+
+	regSvc := registryservice.NewService(stubClient, pkg.FEEdition, logger)
+
+	svc := NewService(
+		regSvc,
+		workingDir,
+		&Options{
+			TargetTag: "v1.69.0",
+			BundleDir: bundleDir,
+			DryRun:    true,
+		},
+		logger,
+		userLogger,
+	)
+
+	require.NoError(t, svc.PullInstaller(context.Background()))
+
+	stats := svc.Stats()
+	require.True(t, stats.Attempted)
+	require.Equal(t, 1, stats.Images)
+}
+
+// TestStats_RealPull_SurvivesPacking is the regression test for the bug where
+// Stats reported 0 images after a successful real pull. The pack step deletes
+// every OCI layout file as it tars it (see bundle.Pack), so counting manifests
+// in Stats() - which runs after packing - read an emptied layout and returned
+// zero. The fix captures the count before packing; this test asserts the
+// installer count is non-zero after a full PullInstaller (pull + pack).
+func TestStats_RealPull_SurvivesPacking(t *testing.T) {
+	workingDir := t.TempDir()
+	bundleDir := t.TempDir()
+
+	stubClient := fake.NewRegistryClientStub()
+	logger := dkplog.NewLogger(dkplog.WithLevel(slog.LevelWarn))
+	userLogger := log.NewSLogger(slog.LevelWarn)
+
+	regSvc := registryservice.NewService(stubClient, pkg.FEEdition, logger)
+
+	svc := NewService(
+		regSvc,
+		workingDir,
+		&Options{
+			TargetTag: "v1.69.0",
+			BundleDir: bundleDir,
+			DryRun:    false,
+		},
+		logger,
+		userLogger,
+	)
+
+	require.NoError(t, svc.PullInstaller(context.Background()))
+
+	stats := svc.Stats()
+	require.True(t, stats.Attempted)
+	require.Equal(t, 1, stats.Images,
+		"installer count must survive packing (captured before bundle.Pack deletes the layout)")
+}

--- a/internal/mirror/modules/modules.go
+++ b/internal/mirror/modules/modules.go
@@ -105,6 +105,10 @@ type Service struct {
 	// options contains service configuration
 	options *Options
 
+	// moduleStats accumulates per-module pull accounting, keyed by module name.
+	// See modulePullStat for what each field holds and when it is filled.
+	moduleStats map[moduleName]modulePullStat
+
 	// rootURL is the base registry URL for modules images
 	rootURL string
 
@@ -147,6 +151,7 @@ func NewService(
 		pullerService:       puller.NewPullerService(logger, userLogger),
 		options:             options,
 		rootURL:             rootURL,
+		moduleStats:         make(map[moduleName]modulePullStat),
 		logger:              logger,
 		userLogger:          userLogger,
 	}
@@ -340,6 +345,11 @@ func (svc *Service) pullModules(ctx context.Context) error {
 		}
 	}
 
+	// Capture per-module manifest counts before packing: bundle.Pack deletes
+	// every layout file as it tars it, so counting after the pack step would
+	// read emptied layouts and report zero.
+	svc.capturePulledImages(filteredModules)
+
 	// Pack each module into separate tar
 	if err := svc.packModules(postCtx, filteredModules); err != nil {
 		return err
@@ -370,8 +380,23 @@ func (svc *Service) pullSingleModule(ctx context.Context, module moduleData) err
 
 	moduleVersions := svc.mergeAndDedupeVersions(module.name, module.registryPath, channelVersions, tags)
 
+	// Record the resolved versions for the summary. Happens before download, so
+	// it is populated in dry-run too.
+	stat := svc.moduleStats[module.name]
+	stat.versions = moduleVersions
+	svc.moduleStats[module.name] = stat
+
 	if svc.options.DryRun {
 		svc.printDryRunPlan(module.name, downloadList, moduleVersions)
+
+		// Record the planned version images so the end-of-pull summary counts
+		// them, mirroring the references printDryRunPlan prints. Extra images
+		// are not resolved in dry-run (they require a real pull), so the
+		// per-module count stays "release channels + versions".
+		for _, version := range moduleVersions {
+			downloadList.Module[svc.rootURL+"/modules/"+module.name+":"+version] = nil
+		}
+
 		return nil
 	}
 

--- a/internal/mirror/modules/stats.go
+++ b/internal/mirror/modules/stats.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modules
+
+import (
+	"sort"
+	"strings"
+
+	regimage "github.com/deckhouse/deckhouse-cli/pkg/registry/image"
+)
+
+// vexTagSuffix marks a manifest as a VEX attestation (cosign ".att" convention).
+const vexTagSuffix = ".att"
+
+// ModuleStat is one module's contribution to the pull.
+type ModuleStat struct {
+	Name   string
+	Images int
+	// VEX is how many of Images are VEX attestations (a subset of Images, not
+	// an additional count).
+	VEX int
+	// Versions are the resolved module versions to pull, e.g.
+	// ["v1.10.3", "v1.9.16"]. Resolved before download, so available in dry-run.
+	Versions []string
+}
+
+// ModulesStats is the modules phase's accounting, mapped into the top-level
+// summary by the pull orchestrator.
+type ModulesStats struct {
+	Attempted       bool
+	OnlyExtraImages bool
+	Modules         []ModuleStat
+	TotalImages     int
+	// TotalVEX is the number of VEX attestations across all modules, a subset of
+	// TotalImages.
+	TotalVEX int
+}
+
+// moduleName is the registry module name (e.g. "code", "csi-nfs") used as the
+// key of Service.moduleStats. It is an alias for string, so it interoperates
+// with the plain module names used throughout the package without conversions.
+type moduleName = string
+
+// modulePullStat is the internal per-module accounting accumulated during a
+// pull and keyed by module name in Service.moduleStats; Stats builds the
+// exported ModuleStat from it. The fields are filled at different stages:
+// versions during resolution (before download), images and vex before packing
+// (bundle.Pack deletes the OCI layouts as it tars them, so the counts cannot be
+// taken in Stats, which runs afterwards).
+type modulePullStat struct {
+	// images is the total image manifest count across the module's layouts.
+	images int
+	// vex is how many of images are VEX attestations (".att" suffix), a subset.
+	vex int
+	// versions are the versions selected for pull, e.g. ["v1.10.3", "v1.9.16"].
+	versions []string
+}
+
+// Stats returns accounting for the modules phase. In dry-run it reports planned
+// per-module counts from the download lists; otherwise it reports the actual
+// number of manifests pulled into each module's OCI layouts, captured before
+// packing in Service.moduleStats (modules that produced no images are omitted,
+// matching packModules, which emits no tar for them).
+func (svc *Service) Stats() ModulesStats {
+	stats := ModulesStats{
+		Attempted:       true,
+		OnlyExtraImages: svc.options.OnlyExtraImages,
+	}
+
+	if svc.options.DryRun {
+		for name, dl := range svc.modulesDownloadList.list {
+			images := len(dl.Module) + len(dl.ModuleReleaseChannels) + len(dl.ModuleExtra)
+			stats.Modules = append(stats.Modules, ModuleStat{Name: name, Images: images, Versions: svc.moduleStats[name].versions})
+			stats.TotalImages += images
+		}
+	} else {
+		for name, ms := range svc.moduleStats {
+			if ms.images == 0 {
+				continue
+			}
+
+			stats.Modules = append(stats.Modules, ModuleStat{Name: name, Images: ms.images, VEX: ms.vex, Versions: ms.versions})
+			stats.TotalImages += ms.images
+			stats.TotalVEX += ms.vex
+		}
+	}
+
+	sort.Slice(stats.Modules, func(i, j int) bool {
+		return stats.Modules[i].Name < stats.Modules[j].Name
+	})
+
+	return stats
+}
+
+// capturePulledImages records, per module, the image and VEX manifest counts
+// pulled into its OCI layouts, merging them into the existing moduleStats entry
+// (which already holds the resolved versions). It must run before packing
+// deletes the layout files (see bundle.Pack).
+func (svc *Service) capturePulledImages(modules []moduleData) {
+	if svc.layout == nil {
+		return
+	}
+
+	for _, module := range modules {
+		ml := svc.layout.Module(module.name)
+		if ml == nil {
+			continue
+		}
+
+		paths := ml.AsList()
+
+		stat := svc.moduleStats[module.name]
+		stat.images = regimage.CountManifests(paths)
+		// VEX attestations live in the same layouts as regular images and are
+		// recognised by the ".att" suffix on their short-tag annotation; count
+		// them as a subset of the total.
+		stat.vex = regimage.CountManifestsMatching(paths,
+			func(annotations map[string]string) bool {
+				return strings.HasSuffix(annotations[regimage.AnnotationImageShortTag], vexTagSuffix)
+			})
+		svc.moduleStats[module.name] = stat
+	}
+}

--- a/internal/mirror/packages/packages.go
+++ b/internal/mirror/packages/packages.go
@@ -46,6 +46,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/registry/client"
 
 	"github.com/deckhouse/deckhouse-cli/internal"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/errmatch"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/pack"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/puller"
@@ -329,8 +330,12 @@ func (svc *Service) validatePackagesAccess(ctx context.Context) error {
 		return nil
 	}
 
+	// A registry without a packages catalog reports it as either ErrImageNotFound
+	// or a NAME_UNKNOWN transport error (the public registry returns the latter).
+	// Both mean "no packages here": skip the phase instead of failing the pull,
+	// matching the graceful skip in PullPackageVersions.
 	_, err := svc.packagesService.ListTags(ctx)
-	if errors.Is(err, client.ErrImageNotFound) {
+	if errors.Is(err, client.ErrImageNotFound) || errmatch.IsRepoNotFound(err) {
 		svc.userLogger.Warnf("Skipping pull of packages: %v", err)
 
 		return nil
@@ -600,6 +605,13 @@ func (svc *Service) discoverPackageNames(ctx context.Context) ([]string, error) 
 
 	packageNames, err := svc.packagesService.ListTags(ctx)
 	if err != nil {
+		// A missing packages repository (ErrImageNotFound, or a NAME_UNKNOWN
+		// transport error from the public registry) means there are no packages
+		// to mirror: report an empty set rather than failing the pull.
+		if errors.Is(err, client.ErrImageNotFound) || errmatch.IsRepoNotFound(err) {
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("list packages: %w", err)
 	}
 

--- a/internal/mirror/packages/packages.go
+++ b/internal/mirror/packages/packages.go
@@ -95,6 +95,10 @@ type Service struct {
 	// options contains service configuration
 	options *Options
 
+	// packageStats accumulates per-package pull accounting, keyed by package name.
+	// See packagePullStat for what each field holds and when it is filled.
+	packageStats map[packageName]packagePullStat
+
 	// rootURL is the base registry URL for packages images
 	rootURL string
 
@@ -134,6 +138,7 @@ func NewService(
 		packagesDownloadList: NewPackagesDownloadList(rootURL),
 		pullerService:        puller.NewPullerService(logger, userLogger),
 		options:              options,
+		packageStats:         make(map[packageName]packagePullStat),
 		rootURL:              rootURL,
 		logger:               logger,
 		userLogger:           userLogger,
@@ -469,6 +474,11 @@ func (svc *Service) pullPackages(ctx context.Context) error {
 		}
 	}
 
+	// Capture per-package manifest counts before packing: bundle.Pack deletes
+	// every layout file as it tars it, so counting after the pack step would
+	// read emptied layouts and report zero.
+	svc.capturePulledImages(filteredPackages)
+
 	// Pack each package into separate tar
 	if err := svc.packPackages(postCtx, filteredPackages); err != nil {
 		return err
@@ -499,8 +509,23 @@ func (svc *Service) pullSinglePackage(ctx context.Context, pkg packageData) erro
 
 	packageVersions := svc.mergeAndDedupeVersions(pkg.name, pkg.registryPath, channelVersions, tags)
 
+	// Record the resolved versions for the summary. Happens before download, so
+	// it is populated in dry-run too.
+	stat := svc.packageStats[pkg.name]
+	stat.versions = packageVersions
+	svc.packageStats[pkg.name] = stat
+
 	if svc.options.DryRun {
 		svc.printDryRunPlan(pkg.name, downloadList, packageVersions)
+
+		// Record the planned version images so the end-of-pull summary counts
+		// them, mirroring the references printDryRunPlan prints. Extra images are
+		// not resolved in dry-run (they require a real pull), so the per-package
+		// count stays "version channels + versions".
+		for _, version := range packageVersions {
+			downloadList.Package[svc.packageRef(pkg.name, version)] = nil
+		}
+
 		return nil
 	}
 

--- a/internal/mirror/packages/packages_test.go
+++ b/internal/mirror/packages/packages_test.go
@@ -307,6 +307,31 @@ func TestPullPackages_PerPackageListTagsErrorHandling(t *testing.T) {
 	}
 }
 
+// TestPullPackages_MissingPackagesRepoSkipsGracefully is the regression test for
+// the bug where a registry without a /packages repository failed the entire
+// pull instead of skipping the packages phase. The public registry reports the
+// missing repo as a NAME_UNKNOWN transport error (not ErrImageNotFound), so both
+// root-level ListTags probes - validatePackagesAccess and discoverPackageNames -
+// must treat either signal as "no packages here".
+func TestPullPackages_MissingPackagesRepoSkipsGracefully(t *testing.T) {
+	cases := map[string]error{
+		"NAME_UNKNOWN transport error": errors.New("NAME_UNKNOWN: repository name not known to registry"),
+		"ErrImageNotFound":             dkpreg.ErrImageNotFound,
+	}
+
+	for name, injected := range cases {
+		t.Run(name, func(t *testing.T) {
+			reg := upfake.NewRegistry(testHost)
+			client := &listTagsAlwaysErr{Client: upfake.NewClient(reg), err: injected}
+
+			svc := newService(t, pkgclient.Adapt(client), nil)
+
+			require.NoError(t, svc.PullPackages(context.Background()),
+				"a registry without a /packages repo must skip the phase, not fail the pull")
+		})
+	}
+}
+
 // =============================================================================
 // Tests: empty package layouts are not packed into tars
 // =============================================================================
@@ -962,6 +987,23 @@ func (c *listTagsErrAtPackage) ListTags(ctx context.Context, opts ...dkpreg.List
 		return nil, c.err
 	}
 	return c.Client.ListTags(ctx, opts...)
+}
+
+// listTagsAlwaysErr returns a fixed error from every ListTags call, at any depth.
+// It simulates a registry whose packages repository does not exist: the root
+// packages ListTags (validatePackagesAccess, then discoverPackageNames) is the
+// first thing PullPackages probes.
+type listTagsAlwaysErr struct {
+	dkpreg.Client
+	err error
+}
+
+func (c *listTagsAlwaysErr) WithSegment(segments ...string) dkpreg.Client {
+	return &listTagsAlwaysErr{Client: c.Client.WithSegment(segments...), err: c.err}
+}
+
+func (c *listTagsAlwaysErr) ListTags(_ context.Context, _ ...dkpreg.ListTagsOption) ([]string, error) {
+	return nil, c.err
 }
 
 // cancelOnSecondPackage is a registry client wrapper that fires the supplied

--- a/internal/mirror/packages/stats.go
+++ b/internal/mirror/packages/stats.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"sort"
+	"strings"
+
+	regimage "github.com/deckhouse/deckhouse-cli/pkg/registry/image"
+)
+
+// vexTagSuffix marks a manifest as a VEX attestation (cosign ".att" convention).
+const vexTagSuffix = ".att"
+
+// PackageStat is one package's contribution to the pull.
+type PackageStat struct {
+	Name   string
+	Images int
+	// VEX is how many of Images are VEX attestations (a subset of Images, not
+	// an additional count).
+	VEX int
+	// Versions are the resolved package versions to pull, e.g.
+	// ["v1.45.2", "v1.44.0"]. Resolved before download, so available in dry-run.
+	Versions []string
+}
+
+// PackagesStats is the packages phase's accounting, mapped into the top-level
+// summary by the pull orchestrator.
+type PackagesStats struct {
+	Attempted       bool
+	OnlyExtraImages bool
+	Packages        []PackageStat
+	TotalImages     int
+	// TotalVEX is the number of VEX attestations across all packages, a subset of
+	// TotalImages.
+	TotalVEX int
+}
+
+// packageName is the registry package name (e.g. "console") used as the key of
+// Service.packageStats. It is an alias for string, so it interoperates with the
+// plain package names used throughout the package without conversions.
+type packageName = string
+
+// packagePullStat is the internal per-package accounting accumulated during a
+// pull and keyed by package name in Service.packageStats; Stats builds the
+// exported PackageStat from it. The fields are filled at different stages:
+// versions during resolution (before download), images and vex before packing
+// (bundle.Pack deletes the OCI layouts as it tars them, so the counts cannot be
+// taken in Stats, which runs afterwards).
+type packagePullStat struct {
+	// images is the total image manifest count across the package's layouts.
+	images int
+	// vex is how many of images are VEX attestations (".att" suffix), a subset.
+	vex int
+	// versions are the versions selected for pull, e.g. ["v1.45.2", "v1.44.0"].
+	versions []string
+}
+
+// Stats returns accounting for the packages phase. In dry-run it reports planned
+// per-package counts from the download lists; otherwise it reports the actual
+// number of manifests pulled into each package's OCI layouts, captured before
+// packing in Service.packageStats (packages that produced no images are omitted,
+// matching packPackages, which emits no tar for them).
+func (svc *Service) Stats() PackagesStats {
+	stats := PackagesStats{
+		Attempted:       true,
+		OnlyExtraImages: svc.options.OnlyExtraImages,
+	}
+
+	if svc.options.DryRun {
+		for name, dl := range svc.packagesDownloadList.list {
+			images := len(dl.Package) + len(dl.PackageVersionChannels) + len(dl.PackageExtra)
+			stats.Packages = append(stats.Packages, PackageStat{Name: name, Images: images, Versions: svc.packageStats[name].versions})
+			stats.TotalImages += images
+		}
+	} else {
+		for name, ps := range svc.packageStats {
+			if ps.images == 0 {
+				continue
+			}
+
+			stats.Packages = append(stats.Packages, PackageStat{Name: name, Images: ps.images, VEX: ps.vex, Versions: ps.versions})
+			stats.TotalImages += ps.images
+			stats.TotalVEX += ps.vex
+		}
+	}
+
+	sort.Slice(stats.Packages, func(i, j int) bool {
+		return stats.Packages[i].Name < stats.Packages[j].Name
+	})
+
+	return stats
+}
+
+// capturePulledImages records, per package, the image and VEX manifest counts
+// pulled into its OCI layouts, merging them into the existing packageStats entry
+// (which already holds the resolved versions). It must run before packing
+// deletes the layout files (see bundle.Pack).
+func (svc *Service) capturePulledImages(pkgs []packageData) {
+	if svc.layout == nil {
+		return
+	}
+
+	for _, pkg := range pkgs {
+		pl := svc.layout.Package(pkg.name)
+		if pl == nil {
+			continue
+		}
+
+		paths := pl.AsList()
+
+		stat := svc.packageStats[pkg.name]
+		stat.images = regimage.CountManifests(paths)
+		// VEX attestations live in the same layouts as regular images and are
+		// recognised by the ".att" suffix on their short-tag annotation; count
+		// them as a subset of the total.
+		stat.vex = regimage.CountManifestsMatching(paths,
+			func(annotations map[string]string) bool {
+				return strings.HasSuffix(annotations[regimage.AnnotationImageShortTag], vexTagSuffix)
+			})
+		svc.packageStats[pkg.name] = stat
+	}
+}

--- a/internal/mirror/packages/stats_test.go
+++ b/internal/mirror/packages/stats_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	upfake "github.com/deckhouse/deckhouse/pkg/registry/fake"
+
+	pkgclient "github.com/deckhouse/deckhouse-cli/pkg/registry/client"
+)
+
+// TestStats_DryRun verifies that, in dry-run mode, Stats reports the resolved
+// package and its planned versions from the download list, without downloading
+// any image blobs.
+func TestStats_DryRun(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, []string{channelVersion})
+
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{DryRun: true})
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	stats := svc.Stats()
+	require.True(t, stats.Attempted)
+	require.Len(t, stats.Packages, 1)
+	require.Equal(t, testPackageName, stats.Packages[0].Name)
+	require.Equal(t, []string{channelVersion}, stats.Packages[0].Versions)
+}
+
+// TestStats_RealPull_SurvivesPacking is the regression test for the bug where
+// Stats reported 0 images after a successful real pull. The pack step deletes
+// every OCI layout file as it tars it (see bundle.Pack), so counting manifests
+// in Stats() - which runs after packing - read an emptied layout and returned
+// zero. The fix captures the counts before packing; this test asserts the
+// package's image count is non-zero after a full PullPackages (pull + pack).
+func TestStats_RealPull_SurvivesPacking(t *testing.T) {
+	reg := singlePackageRegistry(testPackageName, channelVersion, []string{channelVersion})
+
+	svc := newServiceOpts(t, pkgclient.Adapt(upfake.NewClient(reg)), &Options{SkipVexImages: true})
+
+	require.NoError(t, svc.PullPackages(context.Background()))
+
+	stats := svc.Stats()
+	require.True(t, stats.Attempted)
+	require.Len(t, stats.Packages, 1)
+	require.Equal(t, testPackageName, stats.Packages[0].Name)
+	require.Greater(t, stats.Packages[0].Images, 0,
+		"package image count must survive packing (captured before bundle.Pack deletes the layout)")
+	require.Contains(t, stats.Packages[0].Versions, channelVersion)
+}

--- a/internal/mirror/platform/layout.go
+++ b/internal/mirror/platform/layout.go
@@ -19,7 +19,6 @@ package platform
 import (
 	"fmt"
 	"path"
-	"reflect"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -124,20 +123,19 @@ func (l *ImageLayouts) setLayoutByMirrorType(rootFolder string, mirrorType inter
 	return nil
 }
 
-// AsList returns a list of layout.Path's in it. Undefined path's are not included in the list.
+// AsList returns the layout.Path of every defined sub-layout. Nil sub-layouts
+// (for example, those never created in dry-run) are skipped.
 func (l *ImageLayouts) AsList() []layout.Path {
-	layoutsValue := reflect.ValueOf(l).Elem()
-	layoutPathType := reflect.TypeOf(layout.Path(""))
+	paths := make([]layout.Path, 0, 4)
 
-	paths := make([]layout.Path, 0)
-
-	for i := 0; i < layoutsValue.NumField(); i++ {
-		if layoutsValue.Field(i).Type() != layoutPathType {
-			continue
-		}
-
-		if pathValue := layoutsValue.Field(i).String(); pathValue != "" {
-			paths = append(paths, layout.Path(pathValue))
+	for _, sub := range []*regimage.ImageLayout{
+		l.Deckhouse,
+		l.DeckhouseInstall,
+		l.DeckhouseInstallStandalone,
+		l.DeckhouseReleaseChannel,
+	} {
+		if sub != nil {
+			paths = append(paths, sub.Path())
 		}
 	}
 

--- a/internal/mirror/platform/layout_test.go
+++ b/internal/mirror/platform/layout_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse-cli/internal"
+)
+
+// TestAsList_ReturnsDefinedSubLayouts is a regression test for a bug where
+// ImageLayouts.AsList used reflection to look for layout.Path-typed fields,
+// which the struct does not have (its sub-layouts are *regimage.ImageLayout).
+// The reflection loop therefore matched nothing and AsList returned an empty
+// slice, which in turn made the end-of-pull summary report "0 images" for the
+// platform even after a successful pull.
+func TestAsList_ReturnsDefinedSubLayouts(t *testing.T) {
+	tmp := t.TempDir()
+	l := NewImageLayouts(tmp)
+
+	require.Empty(t, l.AsList(), "no sub-layouts defined yet")
+
+	mirrorTypes := []internal.MirrorType{
+		internal.MirrorTypeDeckhouse,
+		internal.MirrorTypeDeckhouseInstall,
+		internal.MirrorTypeDeckhouseInstallStandalone,
+		internal.MirrorTypeDeckhouseReleaseChannels,
+	}
+	for _, mt := range mirrorTypes {
+		require.NoError(t, l.setLayoutByMirrorType(tmp, mt))
+	}
+
+	require.Len(t, l.AsList(), len(mirrorTypes),
+		"every defined sub-layout must be returned by AsList")
+}

--- a/internal/mirror/platform/platform.go
+++ b/internal/mirror/platform/platform.go
@@ -105,6 +105,16 @@ type Service struct {
 	// options contains service configuration
 	options *Options
 
+	// pulledImages caches the number of image manifests that were pulled into
+	// the OCI layouts, captured before packing. Needed for Stats() which runs afterwards.
+	pulledImages int
+
+	// resolvedVersions and resolvedChannels record the release versions and
+	// channels selected by findTagsToMirror, for the end-of-pull summary. They
+	// are set before any download, so they are populated in dry-run too.
+	resolvedVersions []string
+	resolvedChannels []string
+
 	// logger is for internal debug logging
 	logger *dkplog.Logger
 	// userLogger is for user-facing informational messages
@@ -183,6 +193,11 @@ func (svc *Service) PullPlatform(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("find tags to mirror: %w", err)
 	}
+
+	// Record the resolved versions/channels for the summary. Happens before any
+	// download, so the data is available in dry-run as well.
+	svc.resolvedVersions = tagsToMirror
+	svc.resolvedChannels = channelsToMirror
 
 	svc.downloadList.FillDeckhouseImages(tagsToMirror)
 	svc.downloadList.FillForChannels(channelsToMirror)
@@ -904,6 +919,11 @@ func (svc *Service) pullDeckhousePlatform(ctx context.Context, tagsToMirror []st
 	if err != nil {
 		return fmt.Errorf("Processing image indexes: %w", err)
 	}
+
+	// Capture the manifest count before packing: bundle.Pack deletes every
+	// layout file as it tars it, so counting after the pack step would read an
+	// emptied layout and report zero.
+	svc.pulledImages = image.CountManifests(svc.layout.AsList())
 
 	if err := logger.Process("Pack Deckhouse images into platform.tar", func() error {
 		return pack.Bundle(ctx, svc.options.BundleDir, "platform.tar", svc.options.BundleChunkSize, func(w io.Writer) error {

--- a/internal/mirror/platform/stats.go
+++ b/internal/mirror/platform/stats.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+// ComponentStats is the platform phase's image accounting, mapped into the
+// top-level summary by the pull orchestrator.
+type ComponentStats struct {
+	Attempted bool
+	Images    int
+	// Versions are the resolved Deckhouse release versions to mirror (e.g.
+	// ["v1.69.0"]); Channels are the release channels mapped to them. Both are
+	// resolved by findTagsToMirror before any download, so they are populated in
+	// dry-run as well.
+	Versions []string
+	Channels []string
+}
+
+// Stats returns image accounting for the platform phase. In dry-run it reports
+// planned counts from the download list; otherwise it reports the actual number
+// of manifests pulled into the OCI layouts, captured before packing (see
+// Service.pulledImages).
+func (svc *Service) Stats() ComponentStats {
+	if svc.options.DryRun {
+		images := len(svc.downloadList.Deckhouse) +
+			len(svc.downloadList.DeckhouseInstall) +
+			len(svc.downloadList.DeckhouseInstallStandalone) +
+			len(svc.downloadList.DeckhouseReleaseChannel)
+
+		return ComponentStats{Attempted: true, Images: images, Versions: svc.resolvedVersions, Channels: svc.resolvedChannels}
+	}
+
+	return ComponentStats{Attempted: true, Images: svc.pulledImages, Versions: svc.resolvedVersions, Channels: svc.resolvedChannels}
+}

--- a/internal/mirror/pull.go
+++ b/internal/mirror/pull.go
@@ -197,44 +197,64 @@ func NewPullService(
 	}
 }
 
-// Pull downloads Deckhouse components from registry
-func (svc *PullService) Pull(ctx context.Context) error {
+// Pull downloads Deckhouse components from registry.
+//
+// It returns a PullSummary describing what was pulled (or planned, in dry-run).
+// The summary is assembled incrementally as each phase completes, and is
+// returned even on error so that callers can render a partial summary after a
+// graceful cancellation.
+func (svc *PullService) Pull(ctx context.Context) (*PullSummary, error) {
+	summary := &PullSummary{DryRun: svc.options.DryRun}
+
 	if svc.options.SkipVexImages {
 		svc.userLogger.WarnLn("The skip-vex-images flag was detected: Vulnerability scanning may not work correctly when this flag is used.")
 	}
 
-	if !svc.options.SkipPlatform {
-		err := svc.platformService.PullPlatform(ctx)
-		if err != nil {
-			return fmt.Errorf("pull platform: %w", err)
+	if svc.options.SkipPlatform {
+		summary.Platform.Skipped = true
+	} else {
+		if err := svc.platformService.PullPlatform(ctx); err != nil {
+			return summary, fmt.Errorf("pull platform: %w", err)
 		}
+
+		ps := svc.platformService.Stats()
+		summary.Platform = ComponentStats{Attempted: ps.Attempted, Images: ps.Images, Versions: ps.Versions, Channels: ps.Channels}
 	}
 
-	if !svc.options.SkipInstaller {
-		err := svc.installerService.PullInstaller(ctx)
-		if err != nil {
-			return fmt.Errorf("pull installer: %w", err)
+	if svc.options.SkipInstaller {
+		summary.Installer.Skipped = true
+	} else {
+		if err := svc.installerService.PullInstaller(ctx); err != nil {
+			return summary, fmt.Errorf("pull installer: %w", err)
 		}
+
+		is := svc.installerService.Stats()
+		summary.Installer = ComponentStats{Attempted: is.Attempted, Images: is.Images, Versions: []string{is.Tag}}
 	}
 
-	if !svc.options.SkipSecurity {
-		err := svc.securityService.PullSecurity(ctx)
-		if err != nil {
-			return fmt.Errorf("pull security databases: %w", err)
+	if svc.options.SkipSecurity {
+		summary.Security.Skipped = true
+	} else {
+		if err := svc.securityService.PullSecurity(ctx); err != nil {
+			return summary, fmt.Errorf("pull security databases: %w", err)
 		}
+
+		summary.Security = toSecurityStats(svc.securityService.Stats())
 	}
 
 	if !svc.options.SkipModules || svc.options.OnlyExtraImages {
-		err := svc.modulesService.PullModules(ctx)
-		if err != nil {
-			return fmt.Errorf("pull modules: %w", err)
+		if err := svc.modulesService.PullModules(ctx); err != nil {
+			return summary, fmt.Errorf("pull modules: %w", err)
 		}
+
+		summary.Modules = toModulesStats(svc.modulesService.Stats())
+	} else {
+		summary.Modules.Skipped = true
 	}
 
 	if !svc.options.SkipPackages || svc.options.OnlyExtraImages {
-		err := svc.packagesService.PullPackages(ctx)
-		if err != nil {
-			return fmt.Errorf("pull packages: %w", err)
+		if err := svc.packagesService.PullPackages(ctx); err != nil {
+			return summary, fmt.Errorf("pull packages: %w", err)
 		}
 	}
 
@@ -243,8 +263,37 @@ func (svc *PullService) Pull(ctx context.Context) error {
 	// packages are skipped via --no-packages. This keeps the bundle's package
 	// release metadata in sync on every mirror operation.
 	if err := svc.packagesService.PullPackageVersions(ctx); err != nil {
-		return fmt.Errorf("pull package release images: %w", err)
+		return summary, fmt.Errorf("pull package release images: %w", err)
 	}
 
-	return nil
+	return summary, nil
+}
+
+// The mapper functions below copy each service's package-local stat struct into
+// the corresponding summary type. The structs are duplicated to keep the
+// service packages decoupled from package mirror, which imports them (so the
+// dependency cannot be reversed).
+
+func toSecurityStats(s security.SecurityStats) SecurityStats {
+	return SecurityStats{
+		Attempted:          s.Attempted,
+		Available:          s.Available,
+		Databases:          s.Databases,
+		AvailableDatabases: s.AvailableDatabases,
+	}
+}
+
+func toModulesStats(s modules.ModulesStats) ModulesStats {
+	mods := make([]ModuleStat, 0, len(s.Modules))
+	for _, m := range s.Modules {
+		mods = append(mods, ModuleStat{Name: m.Name, Images: m.Images, VEX: m.VEX, Versions: m.Versions})
+	}
+
+	return ModulesStats{
+		Attempted:       s.Attempted,
+		OnlyExtraImages: s.OnlyExtraImages,
+		Modules:         mods,
+		TotalImages:     s.TotalImages,
+		TotalVEX:        s.TotalVEX,
+	}
 }

--- a/internal/mirror/pull.go
+++ b/internal/mirror/pull.go
@@ -256,6 +256,10 @@ func (svc *PullService) Pull(ctx context.Context) (*PullSummary, error) {
 		if err := svc.packagesService.PullPackages(ctx); err != nil {
 			return summary, fmt.Errorf("pull packages: %w", err)
 		}
+
+		summary.Packages = toPackagesStats(svc.packagesService.Stats())
+	} else {
+		summary.Packages.Skipped = true
 	}
 
 	// The package release-image catalog (package-versions) is always cloned
@@ -293,6 +297,21 @@ func toModulesStats(s modules.ModulesStats) ModulesStats {
 		Attempted:       s.Attempted,
 		OnlyExtraImages: s.OnlyExtraImages,
 		Modules:         mods,
+		TotalImages:     s.TotalImages,
+		TotalVEX:        s.TotalVEX,
+	}
+}
+
+func toPackagesStats(s packages.PackagesStats) PackagesStats {
+	pkgs := make([]PackageStat, 0, len(s.Packages))
+	for _, p := range s.Packages {
+		pkgs = append(pkgs, PackageStat{Name: p.Name, Images: p.Images, VEX: p.VEX, Versions: p.Versions})
+	}
+
+	return PackagesStats{
+		Attempted:       s.Attempted,
+		OnlyExtraImages: s.OnlyExtraImages,
+		Packages:        pkgs,
 		TotalImages:     s.TotalImages,
 		TotalVEX:        s.TotalVEX,
 	}

--- a/internal/mirror/pull_test.go
+++ b/internal/mirror/pull_test.go
@@ -132,7 +132,7 @@ func TestPull_EmptyRegistry_ReturnsPlatformError(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	err := svc.Pull(context.Background())
+	_, err := svc.Pull(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pull platform")
 }
@@ -146,7 +146,7 @@ func TestPull_MissingTargetTag_ReturnsPlatformError(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	err := svc.Pull(context.Background())
+	_, err := svc.Pull(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pull platform")
 	assert.Contains(t, err.Error(), "v9.99.0")
@@ -184,7 +184,7 @@ func TestPull_SuspendedChannel_ReturnsError(t *testing.T) {
 		IgnoreSuspend: false,
 	})
 
-	err := svc.Pull(context.Background())
+	_, err := svc.Pull(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pull platform")
 	assert.Contains(t, err.Error(), "suspended")
@@ -204,7 +204,10 @@ func TestPull_DefaultStub_Succeeds(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_AllChannelTags verifies Pull succeeds for each of the five
@@ -218,7 +221,10 @@ func TestPull_AllChannelTags(t *testing.T) {
 				SkipModules:   true,
 				SkipInstaller: true,
 			})
-			require.NoError(t, svc.Pull(context.Background()))
+			{
+				_, err := svc.Pull(context.Background())
+				require.NoError(t, err)
+			}
 		})
 	}
 }
@@ -232,7 +238,10 @@ func TestPull_EmptyTargetTag_FullDiscovery(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_IgnoreSuspend_AllowsSuspendedChannel verifies that
@@ -277,7 +286,10 @@ func TestPull_IgnoreSuspend_AllowsSuspendedChannel(t *testing.T) {
 		IgnoreSuspend: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_SkipPlatform_AlwaysSucceeds verifies that SkipPlatform=true
@@ -292,7 +304,10 @@ func TestPull_SkipPlatform_AlwaysSucceeds(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_SkipAll_EmptyRegistry verifies Pull succeeds when every
@@ -307,7 +322,10 @@ func TestPull_SkipAll_EmptyRegistry(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_InstallerGracefulSkip verifies that when the "installer"
@@ -321,7 +339,10 @@ func TestPull_InstallerGracefulSkip(t *testing.T) {
 		SkipInstaller: false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_SecurityGracefulSkip verifies that when the security repo is
@@ -335,7 +356,10 @@ func TestPull_SecurityGracefulSkip(t *testing.T) {
 		SkipSecurity:  false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_ModulesGracefulSkip verifies that when no modules exist in
@@ -348,7 +372,10 @@ func TestPull_ModulesGracefulSkip(t *testing.T) {
 		SkipModules:   false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_SkipVexImages_DoesNotError verifies the SkipVexImages flag
@@ -361,7 +388,10 @@ func TestPull_SkipVexImages_DoesNotError(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -375,7 +405,54 @@ func TestPull_FullStub_AllServicesActive(t *testing.T) {
 		SkipVexImages: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
+}
+
+// TestPull_FullStub_SummaryPopulated is the orchestration-level regression test
+// for the summary feature: it asserts that a real (non-dry-run) pull returns a
+// summary whose per-category counts are non-zero and survive packing. This
+// pins both the count-capture-before-pack fix (counting after bundle.Pack would
+// read emptied layouts and report zero) and the mapper functions that copy the
+// per-service stat structs into the summary.
+func TestPull_FullStub_SummaryPopulated(t *testing.T) {
+	svc := newPullService(t, fullStub(), "v1.69.0", &PullServiceOptions{
+		InstallerTag:  "v1.69.0",
+		SkipVexImages: true,
+	})
+
+	summary, err := svc.Pull(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.False(t, summary.DryRun)
+
+	// Platform: at least the deckhouse, install, install-standalone and
+	// release-channel images for v1.69.0 were pulled.
+	assert.True(t, summary.Platform.Attempted)
+	assert.False(t, summary.Platform.Skipped)
+	assert.Greater(t, summary.Platform.Images, 0,
+		"platform image count must survive packing")
+
+	// Installer: a single installer image.
+	assert.True(t, summary.Installer.Attempted)
+	assert.Equal(t, 1, summary.Installer.Images)
+
+	// Security: trivy-db is available in the stub, so the edition is reported
+	// as available with at least one database pulled.
+	assert.True(t, summary.Security.Attempted)
+	assert.True(t, summary.Security.Available)
+	assert.Equal(t, 4, summary.Security.AvailableDatabases)
+	assert.Greater(t, summary.Security.Databases, 0)
+
+	// Modules: the stub exposes two module names but no pullable version or
+	// release-channel images for them, so the phase runs (Attempted) yet pulls
+	// nothing - zero-image modules are correctly omitted from the breakdown.
+	// (Real module counting is exercised end-to-end against a live registry; the
+	// stub only carries module names, not their contents.)
+	assert.True(t, summary.Modules.Attempted)
+	assert.False(t, summary.Modules.Skipped)
 }
 
 // TestPull_FullStub_FullDiscovery verifies full-discovery mode (empty
@@ -385,7 +462,10 @@ func TestPull_FullStub_FullDiscovery(t *testing.T) {
 		SkipVexImages: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_FullStub_CustomTag verifies Pull succeeds with a custom
@@ -422,7 +502,10 @@ func TestPull_FullStub_CustomTag(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_DevRegistry_CustomTagWithNoChannels reproduces the v0.27.0 user
@@ -464,7 +547,8 @@ func TestPull_DevRegistry_CustomTagWithNoChannels(t *testing.T) {
 		SkipInstaller: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()),
+	_, pullErr := svc.Pull(context.Background())
+	require.NoError(t, pullErr,
 		"d8 mirror pull --deckhouse-tag must succeed against a dev registry without release-channel images")
 }
 
@@ -478,7 +562,10 @@ func TestPull_FullStub_InstallerPresent(t *testing.T) {
 		SkipInstaller: false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_FullStub_SecurityPresent verifies that when the security
@@ -491,7 +578,10 @@ func TestPull_FullStub_SecurityPresent(t *testing.T) {
 		SkipSecurity:  false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_FullStub_ModulesPresent verifies that when modules exist in
@@ -504,7 +594,10 @@ func TestPull_FullStub_ModulesPresent(t *testing.T) {
 		SkipModules:   false,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }
 
 // TestPull_FullStub_AllServices verifies Pull returns nil when all four
@@ -515,5 +608,8 @@ func TestPull_FullStub_AllServices(t *testing.T) {
 		SkipVexImages: true,
 	})
 
-	require.NoError(t, svc.Pull(context.Background()))
+	{
+		_, err := svc.Pull(context.Background())
+		require.NoError(t, err)
+	}
 }

--- a/internal/mirror/security/security.go
+++ b/internal/mirror/security/security.go
@@ -60,6 +60,18 @@ type Service struct {
 	// options contains service configuration
 	options *Options
 
+	// available records whether security databases exist in the source
+	// registry, as determined by securityDatabasesAvailable during
+	// PullSecurity. It is false for editions without security databases
+	// (e.g. CE, BE, SE) and feeds the end-of-pull summary.
+	available bool
+
+	// pulledDatabases caches how many of the security databases actually
+	// received at least one image, captured before packing. The pack step
+	// deletes every layout file as it tars it (see bundle.Pack), so the count
+	// must be taken before packing, not in Stats() which runs afterwards.
+	pulledDatabases int
+
 	// logger is for internal debug logging
 	logger *dkplog.Logger
 	// userLogger is for user-facing informational messages
@@ -108,6 +120,8 @@ func (svc *Service) PullSecurity(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("check security databases availability: %w", err)
 	}
+
+	svc.available = available
 
 	if !available {
 		return nil
@@ -194,6 +208,11 @@ func (svc *Service) pullSecurityDatabases(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("processing security image indexes: %w", err)
 	}
+
+	// Capture how many databases actually received images before packing:
+	// bundle.Pack deletes every layout file as it tars it, so counting after the
+	// pack step would read emptied layouts and report zero.
+	svc.pulledDatabases = svc.countPulledDatabases()
 
 	if err := logger.Process("Pack security images into security.tar", func() error {
 		return pack.Bundle(ctx, svc.options.BundleDir, "security.tar", svc.options.BundleChunkSize, func(w io.Writer) error {

--- a/internal/mirror/security/stats.go
+++ b/internal/mirror/security/stats.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+
+	regimage "github.com/deckhouse/deckhouse-cli/pkg/registry/image"
+)
+
+// securityDatabaseCount is the size of the security database catalogue:
+// trivy-db, trivy-bdu, trivy-java-db, trivy-checks.
+const securityDatabaseCount = 4
+
+// SecurityStats is the security phase's accounting, mapped into the top-level
+// summary by the pull orchestrator.
+type SecurityStats struct {
+	Attempted          bool
+	Available          bool
+	Databases          int
+	AvailableDatabases int
+}
+
+// Stats returns accounting for the security phase. It reports whether security
+// databases are available in the source edition; for available editions it
+// reports planned counts in dry-run (enqueued database sets) and actual counts
+// in a real pull (databases whose layout received at least one manifest,
+// captured before packing in Service.pulledDatabases).
+func (svc *Service) Stats() SecurityStats {
+	stats := SecurityStats{
+		Attempted:          true,
+		Available:          svc.available,
+		AvailableDatabases: securityDatabaseCount,
+	}
+
+	if !svc.available {
+		return stats
+	}
+
+	if svc.options.DryRun {
+		stats.Databases = len(svc.downloadList.Security)
+
+		return stats
+	}
+
+	stats.Databases = svc.pulledDatabases
+
+	return stats
+}
+
+// countPulledDatabases returns how many security database layouts received at
+// least one image manifest. It must run before packing deletes the layout
+// files (see bundle.Pack).
+func (svc *Service) countPulledDatabases() int {
+	count := 0
+
+	for _, l := range svc.layout.Security {
+		if l == nil {
+			continue
+		}
+
+		if regimage.CountManifests([]layout.Path{l.Path()}) > 0 {
+			count++
+		}
+	}
+
+	return count
+}

--- a/internal/mirror/summary.go
+++ b/internal/mirror/summary.go
@@ -81,6 +81,34 @@ type ModulesStats struct {
 	TotalVEX int
 }
 
+// PackageStat is one package's contribution to the pull.
+type PackageStat struct {
+	Name   string
+	Images int
+	// VEX is how many of Images are VEX attestations (a subset of Images).
+	VEX int
+	// Versions are the resolved package versions that will be (or were) pulled,
+	// e.g. ["v1.45.2", "v1.44.0"]. Available in dry-run too.
+	Versions []string
+}
+
+// PackagesStats aggregates per-package image accounting.
+type PackagesStats struct {
+	// Skipped is true when packages were disabled and OnlyExtraImages is off.
+	Skipped bool
+	// Attempted is true when the packages phase ran.
+	Attempted bool
+	// OnlyExtraImages reflects the --only-extra-images mode.
+	OnlyExtraImages bool
+	// Packages holds the per-package breakdown, sorted by name.
+	Packages []PackageStat
+	// TotalImages is the sum of images across all packages.
+	TotalImages int
+	// TotalVEX is the number of VEX attestations across all packages, a subset of
+	// TotalImages.
+	TotalVEX int
+}
+
 // BundleFile is one logical bundle artifact (platform.tar, installer.tar,
 // security.tar, module-<name>.tar), possibly spread over .NNNN.chunk files.
 type BundleFile struct {
@@ -120,6 +148,7 @@ type PullSummary struct {
 	Installer ComponentStats
 	Security  SecurityStats
 	Modules   ModulesStats
+	Packages  PackagesStats
 
 	// Bundle is populated by the CLI from the bundle directory (real pull only).
 	Bundle BundleStats

--- a/internal/mirror/summary.go
+++ b/internal/mirror/summary.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mirror
+
+import "time"
+
+// ComponentStats is the per-category image accounting captured after a pull
+// phase completes. The image count is "planned" in dry-run (download-list
+// lengths) and "actual" in a real pull (OCI layout manifest counts).
+type ComponentStats struct {
+	// Skipped is true when the category was disabled via a Skip* option.
+	Skipped bool
+	// Attempted is true when the phase ran, even if it produced zero images.
+	Attempted bool
+	// Images is the number of image manifests (planned or actual).
+	Images int
+	// Versions are the resolved release versions that will be (or were) pulled,
+	// e.g. ["v1.69.0"] or ["v1.71.7", "v1.72.3"]. Populated for the platform;
+	// available in dry-run too, since version selection happens before download.
+	Versions []string
+	// Channels is the set of release channels mapped to Versions (platform only).
+	Channels []string
+}
+
+// SecurityStats specializes ComponentStats for the trivy security databases.
+type SecurityStats struct {
+	// Skipped is true when --no-security-db was set.
+	Skipped bool
+	// Attempted is true when the security phase ran.
+	Attempted bool
+	// Available is false for editions without security databases (CE/BE/SE),
+	// where securityDatabasesAvailable() returned false.
+	Available bool
+	// Databases is the number of databases pulled (real pull) or enqueued
+	// (dry-run). At most AvailableDatabases.
+	Databases int
+	// AvailableDatabases is the size of the security database catalogue
+	// (trivy-db, trivy-bdu, trivy-java-db, trivy-checks).
+	AvailableDatabases int
+}
+
+// ModuleStat is one module's contribution to the pull.
+type ModuleStat struct {
+	Name   string
+	Images int
+	// VEX is how many of Images are VEX attestations (a subset of Images).
+	VEX int
+	// Versions are the resolved module versions that will be (or were) pulled,
+	// e.g. ["v1.10.3", "v1.9.16"]. Available in dry-run too.
+	Versions []string
+}
+
+// ModulesStats aggregates per-module image accounting.
+type ModulesStats struct {
+	// Skipped is true when modules were disabled and OnlyExtraImages is off.
+	Skipped bool
+	// Attempted is true when the modules phase ran.
+	Attempted bool
+	// OnlyExtraImages reflects the --only-extra-images mode.
+	OnlyExtraImages bool
+	// Modules holds the per-module breakdown, sorted by name.
+	Modules []ModuleStat
+	// TotalImages is the sum of images across all modules.
+	TotalImages int
+	// TotalVEX is the number of VEX attestations across all modules, a subset of
+	// TotalImages.
+	TotalVEX int
+}
+
+// BundleFile is one logical bundle artifact (platform.tar, installer.tar,
+// security.tar, module-<name>.tar), possibly spread over .NNNN.chunk files.
+type BundleFile struct {
+	// Name is the logical artifact name, e.g. "module-foo.tar".
+	Name string
+	// Bytes is the total size across all chunks of the artifact.
+	Bytes int64
+	// Chunks is the number of .chunk files (0 for a single .tar artifact).
+	Chunks int
+}
+
+// BundleStats is the on-disk artifact accounting collected after packing.
+type BundleStats struct {
+	Files      []BundleFile
+	TotalBytes int64
+}
+
+// PullSummary is the complete end-of-pull accounting handed to the renderer.
+type PullSummary struct {
+	// DryRun reports whether this was a planning run with no downloads.
+	DryRun bool
+	// Cancelled marks a graceful interrupt (Ctrl+C); the summary reflects what
+	// completed before it.
+	Cancelled bool
+	// Failed marks a hard-error abort (e.g. retries exhausted, checksum failure).
+	// The summary still renders, in a FAILED state. A phase that never ran has a
+	// zero-valued stat and renders "not pulled". Mutually exclusive with Cancelled.
+	Failed bool
+	// Edition is the source edition (e.g. "ce", "ee"), parsed from the source
+	// registry path. Empty for a custom registry with no edition segment, in
+	// which case the summary omits the Edition line.
+	Edition string
+	// Elapsed is the wall-clock duration of the pull, filled by the CLI.
+	Elapsed time.Duration
+
+	Platform  ComponentStats
+	Installer ComponentStats
+	Security  SecurityStats
+	Modules   ModulesStats
+
+	// Bundle is populated by the CLI from the bundle directory (real pull only).
+	Bundle BundleStats
+}

--- a/pkg/registry/image/layout.go
+++ b/pkg/registry/image/layout.go
@@ -213,6 +213,41 @@ func (l *ImageLayout) GetMeta(tag string) (*ImageMeta, error) {
 	return meta, nil
 }
 
+// CountManifests returns the total image-manifest count across the given layout
+// paths. It feeds the pull summary's per-phase image counts, read from the OCI
+// layouts before packing deletes them (bundle.Pack) - no extra registry call.
+// Unreadable paths (e.g. layouts absent in a dry-run) are skipped.
+func CountManifests(paths []layout.Path) int {
+	return CountManifestsMatching(paths, func(map[string]string) bool { return true })
+}
+
+// CountManifestsMatching counts manifests whose descriptor annotations satisfy
+// match. It feeds summary subsets in the same single pass - notably the VEX
+// tally (".att" short-tag). Unreadable paths are skipped, as in CountManifests.
+func CountManifestsMatching(paths []layout.Path, match func(annotations map[string]string) bool) int {
+	total := 0
+
+	for _, lp := range paths {
+		index, err := lp.ImageIndex()
+		if err != nil {
+			continue
+		}
+
+		manifest, err := index.IndexManifest()
+		if err != nil {
+			continue
+		}
+
+		for _, desc := range manifest.Manifests {
+			if match(desc.Annotations) {
+				total++
+			}
+		}
+	}
+
+	return total
+}
+
 func SplitImageRefByRepoAndTag(imageReferenceString string) (string, string) {
 	splitIndex := strings.LastIndex(imageReferenceString, ":")
 	repo := imageReferenceString[:splitIndex]

--- a/pkg/registry/image/layout_test.go
+++ b/pkg/registry/image/layout_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package image_test
 
 import (
+	"strings"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -132,4 +134,34 @@ func TestAddImage_NewDescriptorForSameTagDifferentDigest(t *testing.T) {
 	require.NotNil(t, meta.GetDigest())
 	assert.Equal(t, digestB.String(), meta.GetDigest().String(),
 		"in-memory metadata for the tag must reflect the latest AddImage call")
+}
+
+// TestCountManifestsMatching verifies that CountManifestsMatching counts only
+// the descriptors whose short-tag annotation satisfies the predicate - the
+// mechanism the summary uses to separate VEX attestations (".att" tags) from
+// regular images that share the same layout.
+func TestCountManifestsMatching(t *testing.T) {
+	l, err := regimage.NewImageLayout(t.TempDir())
+	require.NoError(t, err)
+
+	img := func(v string) v1.Image {
+		return upfake.NewImageBuilder().WithFile("version.json", `{"v":"`+v+`"}`).MustBuild()
+	}
+	// Two regular images and one VEX attestation, all in the same layout.
+	require.NoError(t, l.AddImage(wrapImage(t, img("a"), "example.io/repo:v1.0.0"), "v1.0.0"))
+	require.NoError(t, l.AddImage(wrapImage(t, img("b"), "example.io/repo:v2.0.0"), "v2.0.0"))
+	require.NoError(t, l.AddImage(wrapImage(t, img("c"), "example.io/repo:sha256-abc.att"), "sha256-abc.att"))
+
+	paths := []layout.Path{l.Path()}
+
+	assert.Equal(t, 3, regimage.CountManifests(paths),
+		"CountManifests must count every manifest")
+
+	vex := regimage.CountManifestsMatching(paths, func(a map[string]string) bool {
+		return strings.HasSuffix(a[regimage.AnnotationImageShortTag], ".att")
+	})
+	assert.Equal(t, 1, vex, "only the .att manifest must match the VEX predicate")
+
+	none := regimage.CountManifestsMatching(paths, func(map[string]string) bool { return false })
+	assert.Equal(t, 0, none, "a never-true predicate matches nothing")
 }


### PR DESCRIPTION
# [mirror] Add an end-of-pull summary to `d8 mirror pull`

## ℹ️ What

Prints a short, framed summary at the end of every `d8 mirror pull` (and `--dry-run`):
what was pulled (or, in dry-run, what will be) - platform, installer, security databases,
modules and packages. 

A `--verbose-summary` flag adds a per-module and per-package breakdown with their resolved versions.

## ❓ Why

Before this, a pull ended with hundreds of `Pulling ...@sha256:...` lines and no recap.
To learn the one thing we actually need - **which releases, module and package
versions will be mirrored** (and whether the bundle is complete) - you had to scroll the log.

The original ask was exactly that: in `--dry-run`, see which platform release and which
module/package versions will be pulled, honouring all filters (`--include-module` /
`--exclude-module` / `--include-package` / `--no-platform` / `--include-platform` / ...),
without reading sha lines.

## 📝 How it works

- Each phase (platform / installer / security / modules / packages) records what it
  resolved/pulled - versions, VEX attestations, bundle sizes - from data the pull
  **already has**. No extra registry requests.
- Counts are taken **before packing** (packing deletes the layouts as it tars them).
- The summary renders on every outcome, so you always see what landed:
  - success and dry-run,
  - `Ctrl+C` -> partial summary, marked cancelled,
  - a hard failure (e.g. network died) -> partial summary, marked **FAILED**, then the error.
  A phase that never ran shows `not pulled`.
- Colour is semantic and only when attached to a terminal; pipes and files get plain text
  (set `FORCE_COLOR=1` to force colour into a file).

---

## 📊 What the summary shows

- **Edition** - the source edition (`CE`/`EE`/...), parsed from the source path; omitted for
  a custom registry with no edition segment.
- **Platform** - the release version(s), and how many channels they map to.
- **Installer** - its tag (`latest` or a pinned `--installer-tag`).
- **Security** - `N/M databases` (green when complete, yellow when partial).
- **Modules** - module count and the total VEX; with `--verbose-summary`, each module's
  versions and VEX count.
- **Packages** - same as modules, for Deckhouse packages: package count and total VEX; with
  `--verbose-summary`, each package's versions and VEX count.
- **Bundle** (real pull) - each artifact with its size and chunk count, plus a `TOTAL`.
  Package archives (`package-<name>.tar`, the shared `package-versions.tar`) are listed here
  automatically.

**Versions are sorted newest-first** (semver) everywhere they appear.
(See examples below)

---

## 🔄 Before / after

**Before** - the run just ended with the streaming log; no recap:
```
... [318/319] Pulling registry.../modules/code@sha256:...  succeeded
... [319/319] Pulling registry.../modules/code@sha256:...  succeeded
```

### Pull packages 

```bash
FORCE_COLOR=1 d8 mirror pull \
      --source dev-registry.deckhouse.io/sys/deckhouse-oss \
      --no-platform --no-security-db --no-modules --no-installer \
      --include-package 'boardmaps@>=0.0.0' \
      --include-package 'cossacks-server@>=0.0.0' \
      --verbose-summary \
      <bundle-dir>
```
<img width="1662" height="804" alt="2026-06-04 AT 11 25@2x" src="https://github.com/user-attachments/assets/8b7165c5-e2e7-43cc-a326-8e24aa2b7019" />

### Different platform

```bash
FORCE_COLOR=1 d8 mirror pull \
      --source registry.deckhouse.ru/deckhouse/ee \
      --include-platform '>=v1.71.0 <v1.76.0' --no-modules --dry-run --verbose-summary \
      <bundle-dir>
```
<img width="1730" height="446" alt="2026-06-04 AT 11 26@2x" src="https://github.com/user-attachments/assets/55bdd9c0-d1c6-4292-bd3b-55bfb1059e77" />

### Dry-Run for Community Edition

```bash
FORCE_COLOR=1 d8 mirror pull \
      --source registry.deckhouse.ru/deckhouse/ce \
      --dry-run --verbose-summary \
      <bundle-dir>
```
<img width="1530" height="1290" alt="2026-06-04 AT 11 27@2x" src="https://github.com/user-attachments/assets/320a608d-5271-45de-9893-30f7944c5c3f" />


### Dry-Run for Enterprise Edition

```bash
FORCE_COLOR=1 d8 mirror pull \
      --source registry.deckhouse.ru/deckhouse/ee \
      --dry-run --verbose-summary \
      <bundle-dir>
```
<img width="1542" height="2414" alt="2026-06-04 AT 11 28@2x" src="https://github.com/user-attachments/assets/350c288a-002d-415f-878b-f17c46ca3547" />


---

## ✏️ Main changes

- New summary model and renderer (formatting only; emitted through the existing logger).
- `Pull()` now returns `(*PullSummary, error)` - always a non-nil summary, so a partial run
  (cancel or hard error) still renders instead of showing only a raw error.
- Per-phase `Stats()` that captures counts/versions before packing, for modules **and
  packages**.
- `--verbose-summary` flag (output only - it does not change what is pulled).
- Counting helpers in `pkg/registry/image` (manifest count + a matched subset for VEX).
- Two latent bugs fixed while wiring this up: platform `AsList()` returned empty (reflection
  looked for the wrong field type), and dry-run under-counted module versions.

---

## ℹ️ Also: packages mirroring no longer crashes on registries without packages

While adding the packages summary, surfaced and fixed a regression from the packages
mirroring support (#376): the packages phase failed the **whole** pull against any registry
that has no `/packages` repository - including the public `registry.deckhouse.ru/deckhouse/ee`
and `/ce`. The intended graceful-skip only matched `ErrImageNotFound`, but a missing repo is
reported as a `NAME_UNKNOWN` transport error.

Fix: treat `NAME_UNKNOWN` the same as `ErrImageNotFound` ("no packages here, skip the phase")
in both `validatePackagesAccess` and `discoverPackageNames`, mirroring the already-graceful
`PullPackageVersions`. With this, a pull against a packages-less registry succeeds and the
summary simply shows `Packages: 0 packages`.

---

## 🧪 Tests

- Unit: rendering in every state (dry-run / cancelled / failed / not-pulled / verbose / VEX /
  versions) for modules and packages, semver sorting, colour gating, the counting helpers,
  and outcome classification.
- Packages `Stats()`: dry-run accounting and the before-packing capture (the count must
  survive packing).
- Regression for the graceful-skip fix: a missing `/packages` repo (both `NAME_UNKNOWN` and
  `ErrImageNotFound`) skips the phase instead of failing the pull.
- Verified end-to-end against real registries: dry-run and real pulls render the expected
  versions / VEX / sizes (including a real packages pull); the summary adds no registry requests.