### PR TITLE
[deckhouse-cli] Mask credentials in deckhouse settings output

### DIFF
--- a/internal/status/objects/settings/deckhouse_settings.go
+++ b/internal/status/objects/settings/deckhouse_settings.go
@@ -75,6 +75,36 @@ func getModuleConfigSettings(ctx context.Context, dynamicClient dynamic.Interfac
 	return configSettingsFromMapProcessing(rawSettings), nil
 }
 
+// sensitiveValueMask replaces credential values in output.
+// Fixed length: must not reveal the secret's length.
+const sensitiveValueMask = "***"
+
+// sensitiveKeyMarkers match settings keys that may hold credentials,
+// e.g. registry password/license in ModuleConfig deckhouse.
+// Checked as case-insensitive substrings; false positives are acceptable.
+var sensitiveKeyMarkers = []string{
+	"password",
+	"secret",
+	"token",
+	"license",
+	"dockercfg",
+	"apikey",
+	"accesskey",
+	"credential",
+}
+
+// isSensitiveKey reports whether a settings key likely holds credentials.
+func isSensitiveKey(key string) bool {
+	lowerKey := strings.ToLower(key)
+	for _, marker := range sensitiveKeyMarkers {
+		if strings.Contains(lowerKey, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Processing converts raw resource data into a structured format for easier output and analysis.
 func configSettingsFromMapProcessing(settings map[string]interface{}) []ConfigSetting {
 	if len(settings) == 0 {
@@ -83,7 +113,7 @@ func configSettingsFromMapProcessing(settings map[string]interface{}) []ConfigSe
 
 	result := make([]ConfigSetting, 0, len(settings))
 	for key, value := range settings {
-		result = append(result, configSettingsProcessing(key, value))
+		result = append(result, configSettingsProcessing(key, value, false))
 	}
 
 	sort.Slice(result, func(i, j int) bool {
@@ -93,16 +123,19 @@ func configSettingsFromMapProcessing(settings map[string]interface{}) []ConfigSe
 	return result
 }
 
-func configSettingsProcessing(key string, data interface{}) ConfigSetting {
+func configSettingsProcessing(key string, data interface{}, sensitive bool) ConfigSetting {
 	if key == "" {
 		return ConfigSetting{}
 	}
+
+	// Sensitivity is inherited: everything nested under a credential key is masked.
+	sensitive = sensitive || isSensitiveKey(key)
 
 	// map[string]interface{}
 	if m, ok := data.(map[string]interface{}); ok {
 		children := make([]ConfigSetting, 0, len(m))
 		for k, v := range m {
-			children = append(children, configSettingsProcessing(k, v))
+			children = append(children, configSettingsProcessing(k, v, sensitive))
 		}
 
 		sort.Slice(children, func(i, j int) bool {
@@ -120,7 +153,7 @@ func configSettingsProcessing(key string, data interface{}) ConfigSetting {
 		items := make([]ConfigSetting, 0, len(arr))
 		for i, elem := range arr {
 			itemKey := fmt.Sprintf("#%d", i)
-			items = append(items, configSettingsProcessing(itemKey, elem))
+			items = append(items, configSettingsProcessing(itemKey, elem, sensitive))
 		}
 
 		return ConfigSetting{
@@ -130,9 +163,14 @@ func configSettingsProcessing(key string, data interface{}) ConfigSetting {
 	}
 
 	// default
+	value := fmt.Sprintf("%v", data)
+	if sensitive && data != nil && value != "" {
+		value = sensitiveValueMask
+	}
+
 	return ConfigSetting{
 		Key:   key,
-		Value: fmt.Sprintf("%v", data),
+		Value: value,
 	}
 }
 

--- a/internal/status/objects/settings/deckhouse_settings_test.go
+++ b/internal/status/objects/settings/deckhouse_settings_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deckhousesettings
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSensitiveKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"password", true},
+		{"Password", true},
+		{"license", true},
+		{"licenseKey", true},
+		{"dockerCfg", true},
+		{"registryDockerCfg", true},
+		{"token", true},
+		{"bearerToken", true},
+		{"apiKey", true},
+		{"accessKey", true},
+		{"secretAccessKey", true},
+		{"credentials", true},
+		{"imagesRepo", false},
+		{"username", false},
+		{"mode", false},
+		{"scheme", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := isSensitiveKey(tt.key); got != tt.want {
+				t.Errorf("isSensitiveKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigSettingsProcessingMasksCredentials(t *testing.T) {
+	settings := map[string]interface{}{
+		"registry": map[string]interface{}{
+			"mode": "Direct",
+			"direct": map[string]interface{}{
+				"imagesRepo": "registry.example.com/deckhouse",
+				"username":   "reg-user",
+				"password":   "SuperSecret123",
+				"license":    "LICENSE-KEY-42",
+			},
+		},
+		"dockerCfg":      "eyJhdXRocyI6e319",
+		"emptyPassword":  "",
+		"nullToken":      nil,
+		"tokens":         []interface{}{"tok-a", "tok-b"},
+		"releaseChannel": "Stable",
+	}
+
+	result := configSettingsFromMapProcessing(settings)
+	output := formatModuleConfigSettings(result)
+
+	for _, secret := range []string{"SuperSecret123", "LICENSE-KEY-42", "eyJhdXRocyI6e319", "tok-a", "tok-b"} {
+		if strings.Contains(output, secret) {
+			t.Errorf("output leaks secret %q:\n%s", secret, output)
+		}
+	}
+
+	// Scalar array items are printed without the "#N:" key, mask only.
+	for _, masked := range []string{"password: ***", "license: ***", "dockerCfg: ***", "├ ***", "└ ***"} {
+		if !strings.Contains(output, masked) {
+			t.Errorf("output missing masked line %q:\n%s", masked, output)
+		}
+	}
+
+	// Non-credential values stay readable.
+	for _, plain := range []string{"imagesRepo: registry.example.com/deckhouse", "username: reg-user", "mode: Direct", "releaseChannel: Stable"} {
+		if !strings.Contains(output, plain) {
+			t.Errorf("output missing plain line %q:\n%s", plain, output)
+		}
+	}
+
+	// Empty and null credential values are not replaced with the mask.
+	if strings.Contains(output, "emptyPassword: ***") {
+		t.Errorf("empty credential value must not be masked:\n%s", output)
+	}
+
+	if strings.Contains(output, "nullToken: ***") {
+		t.Errorf("null credential value must not be masked:\n%s", output)
+	}
+}
+
+func TestConfigSettingsProcessingMasksNestedUnderCredentialKey(t *testing.T) {
+	// A map under a credential key: all nested scalars are masked.
+	settings := map[string]interface{}{
+		"registryCredentials": map[string]interface{}{
+			"user": "admin",
+			"pass": "qwerty",
+		},
+	}
+
+	output := formatModuleConfigSettings(configSettingsFromMapProcessing(settings))
+
+	for _, secret := range []string{"admin", "qwerty"} {
+		if strings.Contains(output, secret) {
+			t.Errorf("output leaks nested secret %q:\n%s", secret, output)
+		}
+	}
+
+	for _, masked := range []string{"user: ***", "pass: ***"} {
+		if !strings.Contains(output, masked) {
+			t.Errorf("output missing masked line %q:\n%s", masked, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`d8 status` printed the whole `spec.settings` of ModuleConfig `deckhouse` as is. 

Since DKP 1.76 moved registry management into those settings, this leaked the registry password (and other credentials) in plain text. This masks credential values in the settings section.

## Fix

Detect credential-bearing keys by name and replace their values with a fixed mask while building the settings tree:

- `isSensitiveKey` matches keys case-insensitively by substring against `password`, `secret`, `token`, `license`, `dockercfg`, `apikey`, `accesskey`, `credential`.
- Sensitivity is inherited through recursion, so nested objects and array items under a credential key are masked too.
- The mask is a fixed `***`, so the secret length is not revealed. Empty and null values stay unmasked.

Only the leaf value is masked; keys and non-credential values (repo address, username, scheme, webhook URL) stay readable, preserving the diagnostic value of the output.

## Before / After

**Before:**
```
│   ├ direct:
│   │   ├ imagesRepo: registry.example.com/deckhouse/ee
│   │   ├ password: P@ssw0rd-Reg-9f3k
│   │   └ username: registry-user
│   └ mode: Direct
```
**After:**
```
│   ├ direct:
│   │   ├ imagesRepo: registry.example.com/deckhouse/ee
│   │   ├ password: ***
│   │   └ username: registry-user
│   └ mode: Direct
```

## Tests

- `TestIsSensitiveKey` - key matching, case-insensitivity, and non-credential keys that must stay visible.
- `TestConfigSettingsProcessingMasksCredentials` - registry `password`/`license`/`dockerCfg` masked, secrets absent from output, empty/null values left intact, plain fields unchanged, array items under a credential key masked.
- `TestConfigSettingsProcessingMasksNestedUnderCredentialKey` - inheritance: scalars nested under a credential-named object are masked.

Verified live on a test cluster: with a credential injected into `mc/deckhouse` settings, old binary printed it in clear, patched binary printed `***`, rest of the output unchanged.
