### PR TITLE
feat(snapshot): kind-based DataImport targetRef, snapshot CRUD commands, and full-tree aggregator import

### DIFF
--- a/docs/CHEATSHEET_E2E.md
+++ b/docs/CHEATSHEET_E2E.md
@@ -118,6 +118,13 @@ kubectl create namespace "$TARGET_NS" 2>/dev/null || true
 ~/demo/d8/builds/d8-dev snapshot restore "$SNAP" -n "$TARGET_NS" --wait --timeout 15m
 ```
 
+Под капотом `import` помечает каждый воссоздаваемый узел унифицированным маркером
+`spec.source.import: {}` (имя `DataImport` на листе не хранится) и на каждый data-leaf создаёт
+`DataImport` с `targetRef.{group,kind,name}` на этот лист (kind = вид листа-снимка, например
+`VolumeSnapshot`) плюс параметры тома `storageClassName`/`size`/`volumeMode` прямо в `spec`
+(берутся из архива). state-snapshotter находит `DataImport` обратным поиском по `targetRef` и
+дожидается durable `VolumeSnapshotContent`.
+
 Ограничения текущей реализации:
 
 - импортируются только деревья core `Snapshot` и data-leaf'ы CSI `VolumeSnapshot` (блочные

--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -92,22 +92,23 @@ func AskYesNoWithTimeout(prompt string, timeout time.Duration) bool {
 	}
 }
 
-// KindToGroupResource resolves the API group and plural resource name for a supported
-// DataExport target kind. These values match the producer's DataExportTargetRefSpec
-// contract in storage-volume-data-manager/api/v1alpha1/data_export.go.
+// KindToGroup resolves the API group for a supported DataExport target kind. The kind is
+// sent verbatim as targetRef.kind; only the group needs deriving here (the controller
+// resolves the served version via its RESTMapper). These groups match the producer's
+// DataExportTargetRefSpec contract in storage-volume-data-manager/api/v1alpha1/data_export.go.
 // Returns an error for unrecognised kinds.
-func KindToGroupResource(kind string) (string, string, error) {
+func KindToGroup(kind string) (string, error) {
 	switch kind {
 	case PersistentVolumeClaimKind:
-		return "", "persistentvolumeclaims", nil
+		return "", nil
 	case VolumeSnapshotKind:
-		return "snapshot.storage.k8s.io", "volumesnapshots", nil
+		return "snapshot.storage.k8s.io", nil
 	case VirtualDiskKind:
-		return "virtualization.deckhouse.io", "virtualdisks", nil
+		return "virtualization.deckhouse.io", nil
 	case VirtualDiskSnapshotKind:
-		return "virtualization.deckhouse.io", "virtualdisksnapshots", nil
+		return "virtualization.deckhouse.io", nil
 	default:
-		return "", "", fmt.Errorf("unsupported DataExport target kind %q", kind)
+		return "", fmt.Errorf("unsupported DataExport target kind %q", kind)
 	}
 }
 

--- a/internal/data/dataexport/README.md
+++ b/internal/data/dataexport/README.md
@@ -1,6 +1,16 @@
 # DataExport
 Subcommand for the command line client for Deckhouse.
 
+The export target is referenced by **kind** (`targetRef.kind`, the API group is
+derived from it). Supported target kinds and their CLI aliases:
+
+| Kind | Aliases |
+| --- | --- |
+| `PersistentVolumeClaim` | `pvc`, `persistentvolumeclaim` |
+| `VolumeSnapshot` | `vs`, `volumesnapshot` |
+| `VirtualDisk` | `vd`, `virtualdisk` |
+| `VirtualDiskSnapshot` | `vds`, `virtualdisksnapshot` |
+
 ### Available Commands:
 * create      - Create k8s DataExport object.
 
@@ -61,5 +71,5 @@ NAMESPACE       NAME                  READYTOUSE   SOURCEPVC                    
 
 5. Create data export from that snapshot using d8 command as shown in the example below 
 ```shell
