### PR TITLE
[deckhouse-cli] update build image to container factory for golang 1.25

### DIFF
--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,4 +1,4 @@
-dockerImage: registry.deckhouse.io/base_images@sha256:4aaf81659fa6ea3cbbb0f241d739dda485bce79ec98b0fd5014ef4f4210e1cd5 # from: golang:1.25.8-bookworm
+dockerImage: registry.deckhouse.io/container-factory@sha256:dcd95c2001daf929cb87dee34f9d9899ed2572456312ad57ea23a72f1dd4ab39 # from: builder/golang-debian-1.25 (debian:13.1)
 commands:
   - export TASK_VERSION=v3.41.0
   - export TASK_SHA256=0a2595f7fa3c15a62f8d0c244121a4977018b3bfdec7c1542ac2a8cf079978b8


### PR DESCRIPTION
Migrate trdl build image to container-factory base images

Replace the legacy registry.deckhouse.io/base_images golang image with builder/golang-debian-1.25 from the container-factory registry (v1.0.40)