-d8 data create export-name snapshot/my-snapshot
+d8 data create export-name vs/my-snapshot
 ```

--- a/internal/data/dataexport/api/v1alpha1/data_export.go
+++ b/internal/data/dataexport/api/v1alpha1/data_export.go
@@ -41,7 +41,7 @@ type DataExportStatus struct {
 	VolumeMode      string             `json:"volumeMode,omitempty"`
 }
 
-// TargetRefSpec references the export target by GroupResource + name (namespace is
+// TargetRefSpec references the export target by GroupKind + name (namespace is
 // implicit = the DataExport's own namespace). The version is intentionally NOT pinned:
 // the controller resolves the served version via the RESTMapper. Mirrors the producer's
 // DataExportTargetRefSpec in storage-volume-data-manager/api/v1alpha1/data_export.go.
@@ -50,8 +50,9 @@ type DataExportStatus struct {
 type TargetRefSpec struct {
 	// Group is the API group of the target resource ("" = core group).
 	Group string `json:"group,omitempty"`
-	// Resource is the plural resource name (e.g. "volumesnapshots"). Required by the API server.
-	Resource string `json:"resource"`
+	// Kind is the target object kind (e.g. "VolumeSnapshot", "PersistentVolumeClaim").
+	// Required by the API server.
+	Kind string `json:"kind"`
 	// Name is the target object name.
 	Name string `json:"name"`
 }

--- a/internal/data/dataexport/cmd/create/create.go
+++ b/internal/data/dataexport/cmd/create/create.go
@@ -132,12 +132,12 @@ func Run(ctx context.Context, log *slog.Logger, cmd *cobra.Command, args []strin
 		return err
 	}
 
-	group, resource, err := dataio.KindToGroupResource(volumeKind)
+	group, err := dataio.KindToGroup(volumeKind)
 	if err != nil {
 		return err
 	}
 
-	err = util.CreateDataExport(ctx, deName, namespace, ttl, group, resource, volumeName, publish, rtClient)
+	err = util.CreateDataExport(ctx, deName, namespace, ttl, group, volumeKind, volumeName, publish, rtClient)
 	if err != nil {
 		return err
 	}

--- a/internal/data/dataexport/util/util.go
+++ b/internal/data/dataexport/util/util.go
@@ -92,7 +92,7 @@ func GetDataExportWithRestart(ctx context.Context, deName, namespace string, rtC
 						ctx,
 						deName, namespace, "",
 						deObj.Spec.TargetRef.Group,
-						deObj.Spec.TargetRef.Resource,
+						deObj.Spec.TargetRef.Kind,
 						deObj.Spec.TargetRef.Name,
 						deObj.Spec.Publish, rtClient,
 					); err != nil {
@@ -195,12 +195,12 @@ func CreateDataExporterIfNeeded(ctx context.Context, log *slog.Logger, deName, n
 		return deName, nil
 	}
 
-	group, resource, err := dataio.KindToGroupResource(volumeKind)
+	group, err := dataio.KindToGroup(volumeKind)
 	if err != nil {
 		return deName, err
 	}
 
-	err = CreateDataExport(ctx, deName, namespace, ttl, group, resource, volumeName, publish, rtClient)
+	err = CreateDataExport(ctx, deName, namespace, ttl, group, volumeKind, volumeName, publish, rtClient)
 	if err != nil {
 		return deName, err
 	}
@@ -210,10 +210,10 @@ func CreateDataExporterIfNeeded(ctx context.Context, log *slog.Logger, deName, n
 	return deName, nil
 }
 
-// CreateDataExport creates a DataExport CR targeting the resource identified by group, resource, and volumeName.
+// CreateDataExport creates a DataExport CR targeting the object identified by group, kind, and volumeName.
 // group is the API group ("" for core, e.g. "snapshot.storage.k8s.io" for VolumeSnapshot).
-// resource is the plural resource name (e.g. "volumesnapshots", "persistentvolumeclaims").
-func CreateDataExport(ctx context.Context, deName, namespace, ttl, group, resource, volumeName string, publish bool, rtClient ctrlrtclient.Client) error {
+// kind is the target object kind (e.g. "VolumeSnapshot", "PersistentVolumeClaim").
+func CreateDataExport(ctx context.Context, deName, namespace, ttl, group, kind, volumeName string, publish bool, rtClient ctrlrtclient.Client) error {
 	if ttl == "" {
 		ttl = dataio.DefaultTTL
 	}
@@ -231,9 +231,9 @@ func CreateDataExport(ctx context.Context, deName, namespace, ttl, group, resour
 		Spec: v1alpha1.DataexportSpec{
 			TTL: ttl,
 			TargetRef: v1alpha1.TargetRefSpec{
-				Group:    group,
-				Resource: resource,
-				Name:     volumeName,
+				Group: group,
+				Kind:  kind,
+				Name:  volumeName,
 			},
 			Publish: publish,
 		},
@@ -301,8 +301,13 @@ func getExportStatus(ctx context.Context, log *slog.Logger, deName, namespace st
 		return "", "", "", fmt.Errorf("invalid URL")
 	}
 
-	if !slices.Contains([]string{"persistentvolumeclaims", "volumesnapshots", "virtualdisks", "virtualdisksnapshots"}, deObj.Spec.TargetRef.Resource) {
-		return "", "", "", fmt.Errorf("invalid volume resource: %s", deObj.Spec.TargetRef.Resource)
+	if !slices.Contains([]string{
+		dataio.PersistentVolumeClaimKind,
+		dataio.VolumeSnapshotKind,
+		dataio.VirtualDiskKind,
+		dataio.VirtualDiskSnapshotKind,
+	}, deObj.Spec.TargetRef.Kind) {
+		return "", "", "", fmt.Errorf("invalid volume kind: %s", deObj.Spec.TargetRef.Kind)
 	}
 
 	volumeMode = deObj.Status.VolumeMode

--- a/internal/data/dataexport/util/util_test.go
+++ b/internal/data/dataexport/util/util_test.go
@@ -34,44 +34,44 @@ func TestCreateDataExporterIfNeeded(t *testing.T) {
 	logger := slog.Default()
 
 	tests := []struct {
-		name           string
-		input          string
-		expectName     string
-		expectGroup    string
-		expectResource string
-		expectCreated  bool
+		name          string
+		input         string
+		expectName    string
+		expectGroup   string
+		expectKind    string
+		expectCreated bool
 	}{
 		{
-			name:           "PVC short alias",
-			input:          "pvc/myvol",
-			expectName:     "de-pvc-myvol",
-			expectGroup:    "",
-			expectResource: "persistentvolumeclaims",
-			expectCreated:  true,
+			name:          "PVC short alias",
+			input:         "pvc/myvol",
+			expectName:    "de-pvc-myvol",
+			expectGroup:   "",
+			expectKind:    "PersistentVolumeClaim",
+			expectCreated: true,
 		},
 		{
-			name:           "PVC long alias",
-			input:          "persistentvolumeclaim/myvol",
-			expectName:     "de-pvc-myvol",
-			expectGroup:    "",
-			expectResource: "persistentvolumeclaims",
-			expectCreated:  true,
+			name:          "PVC long alias",
+			input:         "persistentvolumeclaim/myvol",
+			expectName:    "de-pvc-myvol",
+			expectGroup:   "",
+			expectKind:    "PersistentVolumeClaim",
+			expectCreated: true,
 		},
 		{
-			name:           "VolumeSnapshot short alias",
-			input:          "vs/snap1",
-			expectName:     "de-vs-snap1",
-			expectGroup:    "snapshot.storage.k8s.io",
-			expectResource: "volumesnapshots",
-			expectCreated:  true,
+			name:          "VolumeSnapshot short alias",
+			input:         "vs/snap1",
+			expectName:    "de-vs-snap1",
+			expectGroup:   "snapshot.storage.k8s.io",
+			expectKind:    "VolumeSnapshot",
+			expectCreated: true,
 		},
 		{
-			name:           "VolumeSnapshot long alias",
-			input:          "volumesnapshot/snap1",
-			expectName:     "de-vs-snap1",
-			expectGroup:    "snapshot.storage.k8s.io",
-			expectResource: "volumesnapshots",
-			expectCreated:  true,
+			name:          "VolumeSnapshot long alias",
+			input:         "volumesnapshot/snap1",
+			expectName:    "de-vs-snap1",
+			expectGroup:   "snapshot.storage.k8s.io",
+			expectKind:    "VolumeSnapshot",
+			expectCreated: true,
 		},
 		{
 			name:          "Existing DataExport name",
@@ -80,36 +80,36 @@ func TestCreateDataExporterIfNeeded(t *testing.T) {
 			expectCreated: false,
 		},
 		{
-			name:           "VirtualDisk short alias",
-			input:          "vd/mydisk",
-			expectName:     "de-vd-mydisk",
-			expectGroup:    "virtualization.deckhouse.io",
-			expectResource: "virtualdisks",
-			expectCreated:  true,
+			name:          "VirtualDisk short alias",
+			input:         "vd/mydisk",
+			expectName:    "de-vd-mydisk",
+			expectGroup:   "virtualization.deckhouse.io",
+			expectKind:    "VirtualDisk",
+			expectCreated: true,
 		},
 		{
-			name:           "VirtualDisk long alias",
-			input:          "virtualdisk/mydisk",
-			expectName:     "de-vd-mydisk",
-			expectGroup:    "virtualization.deckhouse.io",
-			expectResource: "virtualdisks",
-			expectCreated:  true,
+			name:          "VirtualDisk long alias",
+			input:         "virtualdisk/mydisk",
+			expectName:    "de-vd-mydisk",
+			expectGroup:   "virtualization.deckhouse.io",
+			expectKind:    "VirtualDisk",
+			expectCreated: true,
 		},
 		{
-			name:           "VirtualDiskSnapshot short alias",
-			input:          "vds/snap2",
-			expectName:     "de-vds-snap2",
-			expectGroup:    "virtualization.deckhouse.io",
-			expectResource: "virtualdisksnapshots",
-			expectCreated:  true,
+			name:          "VirtualDiskSnapshot short alias",
+			input:         "vds/snap2",
+			expectName:    "de-vds-snap2",
+			expectGroup:   "virtualization.deckhouse.io",
+			expectKind:    "VirtualDiskSnapshot",
+			expectCreated: true,
 		},
 		{
-			name:           "VirtualDiskSnapshot long alias",
-			input:          "virtualdisksnapshot/snap2",
-			expectName:     "de-vds-snap2",
-			expectGroup:    "virtualization.deckhouse.io",
-			expectResource: "virtualdisksnapshots",
-			expectCreated:  true,
+			name:          "VirtualDiskSnapshot long alias",
+			input:         "virtualdisksnapshot/snap2",
+			expectName:    "de-vds-snap2",
+			expectGroup:   "virtualization.deckhouse.io",
+			expectKind:    "VirtualDiskSnapshot",
+			expectCreated: true,
 		},
 	}
 
@@ -126,7 +126,7 @@ func TestCreateDataExporterIfNeeded(t *testing.T) {
 			if tt.expectCreated {
 				require.NoError(t, getErr)
 				require.Equal(t, tt.expectGroup, de.Spec.TargetRef.Group)
-				require.Equal(t, tt.expectResource, de.Spec.TargetRef.Resource)
+				require.Equal(t, tt.expectKind, de.Spec.TargetRef.Kind)
 				require.Equal(t, "2m", de.Spec.TTL)
 			} else {
 				require.True(t, apierrors.IsNotFound(getErr))

--- a/internal/data/dataimport/README.md
+++ b/internal/data/dataimport/README.md
@@ -1,6 +1,15 @@
 # DataImport
 Subcommand for the Deckhouse CLI to create/import/delete data via DataImport resources.
 
+This command drives the **standalone PVC import** mode of `DataImport`
+(`targetRef.kind: PersistentVolumeClaim`): the target PVC is fully defined by the
+PVC template you pass to `create`, data is uploaded straight into it, and no
+snapshot/`VolumeSnapshotContent` artifact is produced. (The snapshot-leaf import
+mode is driven separately by `d8 snapshot import`.)
+
+The PVC template **must** carry `metadata.name` — the DataImport targets the PVC by
+that name; `create` rejects a template without it before contacting the API server.
+
 ### Available Commands
 - create    – ensure PVC (from template) and create DataImport
 - upload    – upload file contents to the DataImport endpoint

--- a/internal/data/dataimport/api/v1alpha1/data_import.go
+++ b/internal/data/dataimport/api/v1alpha1/data_import.go
@@ -40,6 +40,17 @@ type DataImportList struct {
 	Items []DataImport `json:"items"`
 }
 
+// KindPersistentVolumeClaim is the targetRef.kind discriminator value that selects the
+// standalone PVC-import mode (Mode B) of the unified storage.deckhouse.io/v1alpha1 DataImport
+// CRD: data bytes are streamed straight into a PVC built from pvcTemplate, with no snapshot
+// capture and no VolumeSnapshotContent artifact. `d8 data import` only ever creates Mode B
+// DataImports; the snapshot-leaf import mode (Mode A) is driven by `d8 snapshot import`.
+const KindPersistentVolumeClaim = "PersistentVolumeClaim"
+
+// DataImportSpec mirrors the Mode B subset of the unified DataImport CRD spec that the CLI
+// produces. Mode B carries no root storageClassName/size/volumeMode (those live in pvcTemplate)
+// and no targetRef.group/name; the server's CEL rules reject those fields when
+// targetRef.kind == PersistentVolumeClaim.
 // +k8s:deepcopy-gen=true
 type DataImportSpec struct {
 	TTL                  string                  `json:"ttl"`
@@ -48,6 +59,9 @@ type DataImportSpec struct {
 	TargetRef            DataImportTargetRefSpec `json:"targetRef"`
 }
 
+// DataImportTargetRefSpec is the Mode B view of the unified targetRef: Kind is always
+// KindPersistentVolumeClaim and PvcTemplate fully describes the destination PVC (its
+// metadata.name is mandatory — the controller names the imported PVC after it).
 // +k8s:deepcopy-gen=true
 type DataImportTargetRefSpec struct {
 	Kind        string                             `json:"kind"`

--- a/internal/data/dataimport/util/util.go
+++ b/internal/data/dataimport/util/util.go
@@ -70,6 +70,13 @@ func CreateDataImport(
 		ttl = dataio.DefaultTTL
 	}
 
+	// Mode B requires a pvcTemplate whose metadata.name is set: the controller names the
+	// imported PVC after it, and the server CEL rejects an empty name. Fail early with a
+	// clear message instead of surfacing an opaque admission error.
+	if pvcTpl == nil || pvcTpl.Name == "" {
+		return fmt.Errorf("DataImport %s/%s requires a PVC template with metadata.name set", namespace, name)
+	}
+
 	obj := &v1alpha1.DataImport{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -84,7 +91,7 @@ func CreateDataImport(
 			Publish:              publish,
 			WaitForFirstConsumer: waitForFirstConsumer,
 			TargetRef: v1alpha1.DataImportTargetRefSpec{
-				Kind:        "PersistentVolumeClaim",
+				Kind:        v1alpha1.KindPersistentVolumeClaim,
 				PvcTemplate: pvcTpl,
 			},
 		},

--- a/internal/data/dataimport/util/util_test.go
+++ b/internal/data/dataimport/util/util_test.go
@@ -30,6 +30,53 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/data/dataimport/api/v1alpha1"
 )
 
+func TestCreateDataImport_BuildsModeBSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pvcTpl := &v1alpha1.PersistentVolumeClaimTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Name: "restored-pvc"},
+	}
+
+	require.NoError(t, CreateDataImport(ctx, "import-into-pvc", "my-ns", "15m", false, true, pvcTpl, c))
+
+	var stored v1alpha1.DataImport
+	require.NoError(t, c.Get(ctx, ctrlclient.ObjectKey{Name: "import-into-pvc", Namespace: "my-ns"}, &stored))
+
+	assert.Equal(t, v1alpha1.KindPersistentVolumeClaim, stored.Spec.TargetRef.Kind)
+	assert.Equal(t, "15m", stored.Spec.TTL)
+	assert.True(t, stored.Spec.WaitForFirstConsumer)
+	require.NotNil(t, stored.Spec.TargetRef.PvcTemplate)
+	assert.Equal(t, "restored-pvc", stored.Spec.TargetRef.PvcTemplate.Name)
+}
+
+func TestCreateDataImport_RejectsTemplateWithoutName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cases := map[string]*v1alpha1.PersistentVolumeClaimTemplateSpec{
+		"nil template":      nil,
+		"template w/o name": {},
+	}
+
+	for name, tpl := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := CreateDataImport(ctx, "di", "my-ns", "15m", false, false, tpl, c)
+			require.Error(t, err)
+
+			var stored v1alpha1.DataImport
+			getErr := c.Get(ctx, ctrlclient.ObjectKey{Name: "di", Namespace: "my-ns"}, &stored)
+			require.Error(t, getErr, "no DataImport should be created when the PVC template is invalid")
+		})
+	}
+}
+
 func TestEnsureDataImportPublish(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1alpha1.AddToScheme(scheme))

--- a/internal/snapshot/aggapi/client.go
+++ b/internal/snapshot/aggapi/client.go
@@ -279,30 +279,27 @@ func (c *Client) resourceFor(ref NodeRef) (string, error) {
 	return mapping.Resource.Resource, nil
 }
 
-// LeafDataExportTarget resolves the DataExport targetRef {group, resource} for a snapshot
-// leaf node. CSI VolumeSnapshot leaves use the fixed constants VolumeSnapshotGroup /
-// VolumeSnapshotResource. All other kinds are resolved via the RESTMapper.
+// LeafDataExportTarget resolves the DataExport targetRef {group, kind} for a snapshot leaf
+// node. CSI VolumeSnapshot leaves use the fixed constants VolumeSnapshotGroup /
+// VolumeSnapshotKind; all other kinds derive group from the leaf's apiVersion and use its
+// own kind directly (the controller resolves the served version via its RESTMapper, so no
+// resource-plural lookup is needed here).
 //
 // This is used to build a DataExport that the storage-volume-data-manager controller
-// can route through its resource-agnostic snapshot export path (categorySnapshot):
-// group/resource must identify a namespaced snapshot CR so the controller can read
+// can route through its kind-agnostic snapshot export path (categorySnapshot):
+// group/kind must identify a namespaced snapshot CR so the controller can read
 // its status.boundSnapshotContentName → SnapshotContent → status.dataRef.
 func (c *Client) LeafDataExportTarget(ref NodeRef) (string, string, error) {
+	if ref.IsVolumeSnapshotLeaf() {
+		return VolumeSnapshotGroup, VolumeSnapshotKind, nil
+	}
+
 	gv, err := schema.ParseGroupVersion(ref.APIVersion)
 	if err != nil {
 		return "", "", fmt.Errorf("parse apiVersion %q: %w", ref.APIVersion, err)
 	}
 
-	if ref.IsVolumeSnapshotLeaf() {
-		return VolumeSnapshotGroup, VolumeSnapshotResource, nil
-	}
-
-	res, err := c.resourceFor(ref)
-	if err != nil {
-		return "", "", err
-	}
-
-	return gv.Group, res, nil
+	return gv.Group, ref.Kind, nil
 }
 
 // subresourceGroupVersion returns the aggregated subresource group and version that

--- a/internal/snapshot/archive/snapshot_yaml.go
+++ b/internal/snapshot/archive/snapshot_yaml.go
@@ -102,6 +102,15 @@ type VolumeInfo struct {
 	Target VolumeObjectRef `json:"target"`
 	// Artifact is the VolumeSnapshotContent that holds the durable data artifact.
 	Artifact VolumeObjectRef `json:"artifact"`
+	// VolumeMode records the source volume mode (Block or Filesystem). It feeds the
+	// DataImport spec.volumeMode when re-importing this leaf (Mode A).
+	VolumeMode string `json:"volumeMode,omitempty"`
+	// StorageClassName records the source StorageClass of the captured volume. It feeds
+	// the DataImport spec.storageClassName when re-importing this leaf (Mode A).
+	StorageClassName string `json:"storageClassName,omitempty"`
+	// Size records the real allocated size of the captured volume (e.g. "10Gi"), taken from
+	// VolumeSnapshotContent.status.restoreSize. It feeds the DataImport spec.size on re-import.
+	Size string `json:"size,omitempty"`
 }
 
 // NodeChecksum is the locally-computed integrity digest for one node directory.

--- a/internal/snapshot/cmd/create/create.go
+++ b/internal/snapshot/cmd/create/create.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package create implements the `d8 snapshot create` command: it creates a
+// Snapshot object in a namespace, optionally narrowing the captured set with a
+// label selector and waiting until the Snapshot becomes Ready.
+package create
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	snapshotapi "github.com/deckhouse/deckhouse-cli/internal/snapshot/api/v1alpha1"
+	"github.com/deckhouse/deckhouse-cli/internal/system/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+)
+
+const (
+	cmdUse = "create"
+
+	flagNamespace     = "namespace"
+	flagSnapshotClass = "snapshot-class"
+	flagSelector      = "selector"
+	flagWait          = "wait"
+	flagTimeout       = "timeout"
+	flagOutput        = "output"
+	flagKubeconfig    = "kubeconfig"
+	flagContext       = "context"
+
+	// readyConditionType is the status condition reporting overall Snapshot
+	// readiness; it matches the type used by list/restore.
+	readyConditionType = "Ready"
+
+	defaultWaitTimeout = 5 * time.Minute
+	pollInterval       = 2 * time.Second
+)
+
+// snapshotGVR is the dynamic resource for storage.deckhouse.io Snapshots.
+var snapshotGVR = schema.GroupVersionResource{
+	Group:    snapshotapi.StorageGroup,
+	Version:  snapshotapi.Version,
+	Resource: "snapshots",
+}
+
+// createOptions bundles the resolved inputs for one create run so the cluster
+// logic stays decoupled from cobra flag plumbing (and unit-testable).
+type createOptions struct {
+	namespace     string
+	name          string
+	snapshotClass string
+	matchLabels   map[string]interface{}
+	wait          bool
+	timeout       time.Duration
+	poll          time.Duration
+	outputFmt     string
+}
+
+// NewCommand builds the `d8 snapshot create` cobra command.
+func NewCommand(log *slog.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           cmdUse + " <name>",
+		Short:         "Create a Snapshot of a namespace",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		Long: `Create a Snapshot object that captures a namespace's state/configuration.
+
+The Snapshot is created in the target namespace (defaults to the kubeconfig context
+namespace). An empty selector captures the whole namespace; pass --selector to capture
+only the objects matching the given labels (sets spec.resourceSelector.matchLabels).
+
+The Snapshot is reconciled asynchronously by the state-snapshotter controller. Use --wait
+to block until it reports Ready, after which it can be listed, downloaded, and imported.`,
+		Example: `  # Snapshot the whole "default" namespace and wait until it is Ready
+  d8 snapshot create my-snap -n default --wait
+
+  # Snapshot only the objects labeled app=demo
+  d8 snapshot create my-snap -n demo -l app=demo
+
+  # Print the created object as YAML
+  d8 snapshot create my-snap -n demo -o yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Run(log, cmd, args)
+		},
+	}
+
+	// Reuse the standard kubeconfig/context flags (same as the other snapshot
+	// subcommands), so NewDynamicClient and KubeconfigNamespace can read them.
+	flags.AddPersistentFlags(cmd)
+
+	cmd.Flags().StringP(flagNamespace, "n", "", "namespace to create the Snapshot in (defaults to the kubeconfig context namespace)")
+	cmd.Flags().String(flagSnapshotClass, "", "SnapshotClass name to set on spec.snapshotClassName (optional)")
+	cmd.Flags().StringP(flagSelector, "l", "", "capture only objects matching this label selector (e.g. app=demo,tier=db); sets spec.resourceSelector.matchLabels")
+	cmd.Flags().Bool(flagWait, false, "wait until the Snapshot reports Ready")
+	cmd.Flags().Duration(flagTimeout, defaultWaitTimeout, "timeout for --wait")
+	utilk8s.AddOutputFlag(cmd, "name", "name", "json", "yaml")
+
+	_ = cmd.RegisterFlagCompletionFunc(flagNamespace, func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return utilk8s.CompleteNamespaces(cmd, toComplete)
+	})
+
+	return cmd
+}
+
+// Run resolves flags, builds the dynamic client, and creates the Snapshot.
+func Run(log *slog.Logger, cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	opts, err := resolveOptions(cmd, args[0])
+	if err != nil {
+		return err
+	}
+
+	dyn, err := utilk8s.NewDynamicClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	return runCreate(ctx, dyn, cmd.OutOrStdout(), opts, log)
+}
+
+// resolveOptions reads and validates the flag values into a createOptions.
+func resolveOptions(cmd *cobra.Command, name string) (createOptions, error) {
+	outputFmt, err := cmd.Flags().GetString(flagOutput)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagOutput, err)
+	}
+
+	namespace, err := cmd.Flags().GetString(flagNamespace)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagNamespace, err)
+	}
+
+	// kubectl-style default: when -n is omitted, fall back to the namespace
+	// pinned by the current kubeconfig context (or "default").
+	if namespace == "" {
+		kubeconfigPath, _ := cmd.Flags().GetString(flagKubeconfig)
+		contextName, _ := cmd.Flags().GetString(flagContext)
+
+		namespace, err = utilk8s.KubeconfigNamespace(kubeconfigPath, contextName)
+		if err != nil {
+			return createOptions{}, err
+		}
+	}
+
+	snapshotClass, err := cmd.Flags().GetString(flagSnapshotClass)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagSnapshotClass, err)
+	}
+
+	selector, err := cmd.Flags().GetString(flagSelector)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagSelector, err)
+	}
+
+	matchLabels, err := parseMatchLabels(selector)
+	if err != nil {
+		return createOptions{}, err
+	}
+
+	wait, err := cmd.Flags().GetBool(flagWait)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagWait, err)
+	}
+
+	timeout, err := cmd.Flags().GetDuration(flagTimeout)
+	if err != nil {
+		return createOptions{}, fmt.Errorf("reading --%s flag: %w", flagTimeout, err)
+	}
+
+	return createOptions{
+		namespace:     namespace,
+		name:          name,
+		snapshotClass: snapshotClass,
+		matchLabels:   matchLabels,
+		wait:          wait,
+		timeout:       timeout,
+		poll:          pollInterval,
+		outputFmt:     outputFmt,
+	}, nil
+}
+
+// runCreate creates the Snapshot via the dynamic client and, when requested,
+// waits for it to become Ready before rendering the result.
+func runCreate(ctx context.Context, dyn dynamic.Interface, w io.Writer, opts createOptions, log *slog.Logger) error {
+	obj := buildSnapshot(opts.namespace, opts.name, opts.snapshotClass, opts.matchLabels)
+
+	created, err := dyn.Resource(snapshotGVR).Namespace(opts.namespace).Create(ctx, obj, metav1.CreateOptions{})
+	if err != nil {
+		if kubeerrors.IsAlreadyExists(err) {
+			return fmt.Errorf("Snapshot %q already exists in namespace %q", opts.name, opts.namespace)
+		}
+
+		return fmt.Errorf("creating Snapshot %s/%s: %w", opts.namespace, opts.name, err)
+	}
+
+	log.Info("Snapshot created",
+		slog.String("namespace", opts.namespace),
+		slog.String("name", opts.name),
+	)
+
+	if opts.wait {
+		created, err = waitReady(ctx, dyn, opts.namespace, opts.name, opts.timeout, opts.poll, log)
+		if err != nil {
+			return err
+		}
+	}
+
+	return renderCreated(w, created, opts.outputFmt)
+}
+
+// buildSnapshot assembles the unstructured Snapshot to create. An empty spec
+// captures the whole namespace; snapshotClass and matchLabels are added only
+// when set so old CRDs do not see unknown empty fields.
+func buildSnapshot(namespace, name, snapshotClass string, matchLabels map[string]interface{}) *unstructured.Unstructured {
+	spec := map[string]interface{}{}
+
+	if snapshotClass != "" {
+		spec["snapshotClassName"] = snapshotClass
+	}
+
+	if len(matchLabels) > 0 {
+		spec["resourceSelector"] = map[string]interface{}{"matchLabels": matchLabels}
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": snapshotapi.StorageGroup + "/" + snapshotapi.Version,
+		"kind":       "Snapshot",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": spec,
+	}}
+}
+
+// parseMatchLabels parses a kubectl-style "key=value,key2=value2" selector into
+// a matchLabels map. An empty selector yields a nil map (whole-namespace capture).
+func parseMatchLabels(selector string) (map[string]interface{}, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return nil, nil
+	}
+
+	labels := map[string]interface{}{}
+
+	for _, part := range strings.Split(selector, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		key, value, found := strings.Cut(part, "=")
+		key = strings.TrimSpace(key)
+
+		if !found || key == "" {
+			return nil, fmt.Errorf("invalid --%s %q: expected comma-separated key=value pairs", flagSelector, selector)
+		}
+
+		labels[key] = strings.TrimSpace(value)
+	}
+
+	if len(labels) == 0 {
+		return nil, nil
+	}
+
+	return labels, nil
+}
+
+// waitReady polls the Snapshot until its Ready condition is True or the timeout
+// elapses. Ready=False is treated as still-in-progress (capture is async), so it
+// keeps polling; on timeout it surfaces the last observed reason/message.
+func waitReady(ctx context.Context, dyn dynamic.Interface, namespace, name string, timeout, poll time.Duration, log *slog.Logger) (*unstructured.Unstructured, error) {
+	deadline := time.Now().Add(timeout)
+
+	var lastReason, lastMessage string
+
+	for {
+		obj, err := dyn.Resource(snapshotGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("get Snapshot %s/%s: %w", namespace, name, err)
+		}
+
+		status, reason, message := readyCondition(obj)
+		if status == string(metav1.ConditionTrue) {
+			log.Info("Snapshot is Ready", slog.String("namespace", namespace), slog.String("name", name))
+
+			return obj, nil
+		}
+
+		lastReason, lastMessage = reason, message
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout waiting for Snapshot %s/%s to become Ready (last reason=%q message=%q)",
+				namespace, name, lastReason, lastMessage)
+		}
+
+		log.Debug("waiting for Snapshot to become Ready",
+			slog.String("namespace", namespace),
+			slog.String("name", name),
+			slog.String("status", status),
+			slog.String("reason", reason),
+		)
+
+		if !sleepCtx(ctx, poll) {
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// readyCondition returns the status/reason/message of the "Ready" condition, or
+// empty strings when the Snapshot carries no such condition yet.
+func readyCondition(obj *unstructured.Unstructured) (status, reason, message string) {
+	conds, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return "", "", ""
+	}
+
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		condType, _, _ := unstructured.NestedString(m, "type")
+		if condType != readyConditionType {
+			continue
+		}
+
+		status, _, _ = unstructured.NestedString(m, "status")
+		reason, _, _ = unstructured.NestedString(m, "reason")
+		message, _, _ = unstructured.NestedString(m, "message")
+
+		return status, reason, message
+	}
+
+	return "", "", ""
+}
+
+// renderCreated reports the created Snapshot. The default "name" format prints a
+// kubectl-style confirmation line; json/yaml print the object verbatim.
+func renderCreated(w io.Writer, obj *unstructured.Unstructured, outputFmt string) error {
+	switch outputFmt {
+	case "json", "yaml":
+		return utilk8s.PrintObject(w, obj, outputFmt)
+	case "name", "":
+		_, err := fmt.Fprintf(w, "snapshot.%s/%s created\n", snapshotapi.StorageGroup, obj.GetName())
+		return err
+	default:
+		return fmt.Errorf("unsupported output format %q; use name|json|yaml", outputFmt)
+	}
+}
+
+// sleepCtx sleeps for d or until ctx is cancelled, returning false on cancel.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/internal/snapshot/cmd/create/create_test.go
+++ b/internal/snapshot/cmd/create/create_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newFakeDynamic(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		snapshotGVR: "SnapshotList",
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+// readySnapshot builds a Snapshot already carrying Ready=True (used to drive --wait).
+func readySnapshot(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "Snapshot",
+		"metadata":   map[string]interface{}{"namespace": namespace, "name": name},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		},
+	}}
+}
+
+func TestBuildSnapshot_Empty(t *testing.T) {
+	obj := buildSnapshot("ns", "snap", "", nil)
+
+	if obj.GetKind() != "Snapshot" || obj.GetAPIVersion() != "storage.deckhouse.io/v1alpha1" {
+		t.Fatalf("unexpected GVK: %s %s", obj.GetAPIVersion(), obj.GetKind())
+	}
+
+	if obj.GetNamespace() != "ns" || obj.GetName() != "snap" {
+		t.Fatalf("unexpected metadata: ns=%q name=%q", obj.GetNamespace(), obj.GetName())
+	}
+
+	spec, found, _ := unstructured.NestedMap(obj.Object, "spec")
+	if !found || len(spec) != 0 {
+		t.Fatalf("empty create must produce an empty spec, got found=%v spec=%v", found, spec)
+	}
+}
+
+func TestBuildSnapshot_WithClassAndSelector(t *testing.T) {
+	obj := buildSnapshot("ns", "snap", "fast", map[string]interface{}{"app": "demo", "tier": "db"})
+
+	sc, _, _ := unstructured.NestedString(obj.Object, "spec", "snapshotClassName")
+	if sc != "fast" {
+		t.Errorf("spec.snapshotClassName = %q, want fast", sc)
+	}
+
+	ml, found, _ := unstructured.NestedStringMap(obj.Object, "spec", "resourceSelector", "matchLabels")
+	if !found {
+		t.Fatalf("spec.resourceSelector.matchLabels not set")
+	}
+
+	if !reflect.DeepEqual(ml, map[string]string{"app": "demo", "tier": "db"}) {
+		t.Errorf("matchLabels = %v, want {app:demo, tier:db}", ml)
+	}
+}
+
+func TestParseMatchLabels(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{"empty", "", nil, false},
+		{"whitespace", "   ", nil, false},
+		{"single", "app=demo", map[string]interface{}{"app": "demo"}, false},
+		{"multi with spaces", " app=demo , tier=db ", map[string]interface{}{"app": "demo", "tier": "db"}, false},
+		{"empty value", "app=", map[string]interface{}{"app": ""}, false},
+		{"missing eq", "app", nil, true},
+		{"empty key", "=demo", nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMatchLabels(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.in)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseMatchLabels(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunCreate_CreatesSnapshot(t *testing.T) {
+	dyn := newFakeDynamic()
+
+	var buf bytes.Buffer
+	opts := createOptions{namespace: "ns", name: "snap", outputFmt: "name", poll: time.Millisecond}
+
+	if err := runCreate(context.Background(), dyn, &buf, opts, discardLogger()); err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+
+	// The Snapshot CR must exist in the target namespace.
+	got, err := dyn.Resource(snapshotGVR).Namespace("ns").Get(context.Background(), "snap", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("created Snapshot not found: %v", err)
+	}
+
+	if got.GetName() != "snap" {
+		t.Errorf("created name = %q, want snap", got.GetName())
+	}
+
+	if out := strings.TrimSpace(buf.String()); out != "snapshot.storage.deckhouse.io/snap created" {
+		t.Errorf("confirmation = %q, want kubectl-style created line", out)
+	}
+}
+
+func TestRunCreate_AlreadyExists(t *testing.T) {
+	dyn := newFakeDynamic(readySnapshot("ns", "snap"))
+
+	opts := createOptions{namespace: "ns", name: "snap", outputFmt: "name", poll: time.Millisecond}
+
+	err := runCreate(context.Background(), dyn, io.Discard, opts, discardLogger())
+	if err == nil {
+		t.Fatal("expected already-exists error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q does not mention already exists", err.Error())
+	}
+}
+
+func TestWaitReady_ReturnsWhenReady(t *testing.T) {
+	dyn := newFakeDynamic(readySnapshot("ns", "snap"))
+
+	obj, err := waitReady(context.Background(), dyn, "ns", "snap", time.Second, time.Millisecond, discardLogger())
+	if err != nil {
+		t.Fatalf("waitReady: %v", err)
+	}
+
+	status, _, _ := readyCondition(obj)
+	if status != "True" {
+		t.Errorf("waitReady returned status %q, want True", status)
+	}
+}
+
+func TestWaitReady_TimesOut(t *testing.T) {
+	// A Snapshot without a Ready=True condition never satisfies the wait.
+	pending := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "Snapshot",
+		"metadata":   map[string]interface{}{"namespace": "ns", "name": "snap"},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "False", "reason": "Capturing", "message": "in progress"},
+			},
+		},
+	}}
+
+	dyn := newFakeDynamic(pending)
+
+	_, err := waitReady(context.Background(), dyn, "ns", "snap", 30*time.Millisecond, time.Millisecond, discardLogger())
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "timeout") || !strings.Contains(err.Error(), "Capturing") {
+		t.Errorf("timeout error should carry the last reason, got: %v", err)
+	}
+}
+
+func TestReadyCondition(t *testing.T) {
+	obj := readySnapshot("ns", "snap")
+
+	status, _, _ := readyCondition(obj)
+	if status != "True" {
+		t.Errorf("status = %q, want True", status)
+	}
+
+	none := &unstructured.Unstructured{Object: map[string]interface{}{"status": map[string]interface{}{}}}
+	if s, _, _ := readyCondition(none); s != "" {
+		t.Errorf("no-condition status = %q, want empty", s)
+	}
+}
+
+func TestRenderCreated(t *testing.T) {
+	obj := readySnapshot("ns", "snap")
+
+	var nameBuf bytes.Buffer
+	if err := renderCreated(&nameBuf, obj, "name"); err != nil {
+		t.Fatalf("renderCreated name: %v", err)
+	}
+
+	if !strings.Contains(nameBuf.String(), "snapshot.storage.deckhouse.io/snap created") {
+		t.Errorf("name output = %q", nameBuf.String())
+	}
+
+	var jsonBuf bytes.Buffer
+	if err := renderCreated(&jsonBuf, obj, "json"); err != nil {
+		t.Fatalf("renderCreated json: %v", err)
+	}
+
+	if !strings.Contains(jsonBuf.String(), `"kind": "Snapshot"`) {
+		t.Errorf("json output missing object:\n%s", jsonBuf.String())
+	}
+
+	if err := renderCreated(io.Discard, obj, "wide"); err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+}
+
+func TestNewCommand_ArgsValidation(t *testing.T) {
+	cmd := NewCommand(slog.Default())
+	cmd.SetArgs([]string{}) // missing <name>
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when <name> argument is missing")
+	}
+}

--- a/internal/snapshot/cmd/delete/delete.go
+++ b/internal/snapshot/cmd/delete/delete.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package delete implements the `d8 snapshot delete` command: it deletes one or
+// more Snapshot objects by name, by label selector, or all in a namespace, and
+// can optionally wait until they are fully removed.
+package delete
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	snapshotapi "github.com/deckhouse/deckhouse-cli/internal/snapshot/api/v1alpha1"
+	"github.com/deckhouse/deckhouse-cli/internal/system/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+)
+
+const (
+	cmdUse = "delete"
+
+	flagNamespace      = "namespace"
+	flagSelector       = "selector"
+	flagAll            = "all"
+	flagWait           = "wait"
+	flagTimeout        = "timeout"
+	flagIgnoreNotFound = "ignore-not-found"
+	flagKubeconfig     = "kubeconfig"
+	flagContext        = "context"
+
+	defaultWaitTimeout = 5 * time.Minute
+	pollInterval       = 2 * time.Second
+)
+
+// snapshotGVR is the dynamic resource for storage.deckhouse.io Snapshots.
+var snapshotGVR = schema.GroupVersionResource{
+	Group:    snapshotapi.StorageGroup,
+	Version:  snapshotapi.Version,
+	Resource: "snapshots",
+}
+
+// deleteOptions bundles the resolved inputs for one delete run so the cluster
+// logic stays decoupled from cobra flag plumbing (and unit-testable).
+type deleteOptions struct {
+	namespace      string
+	names          []string
+	selector       string
+	all            bool
+	wait           bool
+	timeout        time.Duration
+	poll           time.Duration
+	ignoreNotFound bool
+}
+
+// NewCommand builds the `d8 snapshot delete` cobra command.
+func NewCommand(log *slog.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           cmdUse + " [name...]",
+		Short:         "Delete one or more Snapshots",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ArbitraryArgs,
+		Long: `Delete Snapshot objects in a namespace.
+
+Targets are selected in exactly one of three ways:
+  - by name:      d8 snapshot delete snap-a snap-b -n demo
+  - by selector:  d8 snapshot delete -l app=demo -n demo
+  - all:          d8 snapshot delete --all -n demo
+
+Deleting a Snapshot lets the state-snapshotter controller garbage-collect the
+associated SnapshotContent and data artifacts. Use --wait to block until the
+Snapshot objects are fully removed from the API server.`,
+		Example: `  # Delete two named Snapshots and wait until they are gone
+  d8 snapshot delete snap-a snap-b -n demo --wait
+
+  # Delete every Snapshot labeled app=demo
+  d8 snapshot delete -l app=demo -n demo
+
+  # Delete all Snapshots in the namespace
+  d8 snapshot delete --all -n demo
+
+  # Do not error if a named Snapshot is already gone
+  d8 snapshot delete snap-a -n demo --ignore-not-found`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Run(log, cmd, args)
+		},
+		ValidArgsFunction: completeSnapshotNames,
+	}
+
+	// Reuse the standard kubeconfig/context flags (same as the other snapshot
+	// subcommands), so NewDynamicClient and KubeconfigNamespace can read them.
+	flags.AddPersistentFlags(cmd)
+
+	cmd.Flags().StringP(flagNamespace, "n", "", "namespace of the Snapshots (defaults to the kubeconfig context namespace)")
+	cmd.Flags().StringP(flagSelector, "l", "", "delete Snapshots matching this label selector (e.g. app=demo,tier=db)")
+	cmd.Flags().Bool(flagAll, false, "delete all Snapshots in the namespace")
+	cmd.Flags().Bool(flagWait, false, "wait until the Snapshots are fully deleted")
+	cmd.Flags().Duration(flagTimeout, defaultWaitTimeout, "timeout for --wait")
+	cmd.Flags().Bool(flagIgnoreNotFound, false, "do not error if a named Snapshot does not exist")
+
+	_ = cmd.RegisterFlagCompletionFunc(flagNamespace, func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return utilk8s.CompleteNamespaces(cmd, toComplete)
+	})
+
+	return cmd
+}
+
+// completeSnapshotNames offers Snapshot names in the target namespace for shell
+// completion of positional args.
+func completeSnapshotNames(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	namespace, _ := cmd.Flags().GetString(flagNamespace)
+	if namespace == "" {
+		kubeconfigPath, _ := cmd.Flags().GetString(flagKubeconfig)
+		contextName, _ := cmd.Flags().GetString(flagContext)
+		namespace, _ = utilk8s.KubeconfigNamespace(kubeconfigPath, contextName)
+	}
+
+	return utilk8s.CompleteResourceNames(cmd, snapshotGVR, namespace, toComplete)
+}
+
+// Run resolves flags, builds the dynamic client, and deletes the Snapshots.
+func Run(log *slog.Logger, cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	opts, err := resolveOptions(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	dyn, err := utilk8s.NewDynamicClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	return runDelete(ctx, dyn, cmd.OutOrStdout(), opts, log)
+}
+
+// resolveOptions reads and validates flags/args into a deleteOptions. Exactly
+// one selection mode (names, --selector, or --all) must be provided.
+func resolveOptions(cmd *cobra.Command, args []string) (deleteOptions, error) {
+	selector, err := cmd.Flags().GetString(flagSelector)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagSelector, err)
+	}
+
+	all, err := cmd.Flags().GetBool(flagAll)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagAll, err)
+	}
+
+	// Validate the selection mode before touching the cluster/kubeconfig so a
+	// misuse fails fast and deterministically.
+	if err := validateScope(len(args) > 0, selector != "", all); err != nil {
+		return deleteOptions{}, err
+	}
+
+	wait, err := cmd.Flags().GetBool(flagWait)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagWait, err)
+	}
+
+	timeout, err := cmd.Flags().GetDuration(flagTimeout)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagTimeout, err)
+	}
+
+	ignoreNotFound, err := cmd.Flags().GetBool(flagIgnoreNotFound)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagIgnoreNotFound, err)
+	}
+
+	namespace, err := cmd.Flags().GetString(flagNamespace)
+	if err != nil {
+		return deleteOptions{}, fmt.Errorf("reading --%s flag: %w", flagNamespace, err)
+	}
+
+	if namespace == "" {
+		kubeconfigPath, _ := cmd.Flags().GetString(flagKubeconfig)
+		contextName, _ := cmd.Flags().GetString(flagContext)
+
+		namespace, err = utilk8s.KubeconfigNamespace(kubeconfigPath, contextName)
+		if err != nil {
+			return deleteOptions{}, err
+		}
+	}
+
+	return deleteOptions{
+		namespace:      namespace,
+		names:          args,
+		selector:       selector,
+		all:            all,
+		wait:           wait,
+		timeout:        timeout,
+		poll:           pollInterval,
+		ignoreNotFound: ignoreNotFound,
+	}, nil
+}
+
+// validateScope enforces that exactly one of name args, --selector, or --all is set.
+func validateScope(haveNames, haveSelector, all bool) error {
+	modes := 0
+	if haveNames {
+		modes++
+	}
+
+	if haveSelector {
+		modes++
+	}
+
+	if all {
+		modes++
+	}
+
+	switch {
+	case modes == 0:
+		return fmt.Errorf("specify one or more Snapshot names, --%s, or --%s", flagSelector, flagAll)
+	case modes > 1:
+		return fmt.Errorf("Snapshot names, --%s, and --%s are mutually exclusive", flagSelector, flagAll)
+	default:
+		return nil
+	}
+}
+
+// runDelete resolves the target set and deletes each Snapshot, optionally waiting
+// for full removal. Errors are aggregated so one bad target does not hide others.
+func runDelete(ctx context.Context, dyn dynamic.Interface, w io.Writer, opts deleteOptions, log *slog.Logger) error {
+	fromSelection := opts.all || opts.selector != ""
+
+	targets := opts.names
+	if fromSelection {
+		names, err := listTargetNames(ctx, dyn, opts.namespace, opts.selector)
+		if err != nil {
+			return err
+		}
+
+		if len(names) == 0 {
+			fmt.Fprintln(w, "No snapshots found.")
+
+			return nil
+		}
+
+		targets = names
+	}
+
+	var (
+		deleted []string
+		errs    []error
+	)
+
+	for _, name := range targets {
+		err := dyn.Resource(snapshotGVR).Namespace(opts.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil {
+			if kubeerrors.IsNotFound(err) {
+				// When selecting by label/all the object may race away between
+				// List and Delete; with --ignore-not-found the user opted out of
+				// the error. Either way: skip silently.
+				if fromSelection || opts.ignoreNotFound {
+					continue
+				}
+
+				errs = append(errs, fmt.Errorf("Snapshot %q not found in namespace %q", name, opts.namespace))
+
+				continue
+			}
+
+			errs = append(errs, fmt.Errorf("deleting Snapshot %s/%s: %w", opts.namespace, name, err))
+
+			continue
+		}
+
+		deleted = append(deleted, name)
+
+		fmt.Fprintf(w, "snapshot.%s/%s deleted\n", snapshotapi.StorageGroup, name)
+		log.Info("Snapshot deleted", slog.String("namespace", opts.namespace), slog.String("name", name))
+	}
+
+	if opts.wait {
+		for _, name := range deleted {
+			if err := waitGone(ctx, dyn, opts.namespace, name, opts.timeout, opts.poll, log); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// listTargetNames returns the names of Snapshots in the namespace, optionally
+// filtered by a label selector.
+func listTargetNames(ctx context.Context, dyn dynamic.Interface, namespace, selector string) ([]string, error) {
+	listOpts := metav1.ListOptions{}
+	if selector != "" {
+		listOpts.LabelSelector = selector
+	}
+
+	list, err := dyn.Resource(snapshotGVR).Namespace(namespace).List(ctx, listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("listing Snapshots in namespace %q: %w", namespace, err)
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		names = append(names, list.Items[i].GetName())
+	}
+
+	return names, nil
+}
+
+// waitGone polls the Snapshot until it is no longer found or the timeout elapses.
+func waitGone(ctx context.Context, dyn dynamic.Interface, namespace, name string, timeout, poll time.Duration, log *slog.Logger) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		_, err := dyn.Resource(snapshotGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if kubeerrors.IsNotFound(err) {
+			log.Debug("Snapshot deleted", slog.String("namespace", namespace), slog.String("name", name))
+
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("get Snapshot %s/%s: %w", namespace, name, err)
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for Snapshot %s/%s to be deleted", namespace, name)
+		}
+
+		if !sleepCtx(ctx, poll) {
+			return ctx.Err()
+		}
+	}
+}
+
+// sleepCtx sleeps for d or until ctx is cancelled, returning false on cancel.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/internal/snapshot/cmd/delete/delete_test.go
+++ b/internal/snapshot/cmd/delete/delete_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newFakeDynamic(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		snapshotGVR: "SnapshotList",
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+// snapshotObj builds an unstructured Snapshot with optional labels.
+func snapshotObj(namespace, name string, labels map[string]interface{}) *unstructured.Unstructured {
+	meta := map[string]interface{}{"namespace": namespace, "name": name}
+	if len(labels) > 0 {
+		meta["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "Snapshot",
+		"metadata":   meta,
+	}}
+}
+
+func existingNames(t *testing.T, dyn *dynamicfake.FakeDynamicClient, namespace string) []string {
+	t.Helper()
+
+	list, err := dyn.Resource(snapshotGVR).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		names = append(names, list.Items[i].GetName())
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func TestValidateScope(t *testing.T) {
+	cases := []struct {
+		name                         string
+		haveNames, haveSelector, all bool
+		wantErr                      bool
+		errContains                  string
+	}{
+		{name: "names only", haveNames: true},
+		{name: "selector only", haveSelector: true},
+		{name: "all only", all: true},
+		{name: "none", wantErr: true, errContains: "specify"},
+		{name: "names+selector", haveNames: true, haveSelector: true, wantErr: true, errContains: "mutually exclusive"},
+		{name: "selector+all", haveSelector: true, all: true, wantErr: true, errContains: "mutually exclusive"},
+		{name: "all three", haveNames: true, haveSelector: true, all: true, wantErr: true, errContains: "mutually exclusive"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateScope(tc.haveNames, tc.haveSelector, tc.all)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunDelete_ByName(t *testing.T) {
+	dyn := newFakeDynamic(
+		snapshotObj("ns", "snap-a", nil),
+		snapshotObj("ns", "snap-b", nil),
+		snapshotObj("ns", "snap-c", nil),
+	)
+
+	var buf bytes.Buffer
+	opts := deleteOptions{namespace: "ns", names: []string{"snap-a", "snap-b"}, poll: time.Millisecond}
+
+	if err := runDelete(context.Background(), dyn, &buf, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete: %v", err)
+	}
+
+	if remaining := existingNames(t, dyn, "ns"); len(remaining) != 1 || remaining[0] != "snap-c" {
+		t.Fatalf("remaining = %v, want [snap-c]", remaining)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "snapshot.storage.deckhouse.io/snap-a deleted") ||
+		!strings.Contains(out, "snapshot.storage.deckhouse.io/snap-b deleted") {
+		t.Fatalf("missing deleted confirmations:\n%s", out)
+	}
+}
+
+func TestRunDelete_ByNameNotFound(t *testing.T) {
+	dyn := newFakeDynamic(snapshotObj("ns", "snap-a", nil))
+
+	opts := deleteOptions{namespace: "ns", names: []string{"ghost"}, poll: time.Millisecond}
+
+	err := runDelete(context.Background(), dyn, io.Discard, opts, discardLogger())
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error %q does not mention not found", err.Error())
+	}
+}
+
+func TestRunDelete_ByNameIgnoreNotFound(t *testing.T) {
+	dyn := newFakeDynamic(snapshotObj("ns", "snap-a", nil))
+
+	opts := deleteOptions{namespace: "ns", names: []string{"ghost"}, ignoreNotFound: true, poll: time.Millisecond}
+
+	if err := runDelete(context.Background(), dyn, io.Discard, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete with ignore-not-found: %v", err)
+	}
+}
+
+func TestRunDelete_BySelector(t *testing.T) {
+	dyn := newFakeDynamic(
+		snapshotObj("ns", "keep", map[string]interface{}{"app": "other"}),
+		snapshotObj("ns", "drop-1", map[string]interface{}{"app": "demo"}),
+		snapshotObj("ns", "drop-2", map[string]interface{}{"app": "demo"}),
+	)
+
+	var buf bytes.Buffer
+	opts := deleteOptions{namespace: "ns", selector: "app=demo", poll: time.Millisecond}
+
+	if err := runDelete(context.Background(), dyn, &buf, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete: %v", err)
+	}
+
+	if remaining := existingNames(t, dyn, "ns"); len(remaining) != 1 || remaining[0] != "keep" {
+		t.Fatalf("remaining = %v, want [keep]", remaining)
+	}
+}
+
+func TestRunDelete_All(t *testing.T) {
+	dyn := newFakeDynamic(
+		snapshotObj("ns", "snap-a", nil),
+		snapshotObj("ns", "snap-b", nil),
+		snapshotObj("other", "snap-x", nil),
+	)
+
+	opts := deleteOptions{namespace: "ns", all: true, poll: time.Millisecond}
+
+	if err := runDelete(context.Background(), dyn, io.Discard, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete: %v", err)
+	}
+
+	if remaining := existingNames(t, dyn, "ns"); len(remaining) != 0 {
+		t.Fatalf("namespace ns should be empty, got %v", remaining)
+	}
+
+	// Other namespaces are untouched.
+	if remaining := existingNames(t, dyn, "other"); len(remaining) != 1 {
+		t.Fatalf("namespace other should keep its snapshot, got %v", remaining)
+	}
+}
+
+func TestRunDelete_SelectorNoMatches(t *testing.T) {
+	dyn := newFakeDynamic(snapshotObj("ns", "snap-a", map[string]interface{}{"app": "other"}))
+
+	var buf bytes.Buffer
+	opts := deleteOptions{namespace: "ns", selector: "app=demo", poll: time.Millisecond}
+
+	if err := runDelete(context.Background(), dyn, &buf, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete: %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "No snapshots found." {
+		t.Fatalf("no-match output = %q, want %q", got, "No snapshots found.")
+	}
+
+	if remaining := existingNames(t, dyn, "ns"); len(remaining) != 1 {
+		t.Fatalf("non-matching snapshot must survive, got %v", remaining)
+	}
+}
+
+func TestRunDelete_Wait(t *testing.T) {
+	dyn := newFakeDynamic(snapshotObj("ns", "snap-a", nil))
+
+	opts := deleteOptions{namespace: "ns", names: []string{"snap-a"}, wait: true, timeout: time.Second, poll: time.Millisecond}
+
+	// Fake client deletes synchronously, so waitGone observes NotFound at once.
+	if err := runDelete(context.Background(), dyn, io.Discard, opts, discardLogger()); err != nil {
+		t.Fatalf("runDelete with wait: %v", err)
+	}
+}
+
+func TestWaitGone_TimesOut(t *testing.T) {
+	dyn := newFakeDynamic(snapshotObj("ns", "snap-a", nil))
+
+	// snap-a is never deleted here, so waitGone must time out.
+	err := waitGone(context.Background(), dyn, "ns", "snap-a", 30*time.Millisecond, time.Millisecond, discardLogger())
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("error %q does not mention timeout", err.Error())
+	}
+}
+
+func TestNewCommand_NoScopeFails(t *testing.T) {
+	cmd := NewCommand(slog.Default())
+	cmd.SetArgs([]string{}) // no names, no -l, no --all
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no selection mode is given")
+	}
+
+	if !strings.Contains(err.Error(), "specify") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewCommand_MutuallyExclusiveScope(t *testing.T) {
+	cmd := NewCommand(slog.Default())
+	cmd.SetArgs([]string{"snap-a", "--all"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when names and --all are combined")
+	}
+
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/snapshot/cmd/list/list.go
+++ b/internal/snapshot/cmd/list/list.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package list implements the `d8 snapshot list` command.
+package list
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/dynamic"
+
+	snapshotapi "github.com/deckhouse/deckhouse-cli/internal/snapshot/api/v1alpha1"
+	"github.com/deckhouse/deckhouse-cli/internal/system/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
+)
+
+const (
+	cmdUse = "list"
+
+	flagNamespace     = "namespace"
+	flagAllNamespaces = "all-namespaces"
+	flagOutput        = "output"
+	flagKubeconfig    = "kubeconfig"
+	flagContext       = "context"
+
+	// readyConditionType is the status condition reporting overall Snapshot
+	// readiness; it matches the type used by the restore preflight.
+	readyConditionType = "Ready"
+
+	// notAvailable is the placeholder for an empty/missing table cell, matching
+	// kubectl's "<none>"-style dash.
+	notAvailable = "-"
+)
+
+// errUnsupportedFormat is returned for an unknown -o value. Callers wrap it
+// with the accepted formats; tests use errors.Is.
+var errUnsupportedFormat = errors.New("unsupported output format")
+
+// snapshotGVR is the dynamic resource for storage.deckhouse.io Snapshots.
+var snapshotGVR = schema.GroupVersionResource{
+	Group:    snapshotapi.StorageGroup,
+	Version:  snapshotapi.Version,
+	Resource: "snapshots",
+}
+
+// NewCommand builds the `d8 snapshot list` cobra command.
+func NewCommand(log *slog.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           cmdUse,
+		Aliases:       []string{"ls"},
+		Short:         "List Snapshot resources",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		Example: `  # List snapshots in the kubeconfig context namespace
+  d8 snapshot list
+
+  # List snapshots in a specific namespace
+  d8 snapshot list -n my-namespace
+
+  # List snapshots across all namespaces
+  d8 snapshot list -A
+
+  # Machine-readable output
+  d8 snapshot list -o json
+  d8 snapshot list -n my-namespace -o yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return Run(log, cmd, args)
+		},
+	}
+
+	// Reuse the standard kubeconfig/context flags (same as `d8 system ...`),
+	// so NewDynamicClient and KubeconfigNamespace can read them.
+	flags.AddPersistentFlags(cmd)
+
+	cmd.Flags().StringP(flagNamespace, "n", "", "namespace to list Snapshots from (defaults to the kubeconfig context namespace)")
+	cmd.Flags().BoolP(flagAllNamespaces, "A", false, "list Snapshots across all namespaces")
+	utilk8s.AddOutputFlag(cmd, "table", "table", "json", "yaml")
+
+	_ = cmd.RegisterFlagCompletionFunc(flagNamespace, func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return utilk8s.CompleteNamespaces(cmd, toComplete)
+	})
+
+	return cmd
+}
+
+// Run resolves the target namespace (kubectl-style), lists Snapshot objects and
+// renders them in the requested format.
+func Run(log *slog.Logger, cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	namespace, err := cmd.Flags().GetString(flagNamespace)
+	if err != nil {
+		return fmt.Errorf("reading --%s flag: %w", flagNamespace, err)
+	}
+
+	allNamespaces, err := cmd.Flags().GetBool(flagAllNamespaces)
+	if err != nil {
+		return fmt.Errorf("reading --%s flag: %w", flagAllNamespaces, err)
+	}
+
+	outputFmt, err := cmd.Flags().GetString(flagOutput)
+	if err != nil {
+		return fmt.Errorf("reading --%s flag: %w", flagOutput, err)
+	}
+
+	if allNamespaces && namespace != "" {
+		return fmt.Errorf("--%s and --%s are mutually exclusive", flagAllNamespaces, flagNamespace)
+	}
+
+	// kubectl-style default: when neither -A nor -n is given, fall back to the
+	// namespace pinned by the current kubeconfig context (or "default").
+	if !allNamespaces && namespace == "" {
+		kubeconfigPath, _ := cmd.Flags().GetString(flagKubeconfig)
+		contextName, _ := cmd.Flags().GetString(flagContext)
+
+		namespace, err = utilk8s.KubeconfigNamespace(kubeconfigPath, contextName)
+		if err != nil {
+			return err
+		}
+	}
+
+	dyn, err := utilk8s.NewDynamicClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("listing snapshots",
+		slog.String("namespace", namespace),
+		slog.Bool("all_namespaces", allNamespaces),
+	)
+
+	list, err := listSnapshots(ctx, dyn, namespace, allNamespaces)
+	if err != nil {
+		return err
+	}
+
+	return render(cmd.OutOrStdout(), list, allNamespaces, outputFmt)
+}
+
+// listSnapshots fetches Snapshot objects for a single namespace, or across all
+// namespaces when allNamespaces is set.
+func listSnapshots(ctx context.Context, dyn dynamic.Interface, namespace string, allNamespaces bool) (*unstructured.UnstructuredList, error) {
+	ri := dyn.Resource(snapshotGVR)
+
+	var (
+		list *unstructured.UnstructuredList
+		err  error
+	)
+
+	if allNamespaces {
+		list, err = ri.List(ctx, metav1.ListOptions{})
+	} else {
+		list, err = ri.Namespace(namespace).List(ctx, metav1.ListOptions{})
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("listing Snapshots: %w", err)
+	}
+
+	return list, nil
+}
+
+// render dispatches the list to the requested output format. json/yaml emit the
+// raw Snapshot objects (full fidelity); table renders the summary columns.
+func render(w io.Writer, list *unstructured.UnstructuredList, allNamespaces bool, outputFmt string) error {
+	switch outputFmt {
+	case "json", "yaml":
+		return utilk8s.PrintObject(w, &unstructured.Unstructured{Object: list.UnstructuredContent()}, outputFmt)
+	case "table", "":
+		return printSnapshotTable(w, buildSnapshotRows(list.Items), allNamespaces)
+	default:
+		return fmt.Errorf("%w %q; use table|json|yaml", errUnsupportedFormat, outputFmt)
+	}
+}
+
+// snapshotRow is the table-ready projection of a Snapshot object.
+type snapshotRow struct {
+	Namespace       string
+	Name            string
+	Ready           string
+	SnapshotContent string
+	Children        int
+	Age             string
+}
+
+// buildSnapshotRows projects unstructured Snapshot objects into table rows.
+func buildSnapshotRows(items []unstructured.Unstructured) []snapshotRow {
+	rows := make([]snapshotRow, 0, len(items))
+
+	for i := range items {
+		obj := &items[i]
+
+		content, _, _ := unstructured.NestedString(obj.Object, "status", "boundSnapshotContentName")
+		if content == "" {
+			content = notAvailable
+		}
+
+		children, _, _ := unstructured.NestedSlice(obj.Object, "status", "childrenSnapshotRefs")
+
+		rows = append(rows, snapshotRow{
+			Namespace:       obj.GetNamespace(),
+			Name:            obj.GetName(),
+			Ready:           readyStatus(obj),
+			SnapshotContent: content,
+			Children:        len(children),
+			Age:             humanAge(obj.GetCreationTimestamp().Time),
+		})
+	}
+
+	return rows
+}
+
+// readyStatus returns the status of the "Ready" condition ("True"/"False"/
+// "Unknown") or "-" when the snapshot carries no such condition yet.
+func readyStatus(obj *unstructured.Unstructured) string {
+	conds, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return notAvailable
+	}
+
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		condType, _, _ := unstructured.NestedString(m, "type")
+		if condType != readyConditionType {
+			continue
+		}
+
+		if status, _, _ := unstructured.NestedString(m, "status"); status != "" {
+			return status
+		}
+
+		return notAvailable
+	}
+
+	return notAvailable
+}
+
+// printSnapshotTable writes rows as an aligned, kubectl-style table. With
+// allNamespaces it prepends a NAMESPACE column.
+func printSnapshotTable(w io.Writer, rows []snapshotRow, allNamespaces bool) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No snapshots found.")
+		return nil
+	}
+
+	tw := printers.GetNewTabWriter(w)
+
+	if allNamespaces {
+		fmt.Fprintln(tw, "NAMESPACE\tNAME\tREADY\tSNAPSHOTCONTENT\tCHILDREN\tAGE")
+	} else {
+		fmt.Fprintln(tw, "NAME\tREADY\tSNAPSHOTCONTENT\tCHILDREN\tAGE")
+	}
+
+	for _, r := range rows {
+		if allNamespaces {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+				r.Namespace, r.Name, r.Ready, r.SnapshotContent, r.Children, r.Age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+				r.Name, r.Ready, r.SnapshotContent, r.Children, r.Age)
+		}
+	}
+
+	return tw.Flush()
+}
+
+// humanAge formats a creation timestamp as the compact age column kubectl uses
+// (e.g. "5m", "2h", "3d"), delegating to apimachinery for consistency.
+func humanAge(t time.Time) string {
+	if t.IsZero() {
+		return notAvailable
+	}
+
+	return duration.HumanDuration(time.Since(t))
+}

--- a/internal/snapshot/cmd/list/list.go
+++ b/internal/snapshot/cmd/list/list.go
@@ -19,10 +19,14 @@ package list
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,8 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	snapshotapi "github.com/deckhouse/deckhouse-cli/internal/snapshot/api/v1alpha1"
+	"github.com/deckhouse/deckhouse-cli/internal/snapshot/archive"
 	"github.com/deckhouse/deckhouse-cli/internal/system/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
@@ -70,12 +76,12 @@ var snapshotGVR = schema.GroupVersionResource{
 // NewCommand builds the `d8 snapshot list` cobra command.
 func NewCommand(log *slog.Logger) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           cmdUse,
+		Use:           cmdUse + " [DIR]",
 		Aliases:       []string{"ls"},
-		Short:         "List Snapshot resources",
+		Short:         "List Snapshot resources (cluster or a local download directory)",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Args:          cobra.NoArgs,
+		Args:          cobra.MaximumNArgs(1),
 		Example: `  # List snapshots in the kubeconfig context namespace
   d8 snapshot list
 
@@ -85,9 +91,12 @@ func NewCommand(log *slog.Logger) *cobra.Command {
   # List snapshots across all namespaces
   d8 snapshot list -A
 
+  # List snapshot nodes from a local download directory (offline, no cluster access)
+  d8 snapshot list ./out
+
   # Machine-readable output
   d8 snapshot list -o json
-  d8 snapshot list -n my-namespace -o yaml`,
+  d8 snapshot list ./out -o yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return Run(log, cmd, args)
 		},
@@ -110,10 +119,21 @@ func NewCommand(log *slog.Logger) *cobra.Command {
 
 // Run resolves the target namespace (kubectl-style), lists Snapshot objects and
 // renders them in the requested format.
-func Run(log *slog.Logger, cmd *cobra.Command, _ []string) error {
+func Run(log *slog.Logger, cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+
+	outputFmt, err := cmd.Flags().GetString(flagOutput)
+	if err != nil {
+		return fmt.Errorf("reading --%s flag: %w", flagOutput, err)
+	}
+
+	// Local mode: a positional directory argument lists snapshot nodes from a
+	// previously downloaded archive tree, without contacting the cluster.
+	if len(args) == 1 {
+		return runLocal(cmd, args[0], outputFmt)
 	}
 
 	namespace, err := cmd.Flags().GetString(flagNamespace)
@@ -124,11 +144,6 @@ func Run(log *slog.Logger, cmd *cobra.Command, _ []string) error {
 	allNamespaces, err := cmd.Flags().GetBool(flagAllNamespaces)
 	if err != nil {
 		return fmt.Errorf("reading --%s flag: %w", flagAllNamespaces, err)
-	}
-
-	outputFmt, err := cmd.Flags().GetString(flagOutput)
-	if err != nil {
-		return fmt.Errorf("reading --%s flag: %w", flagOutput, err)
 	}
 
 	if allNamespaces && namespace != "" {
@@ -304,4 +319,232 @@ func humanAge(t time.Time) string {
 	}
 
 	return duration.HumanDuration(time.Since(t))
+}
+
+// localSnapshotRow is one snapshot node discovered in a local download tree.
+// JSON tags drive the -o json|yaml output.
+type localSnapshotRow struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Children  int    `json:"children"`
+	Volumes   int    `json:"volumes"`
+	Age       string `json:"age"`
+	// Path is the node directory relative to the scanned root (`.` for the root).
+	Path string `json:"path"`
+}
+
+// runLocal lists snapshot nodes found under a local download directory. Cluster
+// scope flags are rejected because the cluster is not consulted in this mode.
+func runLocal(cmd *cobra.Command, dir, outputFmt string) error {
+	if cmd.Flags().Changed(flagAllNamespaces) || cmd.Flags().Changed(flagNamespace) {
+		return fmt.Errorf("--%s/--%s are not applicable with a local directory argument", flagAllNamespaces, flagNamespace)
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolving path %q: %w", dir, err)
+	}
+
+	rows, err := discoverLocalSnapshots(absDir)
+	if err != nil {
+		return err
+	}
+
+	return renderLocal(cmd.OutOrStdout(), rows, outputFmt)
+}
+
+// discoverLocalSnapshots walks root and returns one row per snapshot node, i.e.
+// per directory containing a snapshot.yaml. Walking depth-first in lexical order
+// yields a natural parent-before-child ordering of the tree.
+func discoverLocalSnapshots(root string) ([]localSnapshotRow, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("accessing %q: %w", root, err)
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", root)
+	}
+
+	rows := make([]localSnapshotRow, 0)
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if !d.IsDir() {
+			return nil
+		}
+
+		syPath := filepath.Join(path, archive.SnapshotYAMLName)
+
+		if _, statErr := os.Stat(syPath); statErr != nil {
+			if errors.Is(statErr, os.ErrNotExist) {
+				return nil
+			}
+
+			return fmt.Errorf("stat %s: %w", syPath, statErr)
+		}
+
+		row, rowErr := buildLocalRow(root, path)
+		if rowErr != nil {
+			return rowErr
+		}
+
+		rows = append(rows, row)
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("scanning %q: %w", root, walkErr)
+	}
+
+	return rows, nil
+}
+
+// buildLocalRow reads the snapshot.yaml at nodeDir and projects it into a row.
+func buildLocalRow(root, nodeDir string) (localSnapshotRow, error) {
+	sy, err := archive.ReadSnapshotYAML(nodeDir)
+	if err != nil {
+		return localSnapshotRow{}, fmt.Errorf("read %s: %w", filepath.Join(nodeDir, archive.SnapshotYAMLName), err)
+	}
+
+	rel, err := filepath.Rel(root, nodeDir)
+	if err != nil {
+		rel = nodeDir
+	}
+
+	children, err := countChildNodes(nodeDir)
+	if err != nil {
+		return localSnapshotRow{}, err
+	}
+
+	// Namespace is stored raw (empty for cluster-scoped) so -o json/yaml stays
+	// faithful; the table renderer substitutes the "-" placeholder.
+	return localSnapshotRow{
+		Name:      sy.Name,
+		Kind:      sy.Kind,
+		Namespace: sy.Namespace,
+		Children:  children,
+		Volumes:   len(sy.Volumes),
+		Age:       localNodeAge(nodeDir),
+		Path:      rel,
+	}, nil
+}
+
+// countChildNodes counts immediate child node directories (those holding a
+// snapshot.yaml) under nodeDir/snapshots/. A missing snapshots/ directory means
+// zero children; any other I/O error is propagated so the listing never
+// silently under-reports.
+func countChildNodes(nodeDir string) (int, error) {
+	snapshotsDir := filepath.Join(nodeDir, archive.SnapshotsDirName)
+
+	entries, err := os.ReadDir(snapshotsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+
+		return 0, fmt.Errorf("read %s: %w", snapshotsDir, err)
+	}
+
+	count := 0
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		childSY := filepath.Join(snapshotsDir, e.Name(), archive.SnapshotYAMLName)
+
+		switch _, statErr := os.Stat(childSY); {
+		case statErr == nil:
+			count++
+		case errors.Is(statErr, os.ErrNotExist):
+			// Not a snapshot node directory; ignore.
+		default:
+			return 0, fmt.Errorf("stat %s: %w", childSY, statErr)
+		}
+	}
+
+	return count, nil
+}
+
+// localNodeAge derives the AGE column from the snapshot.yaml modification time.
+func localNodeAge(nodeDir string) string {
+	info, err := os.Stat(filepath.Join(nodeDir, archive.SnapshotYAMLName))
+	if err != nil {
+		return notAvailable
+	}
+
+	return humanAge(info.ModTime())
+}
+
+// renderLocal dispatches local rows to the requested output format.
+func renderLocal(w io.Writer, rows []localSnapshotRow, outputFmt string) error {
+	switch outputFmt {
+	case "json", "yaml":
+		return printStructured(w, rows, outputFmt)
+	case "table", "":
+		return printLocalTable(w, rows)
+	default:
+		return fmt.Errorf("%w %q; use table|json|yaml", errUnsupportedFormat, outputFmt)
+	}
+}
+
+// printLocalTable writes local snapshot rows as an aligned table.
+func printLocalTable(w io.Writer, rows []localSnapshotRow) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No snapshots found.")
+		return nil
+	}
+
+	tw := printers.GetNewTabWriter(w)
+	fmt.Fprintln(tw, "NAME\tKIND\tNAMESPACE\tCHILDREN\tVOLUMES\tAGE\tPATH")
+
+	for _, r := range rows {
+		namespace := r.Namespace
+		if namespace == "" {
+			namespace = notAvailable
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+			r.Name, r.Kind, namespace, r.Children, r.Volumes, r.Age, r.Path)
+	}
+
+	return tw.Flush()
+}
+
+// printStructured renders v as JSON or YAML. YAML goes through json.Marshal +
+// sigsyaml.JSONToYAML so json struct tags drive field names.
+func printStructured(w io.Writer, v any, format string) error {
+	switch format {
+	case "json":
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshalling JSON: %w", err)
+		}
+
+		fmt.Fprintln(w, string(data))
+
+		return nil
+	case "yaml":
+		jsonData, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("marshalling JSON for YAML conversion: %w", err)
+		}
+
+		yamlData, err := sigsyaml.JSONToYAML(jsonData)
+		if err != nil {
+			return fmt.Errorf("converting JSON to YAML: %w", err)
+		}
+
+		fmt.Fprint(w, string(yamlData))
+
+		return nil
+	default:
+		return fmt.Errorf("%w %q", errUnsupportedFormat, format)
+	}
 }

--- a/internal/snapshot/cmd/list/list_test.go
+++ b/internal/snapshot/cmd/list/list_test.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/deckhouse/deckhouse-cli/internal/snapshot/archive"
 )
 
 // snapshotObj builds an unstructured Snapshot for tests. An empty ready/content
@@ -339,5 +343,222 @@ func TestHumanAge(t *testing.T) {
 
 	if got := humanAge(time.Now().Add(-5 * time.Minute)); got != "5m" {
 		t.Fatalf("age = %q, want %q", got, "5m")
+	}
+}
+
+// writeLocalNode creates a node directory with a snapshot.yaml, mirroring the
+// download tree layout used on disk.
+func writeLocalNode(t *testing.T, dir string, sy archive.SnapshotYAML) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+
+	if err := archive.WriteSnapshotYAML(dir, sy); err != nil {
+		t.Fatalf("write snapshot.yaml in %s: %v", dir, err)
+	}
+}
+
+// buildLocalTree lays out a small download tree under a temp dir and returns its root:
+//
+//	root (Snapshot/vol-tree, ns=snap-e2e)
+//	  snapshots/demovirtualdisksnapshot_disk   (1 volume, leaf)
+//	  snapshots/demovirtualmachinesnapshot_vm   (aggregator)
+//	    snapshots/volumesnapshot_leaf            (1 volume, leaf)
+func buildLocalTree(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+
+	writeLocalNode(t, root, archive.SnapshotYAML{
+		APIVersion: "storage.deckhouse.io/v1alpha1", Kind: "Snapshot", Name: "vol-tree", Namespace: "snap-e2e",
+	})
+	writeLocalNode(t, filepath.Join(root, archive.SnapshotsDirName, "demovirtualdisksnapshot_disk"), archive.SnapshotYAML{
+		APIVersion: "demo.deckhouse.io/v1alpha1", Kind: "DemoVirtualDiskSnapshot", Name: "disk", Namespace: "snap-e2e",
+		Volumes: []archive.VolumeInfo{{}},
+	})
+	writeLocalNode(t, filepath.Join(root, archive.SnapshotsDirName, "demovirtualmachinesnapshot_vm"), archive.SnapshotYAML{
+		APIVersion: "demo.deckhouse.io/v1alpha1", Kind: "DemoVirtualMachineSnapshot", Name: "vm", Namespace: "snap-e2e",
+	})
+	writeLocalNode(t, filepath.Join(root, archive.SnapshotsDirName, "demovirtualmachinesnapshot_vm", archive.SnapshotsDirName, "volumesnapshot_leaf"), archive.SnapshotYAML{
+		APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "leaf", Namespace: "snap-e2e",
+		Volumes: []archive.VolumeInfo{{}},
+	})
+
+	return root
+}
+
+func TestDiscoverLocalSnapshots(t *testing.T) {
+	root := buildLocalTree(t)
+
+	rows, err := discoverLocalSnapshots(root)
+	if err != nil {
+		t.Fatalf("discoverLocalSnapshots: %v", err)
+	}
+
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 nodes, got %d: %+v", len(rows), rows)
+	}
+
+	byName := map[string]localSnapshotRow{}
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+
+	rootRow, ok := byName["vol-tree"]
+	if !ok {
+		t.Fatalf("root node not found in rows: %+v", rows)
+	}
+
+	if rootRow.Kind != "Snapshot" || rootRow.Children != 2 || rootRow.Path != "." {
+		t.Fatalf("unexpected root row: %+v", rootRow)
+	}
+
+	if vm := byName["vm"]; vm.Children != 1 {
+		t.Fatalf("vm node should have 1 child, got %+v", vm)
+	}
+
+	if disk := byName["disk"]; disk.Volumes != 1 {
+		t.Fatalf("disk node should have 1 volume, got %+v", disk)
+	}
+
+	// The first row is the root (depth-first, lexical order).
+	if rows[0].Name != "vol-tree" {
+		t.Fatalf("expected root first, got %q", rows[0].Name)
+	}
+}
+
+func TestDiscoverLocalSnapshotsEmpty(t *testing.T) {
+	rows, err := discoverLocalSnapshots(t.TempDir())
+	if err != nil {
+		t.Fatalf("discoverLocalSnapshots: %v", err)
+	}
+
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows for empty dir, got %d", len(rows))
+	}
+}
+
+func TestDiscoverLocalSnapshotsNotADir(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if _, err := discoverLocalSnapshots(file); err == nil {
+		t.Fatal("expected error for a non-directory path")
+	}
+}
+
+func TestRunLocalTableViaCommand(t *testing.T) {
+	root := buildLocalTree(t)
+
+	var buf bytes.Buffer
+	cmd := NewCommand(slog.Default())
+	cmd.SetArgs([]string{root})
+	cmd.SetOut(&buf)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute local list: %v", err)
+	}
+
+	out := buf.String()
+
+	for _, want := range []string{"NAME", "KIND", "PATH", "vol-tree", "VolumeSnapshot", "leaf"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunLocalRejectsScopeFlags(t *testing.T) {
+	root := buildLocalTree(t)
+
+	for _, scope := range [][]string{{"-A", root}, {"-n", "snap-e2e", root}} {
+		cmd := NewCommand(slog.Default())
+		cmd.SetArgs(scope)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatalf("expected error for scope flags %v with a local dir", scope)
+		}
+
+		if !strings.Contains(err.Error(), "not applicable") {
+			t.Fatalf("unexpected error for %v: %v", scope, err)
+		}
+	}
+}
+
+func TestRenderLocalJSON(t *testing.T) {
+	rows, err := discoverLocalSnapshots(buildLocalTree(t))
+	if err != nil {
+		t.Fatalf("discoverLocalSnapshots: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := renderLocal(&buf, rows, "json"); err != nil {
+		t.Fatalf("renderLocal json: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "vol-tree") || !strings.Contains(out, `"kind"`) || !strings.Contains(out, `"path"`) {
+		t.Fatalf("json output missing expected content:\n%s", out)
+	}
+}
+
+func TestPrintLocalTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printLocalTable(&buf, nil); err != nil {
+		t.Fatalf("printLocalTable: %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "No snapshots found." {
+		t.Fatalf("empty local table = %q, want %q", got, "No snapshots found.")
+	}
+}
+
+// TestLocalClusterScopedNamespace verifies a cluster-scoped node keeps an empty
+// Namespace in the row (so -o json omits it), while the table substitutes "-".
+func TestLocalClusterScopedNamespace(t *testing.T) {
+	root := t.TempDir()
+	writeLocalNode(t, root, archive.SnapshotYAML{
+		APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshotContent", Name: "vsc-1",
+	})
+
+	rows, err := discoverLocalSnapshots(root)
+	if err != nil {
+		t.Fatalf("discoverLocalSnapshots: %v", err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	if rows[0].Namespace != "" {
+		t.Fatalf("cluster-scoped node should keep empty Namespace, got %q", rows[0].Namespace)
+	}
+
+	var tbuf bytes.Buffer
+	if err := printLocalTable(&tbuf, rows); err != nil {
+		t.Fatalf("printLocalTable: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(tbuf.String(), "\n"), "\n")
+	fields := strings.Fields(lines[len(lines)-1])
+	if len(fields) < 3 || fields[2] != notAvailable {
+		t.Fatalf("expected NAMESPACE column %q, got fields %v", notAvailable, fields)
+	}
+
+	var jbuf bytes.Buffer
+	if err := renderLocal(&jbuf, rows, "json"); err != nil {
+		t.Fatalf("renderLocal json: %v", err)
+	}
+
+	if strings.Contains(jbuf.String(), "namespace") {
+		t.Fatalf("json should omit empty namespace:\n%s", jbuf.String())
 	}
 }

--- a/internal/snapshot/cmd/list/list_test.go
+++ b/internal/snapshot/cmd/list/list_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// snapshotObj builds an unstructured Snapshot for tests. An empty ready/content
+// is omitted; age==0 leaves creationTimestamp unset.
+func snapshotObj(namespace, name, ready, content string, children int, age time.Duration) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "Snapshot",
+		"metadata": map[string]interface{}{
+			"namespace": namespace,
+			"name":      name,
+		},
+	}}
+
+	if age > 0 {
+		obj.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-age)))
+	}
+
+	status := map[string]interface{}{}
+
+	if ready != "" {
+		status["conditions"] = []interface{}{
+			map[string]interface{}{"type": "Ready", "status": ready},
+		}
+	}
+
+	if content != "" {
+		status["boundSnapshotContentName"] = content
+	}
+
+	if children > 0 {
+		refs := make([]interface{}, 0, children)
+		for i := 0; i < children; i++ {
+			refs = append(refs, map[string]interface{}{
+				"apiVersion": "storage.deckhouse.io/v1alpha1",
+				"kind":       "Snapshot",
+				"name":       fmt.Sprintf("child-%d", i),
+			})
+		}
+
+		status["childrenSnapshotRefs"] = refs
+	}
+
+	if len(status) > 0 {
+		obj.Object["status"] = status
+	}
+
+	return obj
+}
+
+func newFakeDynamic(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		snapshotGVR: "SnapshotList",
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
+}
+
+func TestReadyStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  map[string]interface{}
+		want string
+	}{
+		{
+			name: "ready true",
+			obj: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			}}},
+			want: "True",
+		},
+		{
+			name: "ready false",
+			obj: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "False"},
+			}}},
+			want: "False",
+		},
+		{
+			name: "ready unknown",
+			obj: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "Unknown"},
+			}}},
+			want: "Unknown",
+		},
+		{
+			name: "other condition only",
+			obj: map[string]interface{}{"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "VolumesReady", "status": "True"},
+			}}},
+			want: notAvailable,
+		},
+		{
+			name: "no conditions",
+			obj:  map[string]interface{}{"status": map[string]interface{}{}},
+			want: notAvailable,
+		},
+		{
+			name: "no status",
+			obj:  map[string]interface{}{},
+			want: notAvailable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readyStatus(&unstructured.Unstructured{Object: tc.obj})
+			if got != tc.want {
+				t.Fatalf("readyStatus = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildSnapshotRows(t *testing.T) {
+	items := []unstructured.Unstructured{
+		*snapshotObj("ns1", "ready-snap", "True", "content-a", 2, 5*time.Minute),
+		*snapshotObj("ns1", "bare-snap", "", "", 0, 0),
+	}
+
+	rows := buildSnapshotRows(items)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	if rows[0].Name != "ready-snap" || rows[0].Ready != "True" ||
+		rows[0].SnapshotContent != "content-a" || rows[0].Children != 2 {
+		t.Fatalf("unexpected first row: %+v", rows[0])
+	}
+
+	if rows[0].Age != "5m" {
+		t.Fatalf("expected age 5m, got %q", rows[0].Age)
+	}
+
+	// Bare snapshot: empty content and no conditions fall back to "-".
+	if rows[1].Ready != notAvailable || rows[1].SnapshotContent != notAvailable ||
+		rows[1].Children != 0 || rows[1].Age != notAvailable {
+		t.Fatalf("unexpected bare row: %+v", rows[1])
+	}
+}
+
+func TestPrintSnapshotTableSingleNamespace(t *testing.T) {
+	var buf bytes.Buffer
+
+	rows := buildSnapshotRows([]unstructured.Unstructured{
+		*snapshotObj("ns1", "snap-a", "True", "content-a", 1, time.Hour),
+	})
+
+	if err := printSnapshotTable(&buf, rows, false); err != nil {
+		t.Fatalf("printSnapshotTable: %v", err)
+	}
+
+	out := buf.String()
+
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "READY") ||
+		!strings.Contains(out, "SNAPSHOTCONTENT") || !strings.Contains(out, "CHILDREN") ||
+		!strings.Contains(out, "AGE") {
+		t.Fatalf("missing expected header columns:\n%s", out)
+	}
+
+	if strings.Contains(out, "NAMESPACE") {
+		t.Fatalf("single-namespace table must not include NAMESPACE column:\n%s", out)
+	}
+
+	if !strings.Contains(out, "snap-a") || !strings.Contains(out, "content-a") {
+		t.Fatalf("missing row data:\n%s", out)
+	}
+}
+
+func TestPrintSnapshotTableAllNamespaces(t *testing.T) {
+	var buf bytes.Buffer
+
+	rows := buildSnapshotRows([]unstructured.Unstructured{
+		*snapshotObj("ns1", "snap-a", "True", "content-a", 0, time.Hour),
+		*snapshotObj("ns2", "snap-b", "False", "", 0, time.Hour),
+	})
+
+	if err := printSnapshotTable(&buf, rows, true); err != nil {
+		t.Fatalf("printSnapshotTable: %v", err)
+	}
+
+	out := buf.String()
+
+	if !strings.HasPrefix(strings.TrimSpace(out), "NAMESPACE") {
+		t.Fatalf("all-namespaces table must lead with NAMESPACE column:\n%s", out)
+	}
+
+	if !strings.Contains(out, "ns1") || !strings.Contains(out, "ns2") {
+		t.Fatalf("missing namespace values:\n%s", out)
+	}
+}
+
+func TestPrintSnapshotTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+
+	if err := printSnapshotTable(&buf, nil, false); err != nil {
+		t.Fatalf("printSnapshotTable: %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "No snapshots found." {
+		t.Fatalf("empty list output = %q, want %q", got, "No snapshots found.")
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	list := &unstructured.UnstructuredList{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "SnapshotList",
+	}}
+	list.Items = []unstructured.Unstructured{
+		*snapshotObj("ns1", "snap-a", "True", "content-a", 0, time.Hour),
+	}
+
+	var buf bytes.Buffer
+	if err := render(&buf, list, false, "json"); err != nil {
+		t.Fatalf("render json: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `"items"`) || !strings.Contains(out, "snap-a") ||
+		!strings.Contains(out, "content-a") {
+		t.Fatalf("json output missing expected content:\n%s", out)
+	}
+}
+
+func TestRenderYAML(t *testing.T) {
+	list := &unstructured.UnstructuredList{Object: map[string]interface{}{
+		"apiVersion": "storage.deckhouse.io/v1alpha1",
+		"kind":       "SnapshotList",
+	}}
+	list.Items = []unstructured.Unstructured{
+		*snapshotObj("ns1", "snap-a", "True", "content-a", 0, time.Hour),
+	}
+
+	var buf bytes.Buffer
+	if err := render(&buf, list, false, "yaml"); err != nil {
+		t.Fatalf("render yaml: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "items:") || !strings.Contains(out, "snap-a") {
+		t.Fatalf("yaml output missing expected content:\n%s", out)
+	}
+}
+
+func TestRenderUnsupportedFormat(t *testing.T) {
+	list := &unstructured.UnstructuredList{}
+
+	err := render(io.Discard, list, false, "wide")
+	if !errors.Is(err, errUnsupportedFormat) {
+		t.Fatalf("expected errUnsupportedFormat, got %v", err)
+	}
+}
+
+func TestListSnapshots(t *testing.T) {
+	dyn := newFakeDynamic(
+		snapshotObj("ns1", "snap-a", "True", "content-a", 0, time.Hour),
+		snapshotObj("ns1", "snap-b", "False", "", 0, time.Hour),
+		snapshotObj("ns2", "snap-c", "True", "content-c", 0, time.Hour),
+	)
+
+	t.Run("single namespace", func(t *testing.T) {
+		list, err := listSnapshots(context.Background(), dyn, "ns1", false)
+		if err != nil {
+			t.Fatalf("listSnapshots: %v", err)
+		}
+
+		if len(list.Items) != 2 {
+			t.Fatalf("expected 2 snapshots in ns1, got %d", len(list.Items))
+		}
+	})
+
+	t.Run("all namespaces", func(t *testing.T) {
+		list, err := listSnapshots(context.Background(), dyn, "", true)
+		if err != nil {
+			t.Fatalf("listSnapshots: %v", err)
+		}
+
+		if len(list.Items) != 3 {
+			t.Fatalf("expected 3 snapshots across all namespaces, got %d", len(list.Items))
+		}
+	})
+}
+
+func TestRunMutuallyExclusiveScope(t *testing.T) {
+	cmd := NewCommand(slog.Default())
+	cmd.SetArgs([]string{"--all-namespaces", "--namespace", "ns1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when -A and -n are combined")
+	}
+
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutually-exclusive error, got %v", err)
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	if got := humanAge(time.Time{}); got != notAvailable {
+		t.Fatalf("zero time age = %q, want %q", got, notAvailable)
+	}
+
+	if got := humanAge(time.Now().Add(-5 * time.Minute)); got != "5m" {
+		t.Fatalf("age = %q, want %q", got, "5m")
+	}
+}

--- a/internal/snapshot/cmd/snapimport/import.go
+++ b/internal/snapshot/cmd/snapimport/import.go
@@ -83,17 +83,25 @@ to become Ready, leaving the namespace ready for 'd8 snapshot restore'.
 
 --node restricts the import to a single node and its descendants. The selected node becomes
 the import root; it must be a core Snapshot, a CSI VolumeSnapshot data leaf, or a domain
-data leaf (e.g. DemoVirtualDiskSnapshot). Domain aggregator nodes (e.g.
-DemoVirtualMachineSnapshot) cannot be selected as the import root.
+data leaf (e.g. DemoVirtualDiskSnapshot). Domain aggregator nodes (a DemoVirtualMachineSnapshot
+that references child snapshots) and manifest-only domain nodes cannot be selected as the
+import root (they have no parent SnapshotContent to attach to when imported standalone); they
+are imported only as part of a full-archive import (omit --node) or by selecting an ancestor
+Snapshot.
 
 Scope and limitations:
-  - Core Snapshot trees, CSI VolumeSnapshot data leaves, and domain data leaves (e.g.
-    DemoVirtualDiskSnapshot with volume data) can be imported client-side.
-  - Full domain aggregator trees (e.g. a DemoVirtualMachineSnapshot subtree that contains
-    child DemoVirtualDiskSnapshot nodes) require a server-side import path: the domain
-    controller must reconstruct the aggregator from its children's SnapshotContents, which
-    is not a client-drivable operation. To import an individual disk snapshot from such a
-    tree, use --node <DomainDataLeafKind>/<name> (e.g. --node DemoVirtualDiskSnapshot/dvd-1).
+  - Full Snapshot trees are imported as-is, including domain aggregator nodes (a
+    DemoVirtualMachineSnapshot that aggregates child DemoVirtualDiskSnapshot nodes): the CLI
+    creates each node's unified import marker and uploads its manifests + child refs, and the
+    server-side genericbinder reconstructs the aggregator's content from its children's
+    SnapshotContents. The aggregator is a non-root node in this case, so no DataImport is
+    created for it (only its data-leaf descendants stream volume bytes).
+  - Manifest-only domain nodes (e.g. a disk-less DemoVirtualMachineSnapshot, which carries
+    only manifests) are imported as part of their parent tree (the server materialises their
+    content from the uploaded manifests alone, with no data leg).
+  - A domain aggregator can be reconstructed only within a tree, never as a standalone --node
+    root. To import an individual disk snapshot from such a tree on its own, use
+    --node <DomainDataLeafKind>/<name> (e.g. --node DemoVirtualDiskSnapshot/dvd-1).
   - Both block-volume and filesystem-volume data leaves are supported.
   - Importing requires RBAC to create DataImport (storage-volume-data-manager) and to call
     the manifests-and-children-refs-upload subresource (e.g. an admin kubeconfig); the

--- a/internal/snapshot/cmd/snapimport/import.go
+++ b/internal/snapshot/cmd/snapimport/import.go
@@ -217,7 +217,7 @@ func Run(log *slog.Logger, cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("building dynamic client: %w", err)
 	}
 
-	volumes := snapimport.NewClusterVolumeImporter(dynClient, sc, ttl, timeout, 3*time.Second, tempDir, kubeClient.RESTMapper(), log)
+	volumes := snapimport.NewClusterVolumeImporter(dynClient, sc, ttl, timeout, 3*time.Second, tempDir, log)
 
 	cfg := snapimport.Config{
 		Namespace:        namespace,

--- a/internal/snapshot/cmd/snapshot.go
+++ b/internal/snapshot/cmd/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/download"
+	listcmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/list"
 	restorecmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/restore"
 	snapimportcmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/snapimport"
 )
@@ -30,7 +31,7 @@ import (
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "snapshot",
-		Short:         "Snapshot operations (download, restore, import)",
+		Short:         "Snapshot operations (download, restore, import, list)",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -43,6 +44,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(download.NewCommand(log))
 	cmd.AddCommand(restorecmd.NewCommand(log))
 	cmd.AddCommand(snapimportcmd.NewCommand(log))
+	cmd.AddCommand(listcmd.NewCommand(log))
 
 	return cmd
 }

--- a/internal/snapshot/cmd/snapshot.go
+++ b/internal/snapshot/cmd/snapshot.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	createcmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/create"
+	deletecmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/delete"
 	"github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/download"
 	listcmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/list"
 	restorecmd "github.com/deckhouse/deckhouse-cli/internal/snapshot/cmd/restore"
@@ -31,7 +33,7 @@ import (
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "snapshot",
-		Short:         "Snapshot operations (download, restore, import, list)",
+		Short:         "Snapshot operations (create, delete, download, restore, import, list)",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -41,6 +43,8 @@ func NewCommand() *cobra.Command {
 
 	log := slog.Default()
 
+	cmd.AddCommand(createcmd.NewCommand(log))
+	cmd.AddCommand(deletecmd.NewCommand(log))
 	cmd.AddCommand(download.NewCommand(log))
 	cmd.AddCommand(restorecmd.NewCommand(log))
 	cmd.AddCommand(snapimportcmd.NewCommand(log))

--- a/internal/snapshot/exporter/dataexport.go
+++ b/internal/snapshot/exporter/dataexport.go
@@ -50,19 +50,19 @@ func DataExportName(leafName string) string {
 }
 
 // EnsureDataExport idempotently creates a DataExport in namespace targeting
-// the snapshot leaf CR identified by {group, resource, leafName} with the given
+// the snapshot leaf CR identified by {group, kind, leafName} with the given
 // TTL (empty → "2h"). Returns the DataExport object (newly created or pre-existing).
 //
-// group and resource must identify a namespaced snapshot CR (e.g.
-// "snapshot.storage.k8s.io" / "volumesnapshots" for a CSI VolumeSnapshot leaf, or
-// the domain group / resource for a domain snapshot CR). The controller routes any
-// such targetRef through its resource-agnostic categorySnapshot path.
+// group and kind must identify a namespaced snapshot CR (e.g.
+// "snapshot.storage.k8s.io" / "VolumeSnapshot" for a CSI VolumeSnapshot leaf, or
+// the domain group / kind for a domain snapshot CR). The controller routes any
+// such targetRef through its kind-agnostic categorySnapshot path.
 func EnsureDataExport(
 	ctx context.Context,
 	c client.Client,
 	namespace,
 	group,
-	resource,
+	kind,
 	leafName,
 	ttl string,
 ) (*deapi.DataExport, error) {
@@ -91,9 +91,9 @@ func EnsureDataExport(
 		Spec: deapi.DataexportSpec{
 			TTL: ttl,
 			TargetRef: deapi.TargetRefSpec{
-				Group:    group,
-				Resource: resource,
-				Name:     leafName,
+				Group: group,
+				Kind:  kind,
+				Name:  leafName,
 			},
 		},
 	}

--- a/internal/snapshot/exporter/dataexport_test.go
+++ b/internal/snapshot/exporter/dataexport_test.go
@@ -71,7 +71,7 @@ func TestEnsureDataExport_Creates(t *testing.T) {
 	const (
 		namespace = "test-ns"
 		group     = "snapshot.storage.k8s.io"
-		resource  = "volumesnapshots"
+		kind      = "VolumeSnapshot"
 		leafName  = "my-vs-leaf"
 		ttl       = "3h"
 	)
@@ -81,23 +81,23 @@ func TestEnsureDataExport_Creates(t *testing.T) {
 
 	ctx := context.Background()
 
-	de, err := exporter.EnsureDataExport(ctx, c, namespace, group, resource, leafName, ttl)
+	de, err := exporter.EnsureDataExport(ctx, c, namespace, group, kind, leafName, ttl)
 	require.NoError(t, err)
 	require.NotNil(t, de)
 
 	assert.Equal(t, exporter.DataExportName(leafName), de.Name)
 	assert.Equal(t, namespace, de.Namespace)
 	assert.Equal(t, group, de.Spec.TargetRef.Group)
-	assert.Equal(t, resource, de.Spec.TargetRef.Resource)
+	assert.Equal(t, kind, de.Spec.TargetRef.Kind)
 	assert.Equal(t, leafName, de.Spec.TargetRef.Name)
 	assert.Equal(t, ttl, de.Spec.TTL)
 
-	// Marshal round-trip: the JSON must carry a non-empty "resource" key — the field
+	// Marshal round-trip: the JSON must carry a non-empty "kind" key — the field
 	// the API server rejects when absent (server-side structural CRD validation).
 	raw, marshalErr := json.Marshal(de.Spec.TargetRef)
 	require.NoError(t, marshalErr)
-	assert.Contains(t, string(raw), `"resource":"volumesnapshots"`, "targetRef JSON must contain populated resource key")
-	assert.NotContains(t, string(raw), `"kind"`, "obsolete kind field must not appear in targetRef JSON")
+	assert.Contains(t, string(raw), `"kind":"VolumeSnapshot"`, "targetRef JSON must contain populated kind key")
+	assert.NotContains(t, string(raw), `"resource"`, "obsolete resource field must not appear in targetRef JSON")
 }
 
 func TestEnsureDataExport_DomainLeaf(t *testing.T) {
@@ -106,7 +106,7 @@ func TestEnsureDataExport_DomainLeaf(t *testing.T) {
 	const (
 		namespace = "test-ns"
 		group     = "demo.deckhouse.io"
-		resource  = "virtualdisksnapshots"
+		kind      = "VirtualDiskSnapshot"
 		leafName  = "disk-snap-1"
 		ttl       = "1h"
 	)
@@ -116,13 +116,13 @@ func TestEnsureDataExport_DomainLeaf(t *testing.T) {
 
 	ctx := context.Background()
 
-	de, err := exporter.EnsureDataExport(ctx, c, namespace, group, resource, leafName, ttl)
+	de, err := exporter.EnsureDataExport(ctx, c, namespace, group, kind, leafName, ttl)
 	require.NoError(t, err)
 	require.NotNil(t, de)
 
 	assert.Equal(t, exporter.DataExportName(leafName), de.Name)
 	assert.Equal(t, group, de.Spec.TargetRef.Group)
-	assert.Equal(t, resource, de.Spec.TargetRef.Resource)
+	assert.Equal(t, kind, de.Spec.TargetRef.Kind)
 	assert.Equal(t, leafName, de.Spec.TargetRef.Name)
 }
 
@@ -133,7 +133,7 @@ func TestEnsureDataExport_DefaultTTL(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	de, err := exporter.EnsureDataExport(context.Background(), c, "ns",
-		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotResource, "leaf-vs", "")
+		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotKind, "leaf-vs", "")
 	require.NoError(t, err)
 
 	// Empty TTL should be replaced by the built-in default (non-empty).
@@ -154,11 +154,11 @@ func TestEnsureDataExport_Idempotent(t *testing.T) {
 	ctx := context.Background()
 
 	de1, err := exporter.EnsureDataExport(ctx, c, namespace,
-		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotResource, leafName, "1h")
+		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotKind, leafName, "1h")
 	require.NoError(t, err)
 
 	de2, err := exporter.EnsureDataExport(ctx, c, namespace,
-		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotResource, leafName, "1h")
+		aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotKind, leafName, "1h")
 	require.NoError(t, err)
 
 	assert.Equal(t, de1.Name, de2.Name)
@@ -178,9 +178,9 @@ func makeReadyDE(namespace, leafName, baseURL, volumeMode string) *deapi.DataExp
 		Spec: deapi.DataexportSpec{
 			TTL: "2h",
 			TargetRef: deapi.TargetRefSpec{
-				Group:    aggapi.VolumeSnapshotGroup,
-				Resource: aggapi.VolumeSnapshotResource,
-				Name:     leafName,
+				Group: aggapi.VolumeSnapshotGroup,
+				Kind:  aggapi.VolumeSnapshotKind,
+				Name:  leafName,
 			},
 		},
 		Status: deapi.DataExportStatus{

--- a/internal/snapshot/exporter/export.go
+++ b/internal/snapshot/exporter/export.go
@@ -76,7 +76,7 @@ func NewExport(namespace, deName, volumeMode, baseURL string, fetcher *Fetcher) 
 }
 
 // OpenExport creates (or re-uses) a DataExport targeting the snapshot leaf
-// identified by {group, resource, leafName}, waits until it is Ready, and
+// identified by {group, kind, leafName}, waits until it is Ready, and
 // returns an Export ready for data transfer.
 //
 // An isolated copy of sClient is built for the HTTP Fetcher so that CA
@@ -87,12 +87,12 @@ func OpenExport(
 	c client.Client,
 	namespace,
 	group,
-	resource,
+	kind,
 	leafName,
 	ttl string,
 	sc *safeClient.SafeClient,
 ) (*Export, error) {
-	de, err := EnsureDataExport(ctx, c, namespace, group, resource, leafName, ttl)
+	de, err := EnsureDataExport(ctx, c, namespace, group, kind, leafName, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("ensure DataExport for leaf %q: %w", leafName, err)
 	}

--- a/internal/snapshot/pipeline/config.go
+++ b/internal/snapshot/pipeline/config.go
@@ -171,7 +171,7 @@ func applyDefaults(cfg Config) Config {
 		aggClient := cfg.AggClient
 
 		cfg.OpenExport = func(ctx context.Context, namespace string, leafRef aggapi.NodeRef, ttl string) (*exporter.Export, error) {
-			group, resource, err := aggClient.LeafDataExportTarget(leafRef)
+			group, kind, err := aggClient.LeafDataExportTarget(leafRef)
 			if err != nil {
 				return nil, fmt.Errorf("resolve DataExport target for %s/%s: %w", leafRef.Kind, leafRef.Name, err)
 			}
@@ -179,7 +179,7 @@ func applyDefaults(cfg Config) Config {
 			waitCtx, waitCancel := context.WithTimeout(ctx, timeout)
 			defer waitCancel()
 
-			return exporter.OpenExport(waitCtx, log, c, namespace, group, resource, leafRef.Name, ttl, sc)
+			return exporter.OpenExport(waitCtx, log, c, namespace, group, kind, leafRef.Name, ttl, sc)
 		}
 	}
 

--- a/internal/snapshot/snapimport/import.go
+++ b/internal/snapshot/snapimport/import.go
@@ -377,23 +377,17 @@ func (cfg Config) resourceInterface(mapping *meta.RESTMapping) dynamic.ResourceI
 }
 
 // createMarkers creates every import-mode CR top-down (reverse post-order = parents before
-// children) so a child's parent already exists and exposes a UID. Data-leaf markers
-// reference their (not-yet-created) DataImport by its deterministic name; the DataImport
-// itself is created bottom-up in pass 2 immediately before the upload, so its idle TTL
-// does not start ticking while earlier siblings are still uploading.
+// children) so a child's parent already exists and exposes a UID. Every marker is the same
+// minimal spec.source.import: {} CR; for data leaves the DataImport itself is created bottom-up
+// in pass 2 immediately before the upload (so its idle TTL does not start ticking while earlier
+// siblings are still uploading) and is later matched to the leaf by its targetRef.
 func (cfg Config) createMarkers(ctx context.Context, plan []PlannedNode, parents map[string]int) error {
 	uids := make(map[string]types.UID, len(plan))
 
 	for i := len(plan) - 1; i >= 0; i-- {
 		node := plan[i]
 
-		var dataImportName string
-
-		if node.isVolumeSnapshotLeaf() || node.isDomainDataLeaf() {
-			dataImportName = cfg.Volumes.DataImportName(node)
-		}
-
-		marker, err := importMarkerCR(node, cfg.Namespace, dataImportName)
+		marker, err := importMarkerCR(node, cfg.Namespace)
 		if err != nil {
 			return err
 		}
@@ -573,30 +567,19 @@ func (cfg Config) ensureMarker(ctx context.Context, obj *unstructured.Unstructur
 func reconcileExistingMarker(ctx context.Context, ri dynamic.ResourceInterface, existing *unstructured.Unstructured, desired []metav1.OwnerReference) (types.UID, error) {
 	if !isImportModeMarker(existing) {
 		return "", fmt.Errorf("%s %s/%s already exists and is not in import mode "+
-			"(neither spec.source.import nor spec.source.dataImportName is set); refusing to mutate a pre-existing "+
+			"(spec.source.import is not set); refusing to mutate a pre-existing "+
 			"object — import into a fresh namespace", existing.GetKind(), existing.GetNamespace(), existing.GetName())
 	}
 
 	return reconcileMarkerOwnerRefs(ctx, ri, existing, desired)
 }
 
-// isImportModeMarker reports whether a live CR is an import-mode marker:
-//   - structural Snapshot: spec.source.import is present
-//   - CSI VolumeSnapshot leaf: spec.source.dataImportName is non-empty
-//   - domain data leaf (e.g. DemoVirtualDiskSnapshot): spec.dataSource.name is non-empty
-//     (the genericbinder reconcileGenericImport trigger)
+// isImportModeMarker reports whether a live CR is an import-mode marker. All node kinds use
+// the unified marker spec.source.import: {}, so its mere presence identifies an import-mode CR.
 func isImportModeMarker(obj *unstructured.Unstructured) bool {
-	if _, found, _ := unstructured.NestedMap(obj.Object, "spec", "source", "import"); found {
-		return true
-	}
+	_, found, _ := unstructured.NestedMap(obj.Object, "spec", "source", "import")
 
-	if name, _, _ := unstructured.NestedString(obj.Object, "spec", "source", "dataImportName"); name != "" {
-		return true
-	}
-
-	name, _, _ := unstructured.NestedString(obj.Object, "spec", "dataSource", "name")
-
-	return name != ""
+	return found
 }
 
 // reconcileMarkerOwnerRefs patches any desired child->parent ownerRef a previous partial

--- a/internal/snapshot/snapimport/import.go
+++ b/internal/snapshot/snapimport/import.go
@@ -19,7 +19,6 @@ package snapimport
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -161,14 +160,23 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	} else {
 		// Subtree import: the selected root must be independently importable — a core
-		// Snapshot, a CSI VolumeSnapshot data leaf, or a domain data leaf. Domain
-		// aggregators expose no client-settable import marker and must be reconstructed
-		// by their domain controller.
-		if root.isDomainAggregator() {
+		// Snapshot, a CSI VolumeSnapshot data leaf, or a domain data leaf. A domain
+		// aggregator or a manifest-only domain node is importable too, but only as a non-root
+		// (it needs a parent SnapshotContent to attach to), so neither can be selected as a
+		// standalone --node root; both are reconstructed as part of a full-archive import.
+		switch {
+		case root.isDomainAggregator():
 			return fmt.Errorf(
-				"selected node %s/%s is a domain aggregator that cannot be imported client-side: "+
-					"domain aggregators must be reconstructed by their domain controller; "+
-					"select a supported node with --node <Kind>/<name> (e.g. a CSI VolumeSnapshot or domain data leaf)",
+				"selected node %s/%s is a domain aggregator and cannot be selected as a standalone --node root: "+
+					"it has no parent SnapshotContent to attach to. Import the full archive (omit --node) to "+
+					"reconstruct it as part of its parent tree, or select a supported leaf with "+
+					"--node <Kind>/<name> (e.g. a CSI VolumeSnapshot or domain data leaf)",
+				root.Kind, root.Name)
+		case !root.canBeImportRoot():
+			return fmt.Errorf(
+				"selected node %s/%s is a manifest-only domain node and cannot be imported as a standalone root: "+
+					"it carries no own volume data and is materialised only as part of its parent tree; "+
+					"import the full archive (omit --node) or select its ancestor Snapshot",
 				root.Kind, root.Name)
 		}
 	}
@@ -227,11 +235,11 @@ func Run(ctx context.Context, cfg Config) error {
 }
 
 // preflight rejects, before any cluster mutation, archives the CLI cannot client-drive.
-// It classifies each node and emits ONE actionable error that lists every unsupported
-// domain aggregator and every data leaf blocked by an aggregator ancestor, with a
-// --node suggestion for importing supported subtrees directly.
-//
-// VS data leaves missing their volume data file are also rejected here.
+// A CSI VolumeSnapshot data leaf missing its volume data file (data.bin or data.tar) is the
+// only such case: every node kind — including domain aggregators — is importable as part of
+// a tree (aggregators are reconstructed server-side by the genericbinder from their uploaded
+// manifests + child refs). The standalone --node root restriction is enforced separately in
+// Run, not here.
 func preflight(plan []PlannedNode) error {
 	for _, node := range plan {
 		if node.isVolumeSnapshotLeaf() && !node.HasBlockData() && !node.FilesystemData {
@@ -239,78 +247,7 @@ func preflight(plan []PlannedNode) error {
 		}
 	}
 
-	parents := buildParentIndex(plan)
-
-	var aggNames []string
-	var blockedDescs []string
-
-	for _, node := range plan {
-		if node.isDomainAggregator() {
-			aggNames = append(aggNames, fmt.Sprintf("%s/%s", node.Kind, node.Name))
-
-			continue
-		}
-
-		if node.isDomainDataLeaf() {
-			if blocker := aggregatorAncestor(plan, parents, node); blocker != nil {
-				blockedDescs = append(blockedDescs, fmt.Sprintf(
-					"%s/%s (blocked by aggregator %s/%s; use --node %s/%s to import it directly)",
-					node.Kind, node.Name, blocker.Kind, blocker.Name, node.Kind, node.Name))
-			}
-		}
-	}
-
-	if len(aggNames) == 0 && len(blockedDescs) == 0 {
-		return nil
-	}
-
-	return aggregatorPreflightError(aggNames, blockedDescs)
-}
-
-// aggregatorPreflightError builds the single actionable error for an archive that contains
-// domain aggregators and/or data leaves blocked by them.
-func aggregatorPreflightError(aggNames, blockedDescs []string) error {
-	var b strings.Builder
-
-	if len(aggNames) > 0 {
-		fmt.Fprintf(&b, "%d domain aggregator node(s) cannot be imported client-side (%s); "+
-			"domain aggregators must be reconstructed by their domain controller (server-side import)",
-			len(aggNames), strings.Join(aggNames, ", "))
-	}
-
-	if len(blockedDescs) > 0 {
-		if b.Len() > 0 {
-			b.WriteString("; ")
-		}
-
-		fmt.Fprintf(&b, "%d data leaf(s) blocked by aggregator ancestor(s): %s",
-			len(blockedDescs), strings.Join(blockedDescs, "; "))
-	}
-
-	b.WriteString("; use --node <Kind>/<name> to select a supported subtree for import")
-
-	return errors.New(b.String())
-}
-
-// aggregatorAncestor walks the parent chain of node and returns the first domain
-// aggregator ancestor, or nil when all ancestors are structural or data leaves.
-func aggregatorAncestor(plan []PlannedNode, parents map[string]int, node PlannedNode) *PlannedNode {
-	key := nodeKey(node)
-
-	for {
-		pi, ok := parents[key]
-		if !ok {
-			return nil
-		}
-
-		parent := &plan[pi]
-
-		if parent.isDomainAggregator() {
-			return parent
-		}
-
-		key = nodeKey(*parent)
-	}
+	return nil
 }
 
 // preflightNamespace checks, before any cluster mutation, that the target namespace

--- a/internal/snapshot/snapimport/import_test.go
+++ b/internal/snapshot/snapimport/import_test.go
@@ -49,6 +49,7 @@ var (
 	contentGVR         = schema.GroupVersionResource{Group: "storage.deckhouse.io", Version: "v1alpha1", Resource: "snapshotcontents"}
 	volumeSnapshotGVRt = schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}
 	demoDiskSnapGVR    = schema.GroupVersionResource{Group: "demo.state-snapshotter.deckhouse.io", Version: "v1alpha1", Resource: "demovirtualdisksnapshots"}
+	demoVMSnapGVR      = schema.GroupVersionResource{Group: "demo.state-snapshotter.deckhouse.io", Version: "v1alpha1", Resource: "demovirtualmachinesnapshots"}
 )
 
 type uploadCall struct {
@@ -126,6 +127,7 @@ func newFakeDynamic(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
 		contentGVR:         "SnapshotContentList",
 		volumeSnapshotGVRt: "VolumeSnapshotList",
 		demoDiskSnapGVR:    "DemoVirtualDiskSnapshotList",
+		demoVMSnapGVR:      "DemoVirtualMachineSnapshotList",
 	}
 
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
@@ -138,6 +140,7 @@ func testDomainMapper() meta.RESTMapper {
 	m.Add(schema.GroupVersionKind{Group: "storage.deckhouse.io", Version: "v1alpha1", Kind: "Snapshot"}, meta.RESTScopeNamespace)
 	m.Add(schema.GroupVersionKind{Group: "snapshot.storage.k8s.io", Version: "v1", Kind: "VolumeSnapshot"}, meta.RESTScopeNamespace)
 	m.Add(schema.GroupVersionKind{Group: "demo.state-snapshotter.deckhouse.io", Version: "v1alpha1", Kind: "DemoVirtualDiskSnapshot"}, meta.RESTScopeNamespace)
+	m.Add(schema.GroupVersionKind{Group: "demo.state-snapshotter.deckhouse.io", Version: "v1alpha1", Kind: "DemoVirtualMachineSnapshot"}, meta.RESTScopeNamespace)
 
 	return m
 }
@@ -512,7 +515,13 @@ func TestLeafTargetRef_DomainLeaf(t *testing.T) {
 	}
 }
 
-func TestRun_UnsupportedNodeFailsFast(t *testing.T) {
+// TestRun_ManifestOnlyDomainNode_Imports verifies that a manifest-only domain node — a
+// domain snapshot with neither volume data nor child snapshots (e.g. a disk-less
+// DemoVirtualMachineSnapshot) — is client-importable: it gets the unified
+// spec.source.import: {} marker, its manifests are uploaded, it carries a controller-owned
+// child->parent ownerRef, and no DataImport is created (it has no data leg). It is
+// import-equivalent to a structural Snapshot child.
+func TestRun_ManifestOnlyDomainNode_Imports(t *testing.T) {
 	root := t.TempDir()
 	writeArchiveNode(t, root, archiveNode{
 		apiVersion: "storage.deckhouse.io/v1alpha1",
@@ -528,15 +537,89 @@ func TestRun_UnsupportedNodeFailsFast(t *testing.T) {
 	})
 
 	up := &stubUploader{}
+	vol := &stubVolumes{}
 	dyn := newFakeDynamic(readyRootSnapshot(), readyContent())
 
-	err := Run(context.Background(), baseConfig(root, up, &stubVolumes{}, dyn))
-	if err == nil {
-		t.Fatal("expected unsupported-node error, got nil")
+	cfg := baseConfig(root, up, vol, dyn)
+	cfg.Mapper = testDomainMapper()
+
+	if err := Run(context.Background(), cfg); err != nil {
+		t.Fatalf("manifest-only domain node should import, got: %v", err)
 	}
 
-	if len(up.calls) != 0 {
-		t.Errorf("no uploads should happen when an unsupported node is present, got %d", len(up.calls))
+	// Two manifest uploads: the manifest-only domain node (post-order = leaf first), then root.
+	if len(up.calls) != 2 {
+		t.Fatalf("expected 2 manifest uploads, got %d", len(up.calls))
+	}
+
+	if up.calls[0].ref.Kind != "DemoVirtualMachineSnapshot" || up.calls[0].ref.Name != "vm-1" {
+		t.Errorf("first upload = %s/%s, want DemoVirtualMachineSnapshot/vm-1", up.calls[0].ref.Kind, up.calls[0].ref.Name)
+	}
+
+	// A manifest-only domain node has no data leg: no DataImport is ensured/uploaded.
+	if len(vol.ensure) != 0 || len(vol.upload) != 0 {
+		t.Errorf("manifest-only domain node must not import volume data: ensure=%v upload=%v", vol.ensure, vol.upload)
+	}
+
+	// The domain node import-mode CR was created with the unified import marker.
+	vmObj, err := dyn.Resource(demoVMSnapGVR).Namespace(targetNS).Get(context.Background(), "vm-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("DemoVirtualMachineSnapshot import CR not created: %v", err)
+	}
+
+	if _, found, _ := unstructured.NestedMap(vmObj.Object, "spec", "source", "import"); !found {
+		t.Error("manifest-only domain node marker must set spec.source.import: {}")
+	}
+
+	// It carries a controller-owned child->parent ownerRef pointing to the root Snapshot.
+	refs := vmObj.GetOwnerReferences()
+	if len(refs) != 1 || refs[0].Kind != "Snapshot" || refs[0].Name != "root" {
+		t.Fatalf("manifest-only domain node must carry a parent Snapshot ownerRef, got %+v", refs)
+	}
+
+	if refs[0].Controller == nil || !*refs[0].Controller {
+		t.Errorf("manifest-only domain node parent ownerRef should be controller-owned")
+	}
+}
+
+// TestRun_SelectedNode_ManifestOnlyDomainNodeFails verifies that selecting a manifest-only
+// domain node as a standalone --node root fails fast (it has no parent SnapshotContent to
+// attach to), with a clear message, before any cluster mutation.
+func TestRun_SelectedNode_ManifestOnlyDomainNodeFails(t *testing.T) {
+	root := t.TempDir()
+	writeArchiveNode(t, root, archiveNode{
+		apiVersion: "storage.deckhouse.io/v1alpha1",
+		kind:       "Snapshot",
+		name:       "root",
+	})
+
+	demo := childDir(root, "DemoVirtualMachineSnapshot", "vm-1")
+	writeArchiveNode(t, demo, archiveNode{
+		apiVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
+		kind:       "DemoVirtualMachineSnapshot",
+		name:       "vm-1",
+	})
+
+	up := &stubUploader{}
+	vol := &stubVolumes{}
+	dyn := newFakeDynamic(readyRootSnapshot(), readyContent())
+
+	cfg := baseConfig(root, up, vol, dyn)
+	cfg.Mapper = testDomainMapper()
+	cfg.SelectedNodeKind = "DemoVirtualMachineSnapshot"
+	cfg.SelectedNodeName = "vm-1"
+
+	err := Run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error selecting a manifest-only domain node as standalone root, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "manifest-only domain node") {
+		t.Errorf("expected manifest-only-domain-node error, got: %v", err)
+	}
+
+	if len(up.calls) != 0 || len(vol.ensure) != 0 {
+		t.Errorf("no cluster mutations should occur on selection error: uploads=%d ensures=%d", len(up.calls), len(vol.ensure))
 	}
 }
 
@@ -1266,12 +1349,10 @@ func buildAggregatorWithDomainLeafArchive(t *testing.T) string {
 	return root
 }
 
-// TestPreflight_AggregatorBlocksDataLeaf verifies that a plan containing a domain aggregator
-// (DemoVirtualMachineSnapshot) is rejected by preflight with ONE actionable error that:
-//   - names the aggregator as unsupported
-//   - names the blocked data leaf and its blocking aggregator
-//   - mentions --node for importing a supported subtree
-func TestPreflight_AggregatorBlocksDataLeaf(t *testing.T) {
+// TestPreflight_AggregatorTreePasses verifies that a full archive containing a domain
+// aggregator (DemoVirtualMachineSnapshot) and its data-leaf child passes preflight: the
+// aggregator is reconstructed server-side as a non-root node, so a full-tree import is allowed.
+func TestPreflight_AggregatorTreePasses(t *testing.T) {
 	archiveRoot := buildAggregatorWithDomainLeafArchive(t)
 
 	plan, err := BuildPlan(archiveRoot)
@@ -1279,27 +1360,56 @@ func TestPreflight_AggregatorBlocksDataLeaf(t *testing.T) {
 		t.Fatalf("BuildPlan: %v", err)
 	}
 
-	preflightErr := preflight(plan)
-	if preflightErr == nil {
-		t.Fatal("expected preflight error for domain aggregator, got nil")
+	if err := preflight(plan); err != nil {
+		t.Errorf("expected preflight to pass for a full aggregator tree, got: %v", err)
+	}
+}
+
+// TestRun_FullAggregatorImport verifies that a full-archive import of a tree containing a
+// domain aggregator (DemoVirtualMachineSnapshot) succeeds end-to-end:
+//   - import-mode markers are created for the root, the aggregator, and the data leaf
+//   - manifests are uploaded for every node; the aggregator's upload carries its child ref
+//   - a DataImport is created ONLY for the data leaf (the aggregator carries no own data)
+func TestRun_FullAggregatorImport(t *testing.T) {
+	archiveRoot := buildAggregatorWithDomainLeafArchive(t)
+
+	up := &stubUploader{}
+	vol := &stubVolumes{}
+	dyn := newFakeDynamic(readyRootSnapshot(), readyContent())
+
+	cfg := baseConfig(archiveRoot, up, vol, dyn)
+	cfg.Mapper = testDomainMapper()
+
+	if err := Run(context.Background(), cfg); err != nil {
+		t.Fatalf("full aggregator import: %v", err)
 	}
 
-	msg := preflightErr.Error()
-
-	if !strings.Contains(msg, "DemoVirtualMachineSnapshot/vm-1") {
-		t.Errorf("preflight error should name the unsupported aggregator DemoVirtualMachineSnapshot/vm-1; got: %s", msg)
+	// A DataImport is created only for the data leaf, never for the aggregator.
+	if len(vol.ensure) != 1 || vol.ensure[0] != "dvd-1" {
+		t.Errorf("expected exactly one DataImport for the data leaf dvd-1, got: %v", vol.ensure)
 	}
 
-	if !strings.Contains(msg, "DemoVirtualDiskSnapshot/dvd-1") {
-		t.Errorf("preflight error should name the blocked data leaf DemoVirtualDiskSnapshot/dvd-1; got: %s", msg)
+	// The aggregator marker must have been created in the target namespace.
+	if _, err := dyn.Resource(demoVMSnapGVR).Namespace(targetNS).Get(context.Background(), "vm-1", metav1.GetOptions{}); err != nil {
+		t.Errorf("aggregator import CR DemoVirtualMachineSnapshot/vm-1 should have been created: %v", err)
 	}
 
-	if !strings.Contains(msg, "blocked by aggregator") {
-		t.Errorf("preflight error should mention 'blocked by aggregator'; got: %s", msg)
+	// The aggregator's upload must carry its data-leaf child ref so the server can aggregate it.
+	var aggUpload *uploadCall
+	for i := range up.calls {
+		if up.calls[i].ref.Kind == "DemoVirtualMachineSnapshot" && up.calls[i].ref.Name == "vm-1" {
+			aggUpload = &up.calls[i]
+
+			break
+		}
 	}
 
-	if !strings.Contains(msg, "--node") {
-		t.Errorf("preflight error should reference --node flag; got: %s", msg)
+	if aggUpload == nil {
+		t.Fatalf("expected a manifests upload for the aggregator DemoVirtualMachineSnapshot/vm-1; got calls: %+v", up.calls)
+	}
+
+	if len(aggUpload.body.ChildRefs) != 1 || aggUpload.body.ChildRefs[0].Name != "dvd-1" {
+		t.Errorf("aggregator upload should carry child ref DemoVirtualDiskSnapshot/dvd-1, got: %+v", aggUpload.body.ChildRefs)
 	}
 }
 

--- a/internal/snapshot/snapimport/import_test.go
+++ b/internal/snapshot/snapimport/import_test.go
@@ -461,21 +461,14 @@ func TestRun_DomainDataLeaf_EndToEnd(t *testing.T) {
 		t.Errorf("UploadVolumeData calls = %v, want [dvd-snap-1]", vol.upload)
 	}
 
-	// The domain leaf import-mode CR must have been created with spec.dataSource.name and
-	// spec.sourceRef set.
+	// The domain leaf import-mode CR must have been created with the unified import marker.
 	leafObj, err := dyn.Resource(demoDiskSnapGVR).Namespace(targetNS).Get(context.Background(), "dvd-snap-1", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("DemoVirtualDiskSnapshot import CR not created: %v", err)
 	}
 
-	dsName, _, _ := unstructured.NestedString(leafObj.Object, "spec", "dataSource", "name")
-	if dsName != "dvd-snap-1" {
-		t.Errorf("spec.dataSource.name = %q, want %q", dsName, "dvd-snap-1")
-	}
-
-	srcKind, _, _ := unstructured.NestedString(leafObj.Object, "spec", "sourceRef", "kind")
-	if srcKind != "DemoVirtualDisk" {
-		t.Errorf("spec.sourceRef.kind = %q, want DemoVirtualDisk", srcKind)
+	if _, found, _ := unstructured.NestedMap(leafObj.Object, "spec", "source", "import"); !found {
+		t.Error("domain leaf marker must set spec.source.import: {}")
 	}
 
 	// The domain leaf carries a child->parent ownerRef pointing to the root Snapshot.
@@ -495,8 +488,8 @@ func TestRun_DomainDataLeaf_EndToEnd(t *testing.T) {
 	}
 }
 
-// TestLeafTargetRef_DomainLeaf verifies that leafTargetRef resolves the group/resource for
-// a domain data leaf via the RESTMapper, using the real producer's group constant.
+// TestLeafTargetRef_DomainLeaf verifies that leafTargetRef derives the targetRef group/kind
+// for a domain data leaf directly from its apiVersion/kind, without a RESTMapper lookup.
 func TestLeafTargetRef_DomainLeaf(t *testing.T) {
 	leaf := PlannedNode{
 		APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
@@ -505,7 +498,7 @@ func TestLeafTargetRef_DomainLeaf(t *testing.T) {
 		DataFile:   "/archive/data.bin",
 	}
 
-	group, resource, err := leafTargetRef(leaf, testDomainMapper())
+	group, kind, err := leafTargetRef(leaf)
 	if err != nil {
 		t.Fatalf("leafTargetRef: %v", err)
 	}
@@ -514,8 +507,8 @@ func TestLeafTargetRef_DomainLeaf(t *testing.T) {
 		t.Errorf("group = %q, want demo.state-snapshotter.deckhouse.io", group)
 	}
 
-	if resource != "demovirtualdisksnapshots" {
-		t.Errorf("resource = %q, want demovirtualdisksnapshots", resource)
+	if kind != "DemoVirtualDiskSnapshot" {
+		t.Errorf("kind = %q, want DemoVirtualDiskSnapshot", kind)
 	}
 }
 
@@ -705,7 +698,7 @@ func readyImportLeafVS() *unstructured.Unstructured {
 		"kind":       "VolumeSnapshot",
 		"metadata":   map[string]interface{}{"namespace": targetNS, "name": "pvc-1", "uid": "vs-uid"},
 		"spec": map[string]interface{}{
-			"source": map[string]interface{}{"dataImportName": "pvc-1"},
+			"source": map[string]interface{}{"import": map[string]interface{}{}},
 		},
 		"status": map[string]interface{}{
 			"boundSnapshotContentName": "content-leaf",

--- a/internal/snapshot/snapimport/markers.go
+++ b/internal/snapshot/snapimport/markers.go
@@ -42,41 +42,51 @@ func (n PlannedNode) isVolumeSnapshotLeaf() bool {
 	return n.Ref("").IsVolumeSnapshotLeaf()
 }
 
-// supported reports whether the CLI can client-drive the import of this node kind.
-// Core Snapshot trees, CSI VolumeSnapshot data leaves, and domain data leaves (e.g.
-// DemoVirtualDiskSnapshot with volume data) are supported. Domain aggregator nodes
-// (e.g. DemoVirtualMachineSnapshot with no own volume data) are not: they require a
-// server-side import path and cannot be imported client-side.
-func (n PlannedNode) supported() bool {
+// hasChildren reports whether the node carries any direct child snapshot refs.
+func (n PlannedNode) hasChildren() bool {
+	return len(n.Children) > 0
+}
+
+// canBeImportRoot reports whether the node can be the independent root of an import: a
+// core Snapshot tree, a CSI VolumeSnapshot data leaf, or a domain data leaf. These kinds
+// are either materialised by the namespace Snapshot import orchestrator (core Snapshot) or
+// carry their own volume data (leaves), so the CLI can drive them with no parent present.
+// Domain aggregators and manifest-only domain nodes are intentionally excluded: imported
+// standalone they have no parent SnapshotContent to attach to (the server's genericbinder
+// skips root generic imports), so they can only be reconstructed as non-root nodes within
+// their parent tree (a full-archive import, or a --node selection of an ancestor Snapshot).
+func (n PlannedNode) canBeImportRoot() bool {
 	return n.isStructural() || n.isVolumeSnapshotLeaf() || n.isDomainDataLeaf()
 }
 
 // isDomainAggregator reports whether the node is a domain aggregator: a domain-kind
-// snapshot that carries no own volume data (only child snapshot refs). Domain aggregators
-// cannot be imported client-side — they require the server's genericbinder import path
-// to materialise a parent SnapshotContent, which is a server-side-only operation.
+// snapshot that carries no own volume data but DOES reference child snapshots (e.g. an
+// intermediate DemoVirtualMachineSnapshot fanning out to child DemoVirtualDiskSnapshot
+// nodes). Aggregators are reconstructed server-side: the CLI creates the unified import
+// marker and uploads the node's manifests + child refs, then the genericbinder aggregates
+// the children's SnapshotContents into the aggregator's content. This is fully client-
+// drivable as a NON-ROOT node, so an aggregator is importable as part of its parent tree;
+// it just cannot be selected as a standalone --node root (see canBeImportRoot). A domain
+// node with neither data nor children is a manifest-only node, not an aggregator.
 func (n PlannedNode) isDomainAggregator() bool {
-	return !n.isStructural() && !n.isVolumeSnapshotLeaf() && !n.isDomainDataLeaf()
+	return !n.isStructural() && !n.isVolumeSnapshotLeaf() && !n.isDomainDataLeaf() && n.hasChildren()
 }
 
 // importMarkerCR builds the minimal import-mode CR the server requires to exist before
 // it will accept a manifests-and-children-refs-upload for this node.
 //
-// All supported node kinds — core Snapshot trees, CSI VolumeSnapshot leaves, and domain
-// data leaves — use the same unified marker: spec.source.import: {}. The server keys import
-// mode off this marker; for data leaves the volume content is matched to its DataImport by a
-// reverse-lookup on the DataImport's targetRef (group/kind/name), so the leaf no longer needs
-// to name its DataImport or mirror the captured source.
+// Every node kind uses the same unified marker: spec.source.import: {}. The server keys
+// import mode off this marker. Core Snapshot trees and domain aggregators are materialised
+// server-side from the uploaded manifests + child refs (the genericbinder aggregates the
+// children's SnapshotContents); data leaves additionally stream their volume bytes, matched
+// to their DataImport by a reverse-lookup on the DataImport's targetRef (group/kind/name);
+// manifest-only domain nodes materialise from manifests alone.
 func importMarkerCR(node PlannedNode, namespace string) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(node.APIVersion)
 	obj.SetKind(node.Kind)
 	obj.SetNamespace(namespace)
 	obj.SetName(node.Name)
-
-	if !node.supported() {
-		return nil, unsupportedNodeError(node)
-	}
 
 	if err := unstructured.SetNestedMap(obj.Object, map[string]interface{}{}, "spec", "source", "import"); err != nil {
 		return nil, fmt.Errorf("set import marker: %w", err)
@@ -85,11 +95,11 @@ func importMarkerCR(node PlannedNode, namespace string) (*unstructured.Unstructu
 	return obj, nil
 }
 
-// unsupportedNodeError returns a clear, actionable error for domain aggregator nodes the
-// CLI cannot client-drive during import. Called from importMarkerCR default case.
+// unsupportedNodeError reports an internal invariant violation: a node reached the data-leaf
+// DataImport path (leafTargetRef) although it is neither a CSI VolumeSnapshot leaf nor a
+// domain data leaf. importNodeData only ever invokes that path for data leaves, so this is a
+// programming error rather than a user-facing condition.
 func unsupportedNodeError(node PlannedNode) error {
-	return fmt.Errorf("import of %s/%s is not supported by this CLI: "+
-		"domain aggregator nodes (e.g. intermediate DemoVirtualMachineSnapshot) "+
-		"require a server-side import path and cannot be imported client-side; "+
-		"use --node <Kind>/<name> to import a supported subtree", node.Kind, node.Name)
+	return fmt.Errorf("internal: %s/%s reached the data-leaf import path but carries no own "+
+		"volume data (not a CSI VolumeSnapshot or domain data leaf)", node.Kind, node.Name)
 }

--- a/internal/snapshot/snapimport/markers.go
+++ b/internal/snapshot/snapimport/markers.go
@@ -62,61 +62,24 @@ func (n PlannedNode) isDomainAggregator() bool {
 // importMarkerCR builds the minimal import-mode CR the server requires to exist before
 // it will accept a manifests-and-children-refs-upload for this node.
 //
-//   - core Snapshot:  spec.source.import: {}
-//   - CSI VolumeSnapshot leaf: spec.source.dataImportName: <dataImportName>
-//
-// dataImportName is only consulted for VolumeSnapshot leaves.
-func importMarkerCR(node PlannedNode, namespace, dataImportName string) (*unstructured.Unstructured, error) {
+// All supported node kinds — core Snapshot trees, CSI VolumeSnapshot leaves, and domain
+// data leaves — use the same unified marker: spec.source.import: {}. The server keys import
+// mode off this marker; for data leaves the volume content is matched to its DataImport by a
+// reverse-lookup on the DataImport's targetRef (group/kind/name), so the leaf no longer needs
+// to name its DataImport or mirror the captured source.
+func importMarkerCR(node PlannedNode, namespace string) (*unstructured.Unstructured, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(node.APIVersion)
 	obj.SetKind(node.Kind)
 	obj.SetNamespace(namespace)
 	obj.SetName(node.Name)
 
-	switch {
-	case node.isStructural():
-		if err := unstructured.SetNestedMap(obj.Object, map[string]interface{}{}, "spec", "source", "import"); err != nil {
-			return nil, fmt.Errorf("set import marker: %w", err)
-		}
-
-	case node.isVolumeSnapshotLeaf():
-		if dataImportName == "" {
-			return nil, fmt.Errorf("leaf VolumeSnapshot %q requires a DataImport name", node.Name)
-		}
-
-		if err := unstructured.SetNestedField(obj.Object, dataImportName, "spec", "source", "dataImportName"); err != nil {
-			return nil, fmt.Errorf("set dataImportName: %w", err)
-		}
-
-	case node.isDomainDataLeaf():
-		if node.SourceObjectRef == nil {
-			return nil, fmt.Errorf("domain data leaf %s/%s missing SourceObjectRef in snapshot.yaml; cannot build import marker", node.Kind, node.Name)
-		}
-
-		if dataImportName == "" {
-			return nil, fmt.Errorf("domain data leaf %s/%s requires a DataImport name", node.Kind, node.Name)
-		}
-
-		// spec.sourceRef tells the domain controller what was captured (mirrors the
-		// original capture-mode spec.sourceRef so the domain CR is self-describing).
-		sourceRef := map[string]interface{}{
-			"apiVersion": node.SourceObjectRef.APIVersion,
-			"kind":       node.SourceObjectRef.Kind,
-			"name":       node.SourceObjectRef.Name,
-		}
-
-		if err := unstructured.SetNestedMap(obj.Object, sourceRef, "spec", "sourceRef"); err != nil {
-			return nil, fmt.Errorf("set spec.sourceRef: %w", err)
-		}
-
-		// spec.dataSource.name is the import-mode trigger read by the genericbinder
-		// reconcileGenericImport path (snapshotImportDataImportName).
-		if err := unstructured.SetNestedField(obj.Object, dataImportName, "spec", "dataSource", "name"); err != nil {
-			return nil, fmt.Errorf("set spec.dataSource.name: %w", err)
-		}
-
-	default:
+	if !node.supported() {
 		return nil, unsupportedNodeError(node)
+	}
+
+	if err := unstructured.SetNestedMap(obj.Object, map[string]interface{}{}, "spec", "source", "import"); err != nil {
+		return nil, fmt.Errorf("set import marker: %w", err)
 	}
 
 	return obj, nil

--- a/internal/snapshot/snapimport/markers_test.go
+++ b/internal/snapshot/snapimport/markers_test.go
@@ -21,14 +21,30 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/deckhouse/deckhouse-cli/internal/snapshot/archive"
 )
+
+// assertImportMarker verifies the unified spec.source.import: {} marker is present (and empty).
+func assertImportMarker(t *testing.T, obj *unstructured.Unstructured) {
+	t.Helper()
+
+	m, found, err := unstructured.NestedMap(obj.Object, "spec", "source", "import")
+	if err != nil {
+		t.Fatalf("read spec.source.import: %v", err)
+	}
+
+	if !found {
+		t.Fatalf("expected spec.source.import marker to be set")
+	}
+
+	if len(m) != 0 {
+		t.Errorf("spec.source.import must be an empty map, got %v", m)
+	}
+}
 
 func TestImportMarkerCR_Snapshot(t *testing.T) {
 	node := PlannedNode{APIVersion: "storage.deckhouse.io/v1alpha1", Kind: "Snapshot", Name: "root"}
 
-	obj, err := importMarkerCR(node, "ns", "")
+	obj, err := importMarkerCR(node, "ns")
 	if err != nil {
 		t.Fatalf("importMarkerCR: %v", err)
 	}
@@ -37,38 +53,27 @@ func TestImportMarkerCR_Snapshot(t *testing.T) {
 		t.Errorf("unexpected metadata: ns=%q name=%q", obj.GetNamespace(), obj.GetName())
 	}
 
-	if _, found, _ := unstructured.NestedMap(obj.Object, "spec", "source", "import"); !found {
-		t.Errorf("expected spec.source.import marker to be set")
-	}
+	assertImportMarker(t, obj)
 }
 
 func TestImportMarkerCR_VolumeSnapshot(t *testing.T) {
 	node := PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "pvc-1"}
 
-	obj, err := importMarkerCR(node, "ns", "di-1")
+	obj, err := importMarkerCR(node, "ns")
 	if err != nil {
 		t.Fatalf("importMarkerCR: %v", err)
 	}
 
-	name, found, _ := unstructured.NestedString(obj.Object, "spec", "source", "dataImportName")
-	if !found || name != "di-1" {
-		t.Errorf("spec.source.dataImportName: found=%v value=%q, want %q", found, name, "di-1")
-	}
-}
-
-func TestImportMarkerCR_VolumeSnapshot_RequiresDataImport(t *testing.T) {
-	node := PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "pvc-1"}
-
-	if _, err := importMarkerCR(node, "ns", ""); err == nil {
-		t.Fatal("expected error when DataImport name is empty, got nil")
-	}
+	// CSI VolumeSnapshot leaves use the same unified marker as every other node; the leaf no
+	// longer names its DataImport (matched server-side by targetRef reverse-lookup instead).
+	assertImportMarker(t, obj)
 }
 
 func TestImportMarkerCR_UnsupportedKind(t *testing.T) {
 	// DemoVirtualMachineSnapshot with NO volume data is an unsupported intermediate aggregator.
 	node := PlannedNode{APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1", Kind: "DemoVirtualMachineSnapshot", Name: "vm-1"}
 
-	_, err := importMarkerCR(node, "ns", "")
+	_, err := importMarkerCR(node, "ns")
 	if err == nil {
 		t.Fatal("expected unsupported-kind error, got nil")
 	}
@@ -84,14 +89,9 @@ func TestImportMarkerCR_DomainDataLeaf(t *testing.T) {
 		Kind:       "DemoVirtualDiskSnapshot",
 		Name:       "dvd-snap-1",
 		DataFile:   "/archive/snapshots/demovirtualdisksnapshot_disk-a/data.bin",
-		SourceObjectRef: &archive.SourceObjectRef{
-			APIVersion: "demo.deckhouse.io/v1alpha1",
-			Kind:       "DemoVirtualDisk",
-			Name:       "disk-a",
-		},
 	}
 
-	obj, err := importMarkerCR(node, "ns", "dvd-snap-1")
+	obj, err := importMarkerCR(node, "ns")
 	if err != nil {
 		t.Fatalf("importMarkerCR: %v", err)
 	}
@@ -100,39 +100,9 @@ func TestImportMarkerCR_DomainDataLeaf(t *testing.T) {
 		t.Errorf("unexpected metadata: ns=%q name=%q", obj.GetNamespace(), obj.GetName())
 	}
 
-	// spec.dataSource.name carries the DataImport name (genericbinder import trigger).
-	dsName, found, _ := unstructured.NestedString(obj.Object, "spec", "dataSource", "name")
-	if !found || dsName != "dvd-snap-1" {
-		t.Errorf("spec.dataSource.name: found=%v value=%q, want %q", found, dsName, "dvd-snap-1")
-	}
-
-	// spec.sourceRef mirrors the captured-object identity so the domain CR is self-describing.
-	apiVersion, _, _ := unstructured.NestedString(obj.Object, "spec", "sourceRef", "apiVersion")
-	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "sourceRef", "kind")
-	name, _, _ := unstructured.NestedString(obj.Object, "spec", "sourceRef", "name")
-
-	if apiVersion != "demo.deckhouse.io/v1alpha1" || kind != "DemoVirtualDisk" || name != "disk-a" {
-		t.Errorf("spec.sourceRef = {%q, %q, %q}, want {demo.deckhouse.io/v1alpha1, DemoVirtualDisk, disk-a}", apiVersion, kind, name)
-	}
-}
-
-func TestImportMarkerCR_DomainDataLeaf_MissingSourceObjectRef(t *testing.T) {
-	node := PlannedNode{
-		APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
-		Kind:       "DemoVirtualDiskSnapshot",
-		Name:       "dvd-snap-1",
-		DataFile:   "/archive/snapshots/demovirtualdisksnapshot_disk-a/data.bin",
-		// SourceObjectRef intentionally nil: simulates an archive written before the field was added.
-	}
-
-	_, err := importMarkerCR(node, "ns", "dvd-snap-1")
-	if err == nil {
-		t.Fatal("expected error for missing SourceObjectRef, got nil")
-	}
-
-	if !strings.Contains(err.Error(), "SourceObjectRef") {
-		t.Errorf("error %q should mention SourceObjectRef", err.Error())
-	}
+	// Domain data leaves use the unified marker too; the captured-source identity is no longer
+	// mirrored onto the marker (the DataImport carries it via targetRef).
+	assertImportMarker(t, obj)
 }
 
 func TestPlannedNode_Supported(t *testing.T) {

--- a/internal/snapshot/snapimport/markers_test.go
+++ b/internal/snapshot/snapimport/markers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapimport
 
 import (
-	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -69,18 +68,50 @@ func TestImportMarkerCR_VolumeSnapshot(t *testing.T) {
 	assertImportMarker(t, obj)
 }
 
-func TestImportMarkerCR_UnsupportedKind(t *testing.T) {
-	// DemoVirtualMachineSnapshot with NO volume data is an unsupported intermediate aggregator.
+func TestImportMarkerCR_DomainAggregator(t *testing.T) {
+	// A DemoVirtualMachineSnapshot that references child snapshots but carries no own volume
+	// data is a domain aggregator. It is reconstructed server-side as a NON-ROOT node, so it
+	// gets the same unified spec.source.import: {} marker as every other node (no error); the
+	// genericbinder later aggregates its children's contents into the aggregator's content.
+	node := PlannedNode{
+		APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
+		Kind:       "DemoVirtualMachineSnapshot",
+		Name:       "vm-1",
+		Children: []ChildRef{{
+			APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
+			Kind:       "DemoVirtualDiskSnapshot",
+			Name:       "dvd-1",
+		}},
+	}
+
+	obj, err := importMarkerCR(node, "ns")
+	if err != nil {
+		t.Fatalf("importMarkerCR for domain aggregator: %v", err)
+	}
+
+	if obj.GetNamespace() != "ns" || obj.GetName() != "vm-1" {
+		t.Errorf("unexpected metadata: ns=%q name=%q", obj.GetNamespace(), obj.GetName())
+	}
+
+	assertImportMarker(t, obj)
+}
+
+func TestImportMarkerCR_ManifestOnlyDomainNode(t *testing.T) {
+	// A DemoVirtualMachineSnapshot with neither volume data nor child snapshots is a
+	// manifest-only domain node: import-equivalent to a structural Snapshot, so it gets the
+	// unified spec.source.import: {} marker (no error).
 	node := PlannedNode{APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1", Kind: "DemoVirtualMachineSnapshot", Name: "vm-1"}
 
-	_, err := importMarkerCR(node, "ns")
-	if err == nil {
-		t.Fatal("expected unsupported-kind error, got nil")
+	obj, err := importMarkerCR(node, "ns")
+	if err != nil {
+		t.Fatalf("importMarkerCR for manifest-only domain node: %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "not supported") {
-		t.Errorf("error %q does not explain lack of support", err.Error())
+	if obj.GetNamespace() != "ns" || obj.GetName() != "vm-1" {
+		t.Errorf("unexpected metadata: ns=%q name=%q", obj.GetNamespace(), obj.GetName())
 	}
+
+	assertImportMarker(t, obj)
 }
 
 func TestImportMarkerCR_DomainDataLeaf(t *testing.T) {
@@ -105,29 +136,41 @@ func TestImportMarkerCR_DomainDataLeaf(t *testing.T) {
 	assertImportMarker(t, obj)
 }
 
-func TestPlannedNode_Supported(t *testing.T) {
+// TestPlannedNode_IsDomainAggregator verifies the classification that gates the standalone
+// --node root restriction: only a domain node with no own volume data but WITH child refs is
+// an aggregator. Aggregators are still importable as non-root nodes within a tree.
+func TestPlannedNode_IsDomainAggregator(t *testing.T) {
 	cases := []struct {
 		name string
 		node PlannedNode
 		want bool
 	}{
-		{"core snapshot", PlannedNode{APIVersion: "storage.deckhouse.io/v1alpha1", Kind: "Snapshot"}, true},
-		{"csi volume snapshot", PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot"}, true},
-		// A domain disk snapshot WITH volume data is a domain data leaf → supported.
+		{"core snapshot", PlannedNode{APIVersion: "storage.deckhouse.io/v1alpha1", Kind: "Snapshot"}, false},
+		{"csi volume snapshot", PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot"}, false},
+		// A domain disk snapshot WITH volume data is a domain data leaf, not an aggregator.
 		{"demo disk snapshot with block data", PlannedNode{
 			APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
 			Kind:       "DemoVirtualDiskSnapshot",
 			DataFile:   "/some/data.bin",
+		}, false},
+		// A domain snapshot with neither volume data nor children is manifest-only, not an aggregator.
+		{"manifest-only demo vm snapshot", PlannedNode{APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1", Kind: "DemoVirtualMachineSnapshot"}, false},
+		// A domain snapshot with no data but WITH children is a true aggregator.
+		{"demo vm snapshot aggregator (has children)", PlannedNode{
+			APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
+			Kind:       "DemoVirtualMachineSnapshot",
+			Children: []ChildRef{{
+				APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1",
+				Kind:       "DemoVirtualDiskSnapshot",
+				Name:       "dvd-1",
+			}},
 		}, true},
-		// A domain disk snapshot WITHOUT volume data is NOT a data leaf → unsupported.
-		{"demo disk snapshot no data", PlannedNode{APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1", Kind: "DemoVirtualDiskSnapshot"}, false},
-		{"demo vm snapshot", PlannedNode{APIVersion: "demo.state-snapshotter.deckhouse.io/v1alpha1", Kind: "DemoVirtualMachineSnapshot"}, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.node.supported(); got != tc.want {
-				t.Errorf("supported() = %v, want %v", got, tc.want)
+			if got := tc.node.isDomainAggregator(); got != tc.want {
+				t.Errorf("isDomainAggregator() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/snapshot/snapimport/plan.go
+++ b/internal/snapshot/snapimport/plan.go
@@ -75,6 +75,13 @@ type PlannedNode struct {
 	// ({apiVersion,kind,name} of the source object), read from snapshot.yaml. Nil for
 	// core Snapshot nodes and CSI VolumeSnapshot data leaves.
 	SourceObjectRef *archive.SourceObjectRef
+	// StorageClassName/Size/VolumeMode describe the leaf's captured volume, read from the
+	// first entry of snapshot.yaml Volumes (originally SnapshotContent.status.dataRef). For a
+	// Mode A data-leaf import they become the DataImport's root storageClassName/size/volumeMode.
+	// Empty for structural/aggregator nodes that own no volume data.
+	StorageClassName string
+	Size             string
+	VolumeMode       string
 }
 
 // Ref returns the node's aggregated-API node ref (target namespace applied by the caller).
@@ -94,8 +101,9 @@ func (n PlannedNode) HasBlockData() bool {
 
 // isDomainDataLeaf reports whether the node is a domain data leaf: it carries volume data
 // (block or filesystem) and is neither a core Snapshot nor a CSI VolumeSnapshot leaf.
-// Domain data leaves (e.g. DemoVirtualDiskSnapshot) are imported via spec.dataSource.name
-// by the genericbinder server path, unlike CSI leaves which use spec.source.dataImportName.
+// Domain data leaves (e.g. DemoVirtualDiskSnapshot) and CSI leaves both use the unified
+// spec.source.import: {} marker; their volume content is matched to a DataImport by its
+// targetRef (group/kind/name) in the server-side reverse-lookup.
 func (n PlannedNode) isDomainDataLeaf() bool {
 	return !n.isStructural() && !n.isVolumeSnapshotLeaf() && (n.HasBlockData() || n.FilesystemData)
 }
@@ -175,6 +183,16 @@ func readNode(dir string) (PlannedNode, error) {
 		SourceNamespace: sy.Namespace,
 		Manifests:       manifests,
 		SourceObjectRef: sy.SourceObjectRef,
+	}
+
+	// Data leaves carry exactly one volume; lift its captured metadata onto the node so
+	// EnsureDataImport can echo storageClassName/size/volumeMode into the Mode A DataImport.
+	// Structural/aggregator nodes have no Volumes and leave these empty.
+	if len(sy.Volumes) > 0 {
+		vol := sy.Volumes[0]
+		node.StorageClassName = vol.StorageClassName
+		node.Size = vol.Size
+		node.VolumeMode = vol.VolumeMode
 	}
 
 	blockData, found, err := archive.FindBlockData(dir)

--- a/internal/snapshot/snapimport/plan_test.go
+++ b/internal/snapshot/snapimport/plan_test.go
@@ -35,6 +35,7 @@ type archiveNode struct {
 	manifests       []map[string]interface{}
 	blockData       []byte
 	sourceObjectRef *archive.SourceObjectRef
+	volumes         []archive.VolumeInfo
 }
 
 // writeArchiveNode writes snapshot.yaml, manifests/ and optional data.bin into dir.
@@ -51,6 +52,7 @@ func writeArchiveNode(t *testing.T, dir string, n archiveNode) {
 		Name:            n.name,
 		Namespace:       n.namespace,
 		SourceObjectRef: n.sourceObjectRef,
+		Volumes:         n.volumes,
 	}); err != nil {
 		t.Fatalf("write snapshot.yaml: %v", err)
 	}
@@ -210,6 +212,64 @@ func TestBuildPlan_DomainDataLeaf_SourceObjectRef(t *testing.T) {
 
 	if !leaf.isDomainDataLeaf() {
 		t.Error("DemoVirtualDiskSnapshot with block data should be isDomainDataLeaf()")
+	}
+}
+
+// TestBuildPlan_LeafVolumeMetadata verifies that the captured volume metadata
+// (storageClassName/size/volumeMode) written into snapshot.yaml Volumes[0] is lifted onto
+// the PlannedNode so EnsureDataImport can echo it into the Mode A DataImport spec.
+func TestBuildPlan_LeafVolumeMetadata(t *testing.T) {
+	root := t.TempDir()
+	writeArchiveNode(t, root, archiveNode{
+		apiVersion: "storage.deckhouse.io/v1alpha1",
+		kind:       "Snapshot",
+		name:       "root",
+	})
+
+	leafDir := childDir(root, "VolumeSnapshot", "pvc-1")
+	writeArchiveNode(t, leafDir, archiveNode{
+		apiVersion: "snapshot.storage.k8s.io/v1",
+		kind:       "VolumeSnapshot",
+		name:       "pvc-1",
+		blockData:  []byte("rawbytes"),
+		volumes: []archive.VolumeInfo{{
+			StorageClassName: "linstor-thin-r1",
+			Size:             "10Gi",
+			VolumeMode:       "Block",
+		}},
+	})
+
+	plan, err := BuildPlan(root)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	var leaf *PlannedNode
+
+	for i := range plan {
+		if plan[i].Kind == "VolumeSnapshot" {
+			leaf = &plan[i]
+
+			break
+		}
+	}
+
+	if leaf == nil {
+		t.Fatal("VolumeSnapshot node not found in plan")
+	}
+
+	if leaf.StorageClassName != "linstor-thin-r1" || leaf.Size != "10Gi" || leaf.VolumeMode != "Block" {
+		t.Errorf("leaf volume metadata = {sc:%q, size:%q, mode:%q}, want {linstor-thin-r1, 10Gi, Block}",
+			leaf.StorageClassName, leaf.Size, leaf.VolumeMode)
+	}
+
+	// A structural node owns no volumes and must leave the metadata empty.
+	for i := range plan {
+		if plan[i].Kind == "Snapshot" {
+			if plan[i].StorageClassName != "" || plan[i].Size != "" || plan[i].VolumeMode != "" {
+				t.Errorf("structural node carried volume metadata: %+v", plan[i])
+			}
+		}
 	}
 }
 

--- a/internal/snapshot/snapimport/volume.go
+++ b/internal/snapshot/snapimport/volume.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -42,7 +41,6 @@ import (
 
 const (
 	dataImportKind        = "DataImport"
-	dataArtifactTypeVSC   = "VolumeSnapshotContent"
 	volumeModeBlock       = "Block"
 	conditionReady        = "Ready"
 	conditionCompleted    = "Completed"
@@ -67,11 +65,10 @@ var dataImportGVR = schema.GroupVersionResource{Group: "storage.deckhouse.io", V
 // upload, and waiting for the durable artifact to be produced. It is satisfied by
 // clusterVolumeImporter and stubbed in tests.
 type VolumeImporter interface {
-	// DataImportName returns the deterministic DataImport name for the leaf. It lets the
-	// import-mode CR reference its DataImport (spec.source.dataImportName) before the
-	// DataImport is created, so creation can be deferred until just before the upload —
-	// the DataImport TTL is an idle timer that starts at importer-pod start, so a freshly
-	// created importer must not sit idle waiting for earlier siblings to finish.
+	// DataImportName returns the deterministic DataImport name for the leaf (its own name).
+	// The DataImport is created bottom-up immediately before its upload — its TTL is an idle
+	// timer that starts at importer-pod start, so a freshly created importer must not sit
+	// idle waiting for earlier siblings to finish.
 	DataImportName(leaf PlannedNode) string
 	// EnsureDataImport creates (idempotently) the DataImport for the leaf and returns its name.
 	EnsureDataImport(ctx context.Context, leaf PlannedNode, namespace string) (string, error)
@@ -84,13 +81,12 @@ type VolumeImporter interface {
 // CR lifecycle and status) and a SafeClient (authenticated HTTPS byte upload to the
 // importer pod, trusting status.ca).
 type clusterVolumeImporter struct {
-	dyn    dynamic.Interface
-	sc     *safeClient.SafeClient
-	ttl    string
-	poll   time.Duration
-	wait   time.Duration
-	log    *slog.Logger
-	mapper meta.RESTMapper
+	dyn  dynamic.Interface
+	sc   *safeClient.SafeClient
+	ttl  string
+	poll time.Duration
+	wait time.Duration
+	log  *slog.Logger
 	// tempDir is the directory for decompressed block-volume temporary files. When empty,
 	// sendVolumeData defaults to filepath.Dir(leaf.DataFile) — next to the archive node
 	// on the same filesystem as the compressed source. Override via --temp-dir.
@@ -100,23 +96,21 @@ type clusterVolumeImporter struct {
 
 // NewClusterVolumeImporter builds the live VolumeImporter. ttl is the DataImport TTL,
 // wait bounds the per-DataImport readiness/completion waits, poll is the polling cadence,
-// tempDir is the scratch directory for decompressed block-volume temp files (empty =
-// auto-select filepath.Dir(leaf.DataFile), keeping temps on the same filesystem as the archive),
-// and mapper resolves domain leaf GVKs to their resource plurals for DataImport targetRef.
+// and tempDir is the scratch directory for decompressed block-volume temp files (empty =
+// auto-select filepath.Dir(leaf.DataFile), keeping temps on the same filesystem as the archive).
 func NewClusterVolumeImporter(
 	dyn dynamic.Interface,
 	sc *safeClient.SafeClient,
 	ttl string,
 	wait, poll time.Duration,
 	tempDir string,
-	mapper meta.RESTMapper,
 	log *slog.Logger,
 ) VolumeImporter {
 	if log == nil {
 		log = slog.Default()
 	}
 
-	return &clusterVolumeImporter{dyn: dyn, sc: sc, ttl: ttl, poll: poll, wait: wait, tempDir: tempDir, mapper: mapper, log: log}
+	return &clusterVolumeImporter{dyn: dyn, sc: sc, ttl: ttl, poll: poll, wait: wait, tempDir: tempDir, log: log}
 }
 
 // DataImportName returns the deterministic DataImport name for the leaf (its own name).
@@ -124,13 +118,28 @@ func (c *clusterVolumeImporter) DataImportName(leaf PlannedNode) string {
 	return leaf.Name
 }
 
-// EnsureDataImport upserts the DataImport targeting the leaf snapshot CR.
+// EnsureDataImport upserts the Mode A DataImport targeting the leaf snapshot CR. The leaf's
+// captured volume metadata (storageClassName/size/volumeMode, read back from the archive) is
+// echoed into spec so the controller can provision the scratch PVC and produce the durable
+// VolumeSnapshotContent artifact. The mode is identified server-side by targetRef.kind (a
+// snapshot-leaf kind ⇒ Mode A); the discriminator value PersistentVolumeClaim is reserved for
+// the standalone Mode B path driven by `d8 data import`.
 func (c *clusterVolumeImporter) EnsureDataImport(ctx context.Context, leaf PlannedNode, namespace string) (string, error) {
 	name := c.DataImportName(leaf)
 
-	group, resource, err := leafTargetRef(leaf, c.mapper)
+	group, kind, err := leafTargetRef(leaf)
 	if err != nil {
 		return "", err
+	}
+
+	// storageClassName and size are mandatory for Mode A (enforced by the CRD CEL rules).
+	// They originate from the captured SnapshotContent.status.dataRef and are carried through
+	// the archive; a blank value means a malformed archive, so fail early with a clear message
+	// rather than letting the API server reject an incomplete DataImport.
+	if leaf.StorageClassName == "" || leaf.Size == "" {
+		return "", fmt.Errorf("data leaf %s/%s is missing volume metadata in the archive "+
+			"(storageClassName=%q, size=%q); re-download the snapshot with a current d8 version",
+			leaf.Kind, leaf.Name, leaf.StorageClassName, leaf.Size)
 	}
 
 	obj := &unstructured.Unstructured{}
@@ -141,13 +150,18 @@ func (c *clusterVolumeImporter) EnsureDataImport(ctx context.Context, leaf Plann
 
 	spec := map[string]interface{}{
 		"ttl":              c.ttl,
-		"dataArtifactType": dataArtifactTypeVSC,
+		"storageClassName": leaf.StorageClassName,
+		"size":             leaf.Size,
 		"targetRef": map[string]interface{}{
-			"group":    group,
-			"resource": resource,
-			"name":     leaf.Name,
+			"group": group,
+			"kind":  kind,
+			"name":  leaf.Name,
 		},
 	}
+	if leaf.VolumeMode != "" {
+		spec["volumeMode"] = leaf.VolumeMode
+	}
+
 	if err := unstructured.SetNestedMap(obj.Object, spec, "spec"); err != nil {
 		return "", fmt.Errorf("build DataImport spec: %w", err)
 	}
@@ -446,13 +460,13 @@ func (c *clusterVolumeImporter) waitDataImportCompleted(ctx context.Context, nam
 	}
 }
 
-// leafTargetRef returns the DataImport targetRef {group, resource} for a data leaf.
-// For CSI VolumeSnapshot leaves the group/resource are fixed constants. For domain data
-// leaves the resource plural is resolved via mapper (the domain controller drives import
-// through spec.dataSource.name; the DataImport targetRef identifies the leaf snapshot CR).
-func leafTargetRef(leaf PlannedNode, mapper meta.RESTMapper) (string, string, error) {
+// leafTargetRef returns the DataImport targetRef {group, kind} for a data leaf. The
+// state-snapshotter reverse-lookup matches the leaf by GroupKind directly, so no RESTMapper
+// resource resolution is needed: the kind is the leaf's own kind and the group is parsed from
+// its apiVersion. For CSI VolumeSnapshot leaves the group/kind are fixed constants.
+func leafTargetRef(leaf PlannedNode) (string, string, error) {
 	if leaf.isVolumeSnapshotLeaf() {
-		return aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotResource, nil
+		return aggapi.VolumeSnapshotGroup, aggapi.VolumeSnapshotKind, nil
 	}
 
 	if leaf.isDomainDataLeaf() {
@@ -461,16 +475,7 @@ func leafTargetRef(leaf PlannedNode, mapper meta.RESTMapper) (string, string, er
 			return "", "", fmt.Errorf("parse apiVersion %q for domain leaf %s/%s: %w", leaf.APIVersion, leaf.Kind, leaf.Name, parseErr)
 		}
 
-		if mapper == nil {
-			return "", "", fmt.Errorf("RESTMapper required to resolve domain leaf %s/%s resource", leaf.Kind, leaf.Name)
-		}
-
-		mapping, mapErr := mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: leaf.Kind}, gv.Version)
-		if mapErr != nil {
-			return "", "", fmt.Errorf("resolve resource for domain leaf %s/%s: %w", leaf.Kind, leaf.Name, mapErr)
-		}
-
-		return gv.Group, mapping.Resource.Resource, nil
+		return gv.Group, leaf.Kind, nil
 	}
 
 	return "", "", unsupportedNodeError(leaf)

--- a/internal/snapshot/snapimport/volume_test.go
+++ b/internal/snapshot/snapimport/volume_test.go
@@ -243,7 +243,7 @@ func newTestVolumeImporter(dyn *dynamicfake.FakeDynamicClient) *clusterVolumeImp
 }
 
 func TestEnsureDataImport_ReusesHealthy(t *testing.T) {
-	leaf := PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "pvc-1"}
+	leaf := volumeSnapshotLeaf("pvc-1")
 
 	dyn := newFakeDataImportDyn(dataImportObj(targetNS, "pvc-1", false))
 	imp := newTestVolumeImporter(dyn)
@@ -266,8 +266,84 @@ func TestEnsureDataImport_ReusesHealthy(t *testing.T) {
 	}
 }
 
-func TestEnsureDataImport_AlignsTTLOnReuse(t *testing.T) {
+// volumeSnapshotLeaf builds a CSI VolumeSnapshot data leaf carrying the captured volume
+// metadata that EnsureDataImport echoes into the Mode A DataImport spec.
+func volumeSnapshotLeaf(name string) PlannedNode {
+	return PlannedNode{
+		APIVersion:       "snapshot.storage.k8s.io/v1",
+		Kind:             "VolumeSnapshot",
+		Name:             name,
+		StorageClassName: "sc-1",
+		Size:             "10Gi",
+		VolumeMode:       volumeModeFilesystem,
+	}
+}
+
+func TestEnsureDataImport_BuildsModeASpec(t *testing.T) {
+	leaf := volumeSnapshotLeaf("pvc-1")
+
+	dyn := newFakeDataImportDyn()
+	imp := newTestVolumeImporter(dyn)
+
+	if _, err := imp.EnsureDataImport(context.Background(), leaf, targetNS); err != nil {
+		t.Fatalf("EnsureDataImport: %v", err)
+	}
+
+	got, err := dyn.Resource(dataImportGVR).Namespace(targetNS).Get(context.Background(), "pvc-1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("created DataImport not found: %v", err)
+	}
+
+	if v, _, _ := unstructured.NestedString(got.Object, "spec", "storageClassName"); v != "sc-1" {
+		t.Errorf("spec.storageClassName = %q, want sc-1", v)
+	}
+
+	if v, _, _ := unstructured.NestedString(got.Object, "spec", "size"); v != "10Gi" {
+		t.Errorf("spec.size = %q, want 10Gi", v)
+	}
+
+	if v, _, _ := unstructured.NestedString(got.Object, "spec", "volumeMode"); v != volumeModeFilesystem {
+		t.Errorf("spec.volumeMode = %q, want %q", v, volumeModeFilesystem)
+	}
+
+	// The legacy dataArtifactType field must be gone — the controller infers the artifact.
+	if _, found, _ := unstructured.NestedString(got.Object, "spec", "dataArtifactType"); found {
+		t.Error("spec.dataArtifactType must not be set (removed in the kind-targetRef rework)")
+	}
+
+	group, _, _ := unstructured.NestedString(got.Object, "spec", "targetRef", "group")
+	kind, _, _ := unstructured.NestedString(got.Object, "spec", "targetRef", "kind")
+	refName, _, _ := unstructured.NestedString(got.Object, "spec", "targetRef", "name")
+
+	if group != "snapshot.storage.k8s.io" || kind != "VolumeSnapshot" || refName != "pvc-1" {
+		t.Errorf("targetRef = {group:%q, kind:%q, name:%q}, want {snapshot.storage.k8s.io, VolumeSnapshot, pvc-1}", group, kind, refName)
+	}
+
+	// targetRef must not carry the removed plural "resource" key.
+	if _, found, _ := unstructured.NestedString(got.Object, "spec", "targetRef", "resource"); found {
+		t.Error("spec.targetRef.resource must not be set (renamed to kind)")
+	}
+}
+
+func TestEnsureDataImport_RejectsMissingVolumeMetadata(t *testing.T) {
+	// A data leaf without storageClassName/size means a malformed archive; EnsureDataImport
+	// must fail fast instead of creating a CEL-rejected Mode A DataImport.
 	leaf := PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "pvc-1"}
+
+	dyn := newFakeDataImportDyn()
+	imp := newTestVolumeImporter(dyn)
+
+	if _, err := imp.EnsureDataImport(context.Background(), leaf, targetNS); err == nil {
+		t.Fatal("expected error for missing volume metadata, got nil")
+	}
+
+	if c := countDataImportActions(dyn, "create"); c != 0 {
+		t.Errorf("no DataImport must be created when volume metadata is missing (creates=%d)", c)
+	}
+}
+
+func TestEnsureDataImport_AlignsTTLOnReuse(t *testing.T) {
+	leaf := volumeSnapshotLeaf("pvc-1")
 
 	existing := dataImportObj(targetNS, "pvc-1", false)
 	_ = unstructured.SetNestedField(existing.Object, "2m", "spec", "ttl")
@@ -295,7 +371,7 @@ func TestEnsureDataImport_AlignsTTLOnReuse(t *testing.T) {
 }
 
 func TestEnsureDataImport_RecreatesExpired(t *testing.T) {
-	leaf := PlannedNode{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "pvc-1"}
+	leaf := volumeSnapshotLeaf("pvc-1")
 
 	dyn := newFakeDataImportDyn(dataImportObj(targetNS, "pvc-1", true))
 	imp := newTestVolumeImporter(dyn)

--- a/internal/snapshot/volume/manifest_worker.go
+++ b/internal/snapshot/volume/manifest_worker.go
@@ -171,7 +171,9 @@ func buildVolumesList(node *source.Node) []archive.VolumeInfo {
 	return vols
 }
 
-// bindingToVolumeInfo converts a SnapshotDataBinding to a VolumeInfo.
+// bindingToVolumeInfo converts a SnapshotDataBinding to a VolumeInfo. The volume metadata
+// (volumeMode/storageClassName/size) is carried through so the import side can rebuild the
+// DataImport spec for a Mode A re-import without re-reading the live SnapshotContent.
 func bindingToVolumeInfo(b *snapshotapi.SnapshotDataBinding) archive.VolumeInfo {
 	return archive.VolumeInfo{
 		Target: archive.VolumeObjectRef{
@@ -186,6 +188,9 @@ func bindingToVolumeInfo(b *snapshotapi.SnapshotDataBinding) archive.VolumeInfo 
 			Kind:       b.Artifact.Kind,
 			Name:       b.Artifact.Name,
 		},
+		VolumeMode:       b.VolumeMode,
+		StorageClassName: b.StorageClassName,
+		Size:             b.Size,
 	}
 }
 

--- a/internal/snapshot/volume/manifest_worker_test.go
+++ b/internal/snapshot/volume/manifest_worker_test.go
@@ -718,6 +718,9 @@ func TestFinalizeNode_SnapshotNodeWithOwnDataRefs(t *testing.T) {
 					Kind:       "VolumeSnapshotContent",
 					Name:       "vsc-a",
 				},
+				VolumeMode:       "Block",
+				StorageClassName: "linstor-thin-r1",
+				Size:             "10Gi",
 			},
 			{
 				TargetUID: "uid-pvc-b",
@@ -764,6 +767,13 @@ func TestFinalizeNode_SnapshotNodeWithOwnDataRefs(t *testing.T) {
 
 	if sy.Volumes[1].Artifact.Name != "vsc-b" {
 		t.Errorf("Volumes[1].Artifact.Name: got %q, want vsc-b", sy.Volumes[1].Artifact.Name)
+	}
+
+	// The captured volume metadata must be carried through to the archive so the import
+	// side can rebuild the Mode A DataImport spec.
+	if sy.Volumes[0].VolumeMode != "Block" || sy.Volumes[0].StorageClassName != "linstor-thin-r1" || sy.Volumes[0].Size != "10Gi" {
+		t.Errorf("Volumes[0] metadata = {mode:%q, sc:%q, size:%q}, want {Block, linstor-thin-r1, 10Gi}",
+			sy.Volumes[0].VolumeMode, sy.Volumes[0].StorageClassName, sy.Volumes[0].Size)
 	}
 
 	// VerifyNode must pass: Volumes does not affect the digest.

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -14,6 +14,39 @@ const DefaultKubeContext = ""
 // SetupK8sClientSet reads kubeconfig file at kubeconfigPath and constructs a kubernetes clientset from it.
 // If contextName is not empty, context under that name is used instead of default.
 func SetupK8sClientSet(kubeconfigPath, contextName string) (*rest.Config, *kubernetes.Clientset, error) {
+	clientConfig := newClientConfig(kubeconfigPath, contextName)
+
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading kubeconfig file: %w", err)
+	}
+
+	kubeCl, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("constructing Kubernetes clientset: %w", err)
+	}
+
+	return config, kubeCl, nil
+}
+
+// KubeconfigNamespace resolves the namespace selected by the given kubeconfig
+// path and context, mirroring kubectl: it returns the context's namespace, or
+// "default" when the context does not pin one. It uses the same loading rules
+// as SetupK8sClientSet so flag handling stays consistent across commands.
+func KubeconfigNamespace(kubeconfigPath, contextName string) (string, error) {
+	namespace, _, err := newClientConfig(kubeconfigPath, contextName).Namespace()
+	if err != nil {
+		return "", fmt.Errorf("resolving namespace from kubeconfig: %w", err)
+	}
+
+	return namespace, nil
+}
+
+// newClientConfig builds the deferred-loading client config shared by
+// SetupK8sClientSet and KubeconfigNamespace. Centralising the loading-rules
+// logic keeps kubeconfig discovery identical for both rest.Config and
+// namespace resolution.
+func newClientConfig(kubeconfigPath, contextName string) clientcmd.ClientConfig {
 	var configOverrides *clientcmd.ConfigOverrides
 	if contextName != DefaultKubeContext {
 		configOverrides = &clientcmd.ConfigOverrides{
@@ -37,17 +70,7 @@ func SetupK8sClientSet(kubeconfigPath, contextName string) (*rest.Config, *kuber
 		loadingRules.ExplicitPath = kubeconfigPath
 	}
 
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
-	if err != nil {
-		return nil, nil, fmt.Errorf("reading kubeconfig file: %w", err)
-	}
-
-	kubeCl, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, nil, fmt.Errorf("constructing Kubernetes clientset: %w", err)
-	}
-
-	return config, kubeCl, nil
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 }
 
 // deduplicate removes any duplicated values and returns a new slice, keeping the order unchanged


### PR DESCRIPTION
## Summary

This branch builds on `feat/d8-snapshot-new-endpoints` and bundles several related improvements to the `data` and `snapshot` CLI surfaces:

- Switch DataExport/DataImport `targetRef` from a *resource* to a *kind*, and add a dual-mode (Mode A / Mode B) DataImport flow with an import marker and volume metadata persisted in the archive.
- Add `d8 snapshot list` (cluster + local-archive modes).
- Add `d8 snapshot create` and `d8 snapshot delete`.
- Allow `d8 snapshot import` to import **full** snapshot trees, including domain aggregators (e.g. `DemoVirtualMachineSnapshot`).


## What's included

### data: kind-based targetRef + dual-mode DataImport
- `targetRef` now identifies the target by **kind** instead of resource (group/kind/name), so leaves are matched by GroupKind without RESTMapper resolution.
- DataImport gains a second mode (Mode B) alongside the existing one; the import marker (`spec.source.import: {}`) and captured volume metadata are persisted in the archive.
- Docs/READMEs updated accordingly.

### snapshot: `list`
- `d8 snapshot list` lists top-level `Snapshot` objects in a namespace (with child counts) and supports a local-archive mode that walks a downloaded archive tree and prints each node's KIND/PATH.

### snapshot: `create` / `delete`
- `d8 snapshot create` creates a `Snapshot` object (built via `unstructured` to preserve all CRD fields).
- `d8 snapshot delete` removes `Snapshot` objects, with explicit flag/argument validation.

### snapshot: full-tree import including domain aggregators
- `d8 snapshot import` previously rejected any archive containing a domain aggregator (a domain snapshot that references children but carries no own volume data) as "not client-drivable".
- Aggregators are in fact reconstructed server-side by the genericbinder from the same inputs the CLI already uploads for structural nodes: the unified `spec.source.import` marker plus the node's manifests and child refs (no DataImport, since the aggregator has no own data) — the exact flow the e2e suite client-drives.
- Preflight and `importMarkerCR` no longer reject aggregators, so a full archive imports as-is with the aggregator materialised as a non-root node.
- The only remaining restriction: an aggregator (or a manifest-only domain node) cannot be selected as a standalone `--node` root (no parent SnapshotContent to attach to); import the full archive or select an ancestor `Snapshot` instead.

## Behavior changes / compatibility
- `targetRef` shape changes from resource to kind — any consumer reading/writing DataExport/DataImport `targetRef` must use kind.
- `d8 snapshot import` now succeeds on archives that previously errored out due to a domain aggregator; the `--node <aggregator>` case still errors by design.

