### PR TITLE
[deckhouse-cli] Restore registry install path for plugins

### DIFF
--- a/internal/plugins/cmd/plugins.go
+++ b/internal/plugins/cmd/plugins.go
@@ -87,6 +87,10 @@ func NewCommand(logger *dkplog.Logger, builtinCommands []string) *cobra.Command 
 
 	flags.AddFlags(cmd.PersistentFlags())
 
+	// legacy --source bypass (temporary, hidden): direct registry access, see
+	// internal/plugins/flags/source_legacy.go.
+	flags.AddLegacySourceFlags(cmd.PersistentFlags())
+
 	wrapProxyDiagnostics(cmd)
 
 	return cmd

--- a/internal/plugins/flags/source_legacy.go
+++ b/internal/plugins/flags/source_legacy.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// LEGACY --source bypass (temporary).
+//
+// The plugin machinery reaches the registry exclusively through the in-cluster
+// registry-packages-proxy (ADR #386). This file re-adds the pre-#386 direct
+// registry access as a hidden escape hatch for environments without a cluster
+// (CI publishing plugins straight from a registry).
+//
+// Everything gated behind these flags is temporary. To remove the bypass:
+//   - delete this file and internal/plugins/source_legacy.go
+//   - drop the AddLegacySourceFlags call in internal/plugins/cmd/plugins.go
+//   - drop the SourceRegistryRepo branch in internal/plugins/init.go
+// Grep marker: "legacy --source".
+
+package flags
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// Legacy direct-registry parameters. All empty by default: an empty
+// SourceRegistryRepo keeps RPP as the source, so the bypass is off unless
+// --source is passed.
+var (
+	SourceRegistryRepo     string
+	SourceRegistryLogin    string
+	SourceRegistryPassword string
+	DeckhouseLicenseToken  string
+
+	Insecure      bool
+	TLSSkipVerify bool
+)
+
+// AddLegacySourceFlags registers the hidden --source bypass flags on flagSet.
+// They are hidden: the supported path is RPP, this is a temporary escape hatch.
+func AddLegacySourceFlags(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&SourceRegistryRepo,
+		"source",
+		"",
+		"Pull plugins directly from this registry repo instead of the registry-packages-proxy (bypasses the cluster).",
+	)
+	flagSet.StringVar(
+		&SourceRegistryLogin,
+		"source-login",
+		os.Getenv("D8_MIRROR_SOURCE_LOGIN"),
+		"Source registry login. Defaults to $D8_MIRROR_SOURCE_LOGIN.",
+	)
+	flagSet.StringVar(
+		&SourceRegistryPassword,
+		"source-password",
+		os.Getenv("D8_MIRROR_SOURCE_PASSWORD"),
+		"Source registry password. Defaults to $D8_MIRROR_SOURCE_PASSWORD.",
+	)
+	flagSet.StringVar(
+		&DeckhouseLicenseToken,
+		"license",
+		os.Getenv("D8_MIRROR_LICENSE_TOKEN"),
+		"Deckhouse license key. Shortcut for --source-login=license-token --source-password=<key>. Defaults to $D8_MIRROR_LICENSE_TOKEN.",
+	)
+	flagSet.BoolVar(
+		&TLSSkipVerify,
+		"tls-skip-verify",
+		false,
+		"Disable TLS certificate validation for the source registry.",
+	)
+	flagSet.BoolVar(
+		&Insecure,
+		"insecure",
+		false,
+		"Interact with the source registry over HTTP.",
+	)
+
+	for _, name := range []string{"source", "source-login", "source-password", "license", "tls-skip-verify", "insecure"} {
+		_ = flagSet.MarkHidden(name)
+	}
+}

--- a/internal/plugins/init.go
+++ b/internal/plugins/init.go
@@ -31,6 +31,12 @@ import (
 // discovery, so a Ctrl-C during command startup is honored. The proxy is the only
 // plugin source (ADR: deckhouse-cli reaches the registry exclusively through it).
 func (m *Manager) InitPluginServices(ctx context.Context) error {
+	// legacy --source bypass (temporary): pull straight from a registry, skipping
+	// the proxy and the cluster. See internal/plugins/source_legacy.go.
+	if d8flags.SourceRegistryRepo != "" {
+		return m.initLegacyRegistrySource()
+	}
+
 	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(d8flags.Kubeconfig, d8flags.KubeContext)
 	if err != nil {
 		return fmt.Errorf("set up kubernetes client: %w", err)

--- a/internal/plugins/source_legacy.go
+++ b/internal/plugins/source_legacy.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// LEGACY --source bypass (temporary).
+//
+// registryPluginSource restores the pre-#386 direct registry access: it pulls
+// plugin images straight from a registry through go-containerregistry, bypassing
+// the registry-packages-proxy and the cluster. Activated only when --source is
+// set (see internal/plugins/init.go). Removal steps are listed in
+// internal/plugins/flags/source_legacy.go. Grep marker: "legacy --source".
+
+package plugins
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	dkpreg "github.com/deckhouse/deckhouse/pkg/registry"
+	regclient "github.com/deckhouse/deckhouse/pkg/registry/client"
+
+	"github.com/deckhouse/deckhouse-cli/internal"
+	d8flags "github.com/deckhouse/deckhouse-cli/internal/plugins/flags"
+	pkgclient "github.com/deckhouse/deckhouse-cli/pkg/registry/client"
+)
+
+// legacyPluginsSegment mirrors the RPP layout deckhouse-cli/plugins/<name>: the
+// direct path is <--source>/plugins/<name>, so --source names the CLI image repo.
+const legacyPluginsSegment = "plugins"
+
+// legacyBinaryByteLimit caps the extracted plugin binary (512 MiB), matching
+// rpp.DefaultBinaryByteLimit.
+const legacyBinaryByteLimit int64 = 512 << 20
+
+// legacyExecutableMode is forced on the extracted binary so it is runnable
+// regardless of the mode recorded in the image.
+const legacyExecutableMode os.FileMode = 0o755
+
+// initLegacyRegistrySource wires m.service to a direct registry (the --source
+// bypass) and disables cluster-side requirement checks: the bypass targets
+// environments without a cluster, matching the pre-#386 behavior where no such
+// checks existed. Called from InitPluginServices when --source is set.
+func (m *Manager) initLegacyRegistrySource() error {
+	m.logger.Warn("using the legacy --source registry bypass; cluster-side requirement checks are skipped",
+		slog.String("source_repo", d8flags.SourceRegistryRepo))
+
+	d8flags.SkipClusterChecks = true
+	m.service = newRegistryPluginSource(m.logger)
+
+	return nil
+}
+
+// registryPluginSource implements pluginSource against a registry reached
+// directly, so the install pipeline is unchanged and only the transport differs.
+type registryPluginSource struct {
+	client dkpreg.Client
+	logger *dkplog.Logger
+}
+
+var _ pluginSource = (*registryPluginSource)(nil)
+
+// newRegistryPluginSource builds a source pinned to d8flags.SourceRegistryRepo.
+// Auth priority: --source-login/password, then --license, then the Docker config
+// (what `d8 dk cr login` writes), then anonymous.
+func newRegistryPluginSource(logger *dkplog.Logger) *registryPluginSource {
+	source := d8flags.SourceRegistryRepo
+	auth := legacyRegistryAuth(legacyRegistryHost(source), logger)
+
+	client := pkgclient.NewFromOptions(
+		source,
+		regclient.WithAuth(auth),
+		regclient.WithInsecure(d8flags.Insecure),
+		regclient.WithTLSSkipVerify(d8flags.TLSSkipVerify),
+		regclient.WithLogger(logger.Named("registry-client")),
+	)
+
+	return &registryPluginSource{client: client, logger: logger}
+}
+
+// pluginClient scopes the base client to <source>/plugins/<name>.
+func (s *registryPluginSource) pluginClient(pluginName string) dkpreg.Client {
+	return s.client.WithSegment(legacyPluginsSegment, pluginName)
+}
+
+func (s *registryPluginSource) ListPluginTags(ctx context.Context, pluginName string) ([]string, error) {
+	tags, err := s.pluginClient(pluginName).ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tags for plugin %q: %w", pluginName, err)
+	}
+
+	return tags, nil
+}
+
+func (s *registryPluginSource) GetPluginContract(ctx context.Context, pluginName, tag string) (*internal.Plugin, error) {
+	manifest, err := s.resolveManifest(ctx, s.pluginClient(pluginName), tag)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest for plugin %q: %w", pluginName, err)
+	}
+
+	encoded := manifest.GetAnnotations()[contractAnnotation]
+	if encoded == "" {
+		// No contract annotation: surface just name+version, like rppPluginSource.
+		s.logger.Debug("plugin image has no contract annotation",
+			slog.String("plugin", pluginName), slog.String("tag", tag))
+
+		return &internal.Plugin{Name: pluginName, Version: tag}, nil
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode contract annotation for plugin %q: %w", pluginName, err)
+	}
+
+	return contractFromBytes(raw, pluginName, tag)
+}
+
+// resolveManifest returns the image manifest for tag. A multi-arch tag points at
+// an index; the contract is platform-independent, so its first child manifest is
+// followed (matching rppPluginSource).
+func (s *registryPluginSource) resolveManifest(ctx context.Context, client dkpreg.Client, tag string) (dkpreg.Manifest, error) {
+	result, err := client.GetManifest(ctx, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	if !result.GetMediaType().IsIndex() {
+		return result.GetManifest()
+	}
+
+	index, err := result.GetIndexManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	children := index.GetManifests()
+	if len(children) == 0 {
+		return nil, errors.New("index manifest has no child manifests")
+	}
+
+	child, err := client.GetManifest(ctx, "@"+children[0].GetDigest().String())
+	if err != nil {
+		return nil, err
+	}
+
+	return child.GetManifest()
+}
+
+func (s *registryPluginSource) ExtractPlugin(ctx context.Context, pluginName, tag, destination string) error {
+	platform := &v1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+
+	img, err := s.pluginClient(pluginName).GetImage(ctx, tag, regclient.WithPlatform{Platform: platform})
+	if err != nil {
+		return fmt.Errorf("get image for plugin %q: %w", pluginName, err)
+	}
+
+	body := img.Extract()
+
+	defer func() { _ = body.Close() }()
+
+	if err := extractPluginBinary(body, destination); err != nil {
+		return fmt.Errorf("extract %q binary: %w", pluginName, err)
+	}
+
+	return nil
+}
+
+// extractPluginBinary writes the entry named pluginBinaryEntryName from the
+// image's flattened (uncompressed) tar to destination, forced executable and
+// capped in size. Non-regular entries and other files are skipped.
+func extractPluginBinary(r io.Reader, destination string) error {
+	tr := tar.NewReader(r)
+
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("binary %q not found in image", pluginBinaryEntryName)
+		}
+
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+
+		if header.Typeflag != tar.TypeReg || path.Base(header.Name) != pluginBinaryEntryName {
+			continue
+		}
+
+		return writeCappedBinary(destination, tr)
+	}
+}
+
+func writeCappedBinary(destination string, r io.Reader) error {
+	out, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, legacyExecutableMode)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", destination, err)
+	}
+
+	defer func() { _ = out.Close() }()
+
+	written, err := io.Copy(out, io.LimitReader(r, legacyBinaryByteLimit+1))
+	if err != nil {
+		return fmt.Errorf("write %q: %w", destination, err)
+	}
+
+	if written > legacyBinaryByteLimit {
+		return fmt.Errorf("%q exceeds the %d-byte limit", destination, legacyBinaryByteLimit)
+	}
+
+	// OpenFile honors the umask, so force the exact mode for an executable.
+	if err := os.Chmod(destination, legacyExecutableMode); err != nil {
+		return fmt.Errorf("chmod %q: %w", destination, err)
+	}
+
+	return nil
+}
+
+// legacyRegistryHost extracts the registry host from a --source repo (e.g.
+// "registry.example.com/deckhouse/deckhouse-cli" -> "registry.example.com"),
+// used only for the Docker-config credential lookup.
+func legacyRegistryHost(source string) string {
+	if !strings.Contains(source, "/") {
+		return source
+	}
+
+	ref, err := name.ParseReference(source)
+	if err != nil {
+		host, _, _ := strings.Cut(source, "/")
+
+		return host
+	}
+
+	return ref.Context().RegistryStr()
+}
+
+// legacyRegistryAuth resolves credentials for the source registry, mirroring the
+// pre-#386 priority: explicit login/password, then license token, then the
+// Docker config, then anonymous.
+func legacyRegistryAuth(registryHost string, logger *dkplog.Logger) authn.Authenticator {
+	if d8flags.SourceRegistryLogin != "" {
+		logger.Debug("using --source-login credentials", slog.String("username", d8flags.SourceRegistryLogin))
+
+		return authn.FromConfig(authn.AuthConfig{
+			Username: d8flags.SourceRegistryLogin,
+			Password: d8flags.SourceRegistryPassword,
+		})
+	}
+
+	if d8flags.DeckhouseLicenseToken != "" {
+		logger.Debug("using --license token")
+
+		return authn.FromConfig(authn.AuthConfig{
+			Username: "license-token",
+			Password: d8flags.DeckhouseLicenseToken,
+		})
+	}
+
+	if auth, ok := dockerConfigAuth(registryHost, logger); ok {
+		return auth
+	}
+
+	logger.Debug("using anonymous access for the source registry", slog.String("registry", registryHost))
+
+	return authn.Anonymous
+}
+
+// dockerConfigAuth resolves credentials for registryHost from the Docker config
+// (~/.docker/config.json, written by `d8 dk cr login`). ok is false when the
+// config holds no usable entry for the host.
+func dockerConfigAuth(registryHost string, logger *dkplog.Logger) (authn.Authenticator, bool) {
+	reg, err := name.NewRegistry(registryHost)
+	if err != nil {
+		return nil, false
+	}
+
+	auth, err := authn.DefaultKeychain.Resolve(reg)
+	if err != nil || auth == authn.Anonymous {
+		return nil, false
+	}
+
+	cfg, err := auth.Authorization()
+	if err != nil {
+		return nil, false
+	}
+
+	if cfg.Username == "" && cfg.Password == "" && cfg.Auth == "" && cfg.IdentityToken == "" {
+		return nil, false
+	}
+
+	logger.Debug("using Docker config credentials", slog.String("registry", reg.String()))
+
+	return auth, true
+}

--- a/internal/plugins/source_legacy.go
+++ b/internal/plugins/source_legacy.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path"
 	"runtime"
@@ -58,6 +59,11 @@ const legacyPluginsSegment = "plugins"
 // rpp.DefaultBinaryByteLimit.
 const legacyBinaryByteLimit int64 = 512 << 20
 
+// legacyArchiveByteLimit bounds the TOTAL bytes read while walking the image
+// tar, so a huge entry before the plugin binary cannot exhaust resources.
+// Mirrors rpp maxArchiveBytes (1 GiB); the per-binary cap is the tighter guard.
+const legacyArchiveByteLimit int64 = 1 << 30
+
 // legacyExecutableMode is forced on the extracted binary so it is runnable
 // regardless of the mode recorded in the image.
 const legacyExecutableMode os.FileMode = 0o755
@@ -67,6 +73,13 @@ const legacyExecutableMode os.FileMode = 0o755
 // environments without a cluster, matching the pre-#386 behavior where no such
 // checks existed. Called from InitPluginServices when --source is set.
 func (m *Manager) initLegacyRegistrySource() error {
+	sanitized, err := validateLegacySource(d8flags.SourceRegistryRepo)
+	if err != nil {
+		return fmt.Errorf("invalid --source: %w", err)
+	}
+
+	d8flags.SourceRegistryRepo = sanitized
+
 	m.logger.Warn("using the legacy --source registry bypass; cluster-side requirement checks are skipped",
 		slog.String("source_repo", d8flags.SourceRegistryRepo))
 
@@ -74,6 +87,40 @@ func (m *Manager) initLegacyRegistrySource() error {
 	m.service = newRegistryPluginSource(m.logger)
 
 	return nil
+}
+
+// validateLegacySource sanitizes a --source repo: it strips any URL scheme and a
+// trailing slash, then validates the result as a <registry>/<repo> path. It
+// fails fast with a clear error instead of letting a bad value surface as an
+// opaque failure on the first registry call.
+func validateLegacySource(source string) (string, error) {
+	repo := strings.NewReplacer("http://", "", "https://", "").Replace(source)
+	repo = strings.TrimSuffix(repo, "/")
+
+	if repo == "" {
+		return "", errors.New("registry repo is empty")
+	}
+
+	// Rejects an uppercase host, a :tag or @digest suffix, and other malformed
+	// repositories; a trailing slash was already trimmed above.
+	if _, err := name.NewRepository(repo); err != nil {
+		return "", fmt.Errorf("not a valid registry repo: %w", err)
+	}
+
+	u, err := url.ParseRequestURI("docker://" + repo)
+	if err != nil {
+		return "", err
+	}
+
+	if u.Host == "" {
+		return "", errors.New("no registry host")
+	}
+
+	if u.Path == "" {
+		return "", errors.New("no registry path (expected <registry>/<repo>)")
+	}
+
+	return repo, nil
 }
 
 // registryPluginSource implements pluginSource against a registry reached
@@ -118,12 +165,11 @@ func (s *registryPluginSource) ListPluginTags(ctx context.Context, pluginName st
 }
 
 func (s *registryPluginSource) GetPluginContract(ctx context.Context, pluginName, tag string) (*internal.Plugin, error) {
-	manifest, err := s.resolveManifest(ctx, s.pluginClient(pluginName), tag)
+	encoded, err := s.resolveContractAnnotation(ctx, s.pluginClient(pluginName), tag)
 	if err != nil {
 		return nil, fmt.Errorf("get manifest for plugin %q: %w", pluginName, err)
 	}
 
-	encoded := manifest.GetAnnotations()[contractAnnotation]
 	if encoded == "" {
 		// No contract annotation: surface just name+version, like rppPluginSource.
 		s.logger.Debug("plugin image has no contract annotation",
@@ -140,35 +186,50 @@ func (s *registryPluginSource) GetPluginContract(ctx context.Context, pluginName
 	return contractFromBytes(raw, pluginName, tag)
 }
 
-// resolveManifest returns the image manifest for tag. A multi-arch tag points at
-// an index; the contract is platform-independent, so its first child manifest is
-// followed (matching rppPluginSource).
-func (s *registryPluginSource) resolveManifest(ctx context.Context, client dkpreg.Client, tag string) (dkpreg.Manifest, error) {
+// resolveContractAnnotation returns the base64 contract annotation for tag. The
+// contract may sit on the index or on its (identical) child manifests: the index
+// is read first, and the first child is followed only when the index carries
+// none (matching rppPluginSource). An empty string means no contract was found.
+func (s *registryPluginSource) resolveContractAnnotation(ctx context.Context, client dkpreg.Client, tag string) (string, error) {
 	result, err := client.GetManifest(ctx, tag)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if !result.GetMediaType().IsIndex() {
-		return result.GetManifest()
+		man, err := result.GetManifest()
+		if err != nil {
+			return "", err
+		}
+
+		return man.GetAnnotations()[contractAnnotation], nil
 	}
 
 	index, err := result.GetIndexManifest()
 	if err != nil {
-		return nil, err
+		return "", err
+	}
+
+	if encoded := index.GetAnnotations()[contractAnnotation]; encoded != "" {
+		return encoded, nil
 	}
 
 	children := index.GetManifests()
 	if len(children) == 0 {
-		return nil, errors.New("index manifest has no child manifests")
+		return "", nil
 	}
 
 	child, err := client.GetManifest(ctx, "@"+children[0].GetDigest().String())
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return child.GetManifest()
+	childManifest, err := child.GetManifest()
+	if err != nil {
+		return "", err
+	}
+
+	return childManifest.GetAnnotations()[contractAnnotation], nil
 }
 
 func (s *registryPluginSource) ExtractPlugin(ctx context.Context, pluginName, tag, destination string) error {
@@ -192,9 +253,11 @@ func (s *registryPluginSource) ExtractPlugin(ctx context.Context, pluginName, ta
 
 // extractPluginBinary writes the entry named pluginBinaryEntryName from the
 // image's flattened (uncompressed) tar to destination, forced executable and
-// capped in size. Non-regular entries and other files are skipped.
+// capped in size. The whole walk is bounded by legacyArchiveByteLimit so a huge
+// entry before the target cannot exhaust resources. Non-regular entries and
+// other files are skipped.
 func extractPluginBinary(r io.Reader, destination string) error {
-	tr := tar.NewReader(r)
+	tr := tar.NewReader(io.LimitReader(r, legacyArchiveByteLimit+1))
 
 	for {
 		header, err := tr.Next()

--- a/internal/plugins/source_legacy_test.go
+++ b/internal/plugins/source_legacy_test.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,10 +29,13 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+	dkpreg "github.com/deckhouse/deckhouse/pkg/registry"
 
 	d8flags "github.com/deckhouse/deckhouse-cli/internal/plugins/flags"
 )
@@ -204,3 +208,151 @@ func plainTar(t *testing.T, files map[string]string) []byte {
 
 	return buf.Bytes()
 }
+
+func TestValidateLegacySource(t *testing.T) {
+	t.Run("valid inputs are normalized", func(t *testing.T) {
+		cases := map[string]string{
+			"registry.example.com/deckhouse/deckhouse-cli":         "registry.example.com/deckhouse/deckhouse-cli",
+			"https://registry.example.com/deckhouse/deckhouse-cli": "registry.example.com/deckhouse/deckhouse-cli",
+			"http://registry.example.com/deckhouse/deckhouse-cli":  "registry.example.com/deckhouse/deckhouse-cli",
+			"registry.example.com/deckhouse/deckhouse-cli/":        "registry.example.com/deckhouse/deckhouse-cli",
+			"registry.example.com:5000/deckhouse/deckhouse-cli":    "registry.example.com:5000/deckhouse/deckhouse-cli",
+		}
+
+		for in, want := range cases {
+			got, err := validateLegacySource(in)
+			require.NoErrorf(t, err, "input %q", in)
+			assert.Equalf(t, want, got, "input %q", in)
+		}
+	})
+
+	t.Run("invalid inputs are rejected", func(t *testing.T) {
+		for _, in := range []string{
+			"",
+			"/",
+			"registry.example.com/deckhouse/deckhouse-cli:v1.0.0",
+			"registry.example.com", // host without a repo path
+		} {
+			_, err := validateLegacySource(in)
+			assert.Errorf(t, err, "input %q must be rejected", in)
+		}
+	})
+}
+
+func TestResolveContractAnnotation(t *testing.T) {
+	s := &registryPluginSource{logger: dkplog.NewNop()}
+
+	t.Run("reads the annotation from the index without fetching a child", func(t *testing.T) {
+		client := &fakeManifestClient{byTag: map[string]dkpreg.ManifestResult{
+			"v1.0.0": fakeManifestResult{
+				mediaType: types.OCIImageIndex,
+				index: fakeIndexManifest{
+					annotations: map[string]string{contractAnnotation: "index-contract"},
+					manifests:   []dkpreg.Descriptor{fakeDescriptor{digest: v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("a", 64)}}},
+				},
+			},
+		}}
+
+		got, err := s.resolveContractAnnotation(context.Background(), client, "v1.0.0")
+		require.NoError(t, err)
+		assert.Equal(t, "index-contract", got)
+		assert.Equal(t, []string{"v1.0.0"}, client.gotTags,
+			"the child manifest must not be fetched when the index carries the contract")
+	})
+
+	t.Run("falls back to the first child when the index has no contract", func(t *testing.T) {
+		childDigest := v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("b", 64)}
+		client := &fakeManifestClient{byTag: map[string]dkpreg.ManifestResult{
+			"v1.0.0": fakeManifestResult{
+				mediaType: types.OCIImageIndex,
+				index: fakeIndexManifest{
+					manifests: []dkpreg.Descriptor{fakeDescriptor{digest: childDigest}},
+				},
+			},
+			"@" + childDigest.String(): fakeManifestResult{
+				mediaType: types.OCIManifestSchema1,
+				manifest:  fakeManifest{annotations: map[string]string{contractAnnotation: "child-contract"}},
+			},
+		}}
+
+		got, err := s.resolveContractAnnotation(context.Background(), client, "v1.0.0")
+		require.NoError(t, err)
+		assert.Equal(t, "child-contract", got)
+		assert.Equal(t, []string{"v1.0.0", "@" + childDigest.String()}, client.gotTags)
+	})
+
+	t.Run("reads the annotation from a single (non-index) manifest", func(t *testing.T) {
+		client := &fakeManifestClient{byTag: map[string]dkpreg.ManifestResult{
+			"v1.0.0": fakeManifestResult{
+				mediaType: types.OCIManifestSchema1,
+				manifest:  fakeManifest{annotations: map[string]string{contractAnnotation: "single-contract"}},
+			},
+		}}
+
+		got, err := s.resolveContractAnnotation(context.Background(), client, "v1.0.0")
+		require.NoError(t, err)
+		assert.Equal(t, "single-contract", got)
+	})
+}
+
+// fakeManifestClient serves a preset ManifestResult per reference and records
+// the references it was asked for, so tests can assert whether a child manifest
+// was fetched. Only GetManifest is implemented; the embedded interface panics on
+// any other call.
+type fakeManifestClient struct {
+	dkpreg.Client
+
+	byTag   map[string]dkpreg.ManifestResult
+	gotTags []string
+}
+
+func (c *fakeManifestClient) GetManifest(_ context.Context, tag string) (dkpreg.ManifestResult, error) {
+	c.gotTags = append(c.gotTags, tag)
+
+	res, ok := c.byTag[tag]
+	if !ok {
+		return nil, fmt.Errorf("no manifest for %q", tag)
+	}
+
+	return res, nil
+}
+
+type fakeManifestResult struct {
+	dkpreg.ManifestResult
+
+	mediaType types.MediaType
+	manifest  dkpreg.Manifest
+	index     dkpreg.IndexManifest
+}
+
+func (r fakeManifestResult) GetMediaType() types.MediaType         { return r.mediaType }
+func (r fakeManifestResult) GetManifest() (dkpreg.Manifest, error) { return r.manifest, nil }
+func (r fakeManifestResult) GetIndexManifest() (dkpreg.IndexManifest, error) {
+	return r.index, nil
+}
+
+type fakeManifest struct {
+	dkpreg.Manifest
+
+	annotations map[string]string
+}
+
+func (m fakeManifest) GetAnnotations() map[string]string { return m.annotations }
+
+type fakeIndexManifest struct {
+	dkpreg.IndexManifest
+
+	annotations map[string]string
+	manifests   []dkpreg.Descriptor
+}
+
+func (i fakeIndexManifest) GetAnnotations() map[string]string { return i.annotations }
+func (i fakeIndexManifest) GetManifests() []dkpreg.Descriptor { return i.manifests }
+
+type fakeDescriptor struct {
+	dkpreg.Descriptor
+
+	digest v1.Hash
+}
+
+func (d fakeDescriptor) GetDigest() v1.Hash { return d.digest }

--- a/internal/plugins/source_legacy_test.go
+++ b/internal/plugins/source_legacy_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dkplog "github.com/deckhouse/deckhouse/pkg/log"
+
+	d8flags "github.com/deckhouse/deckhouse-cli/internal/plugins/flags"
+)
+
+// resetLegacyFlags clears the legacy --source globals for a test and restores
+// them afterwards (they are package-level, so tests must not leak state).
+func resetLegacyFlags(t *testing.T) {
+	t.Helper()
+
+	repo, login, pass := d8flags.SourceRegistryRepo, d8flags.SourceRegistryLogin, d8flags.SourceRegistryPassword
+	lic, insec, tls, skip := d8flags.DeckhouseLicenseToken, d8flags.Insecure, d8flags.TLSSkipVerify, d8flags.SkipClusterChecks
+
+	t.Cleanup(func() {
+		d8flags.SourceRegistryRepo, d8flags.SourceRegistryLogin, d8flags.SourceRegistryPassword = repo, login, pass
+		d8flags.DeckhouseLicenseToken, d8flags.Insecure, d8flags.TLSSkipVerify, d8flags.SkipClusterChecks = lic, insec, tls, skip
+	})
+
+	d8flags.SourceRegistryRepo, d8flags.SourceRegistryLogin, d8flags.SourceRegistryPassword = "", "", ""
+	d8flags.DeckhouseLicenseToken, d8flags.Insecure, d8flags.TLSSkipVerify, d8flags.SkipClusterChecks = "", false, false, false
+}
+
+// TestRegistryPluginSourceTagsPath is the guard for the CI pipeline: a plugin
+// image must be addressed as <--source>/plugins/<name>. It runs ListPluginTags
+// against a fake registry and asserts both the returned tags and the exact repo
+// path the client requested.
+func TestRegistryPluginSourceTagsPath(t *testing.T) {
+	resetLegacyFlags(t)
+
+	var gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/tags/list") {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"x","tags":["v1.0.0","v1.1.0"]}`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	d8flags.SourceRegistryRepo = host + "/deckhouse/deckhouse-cli"
+	d8flags.Insecure = true // httptest serves plain HTTP
+
+	source := newRegistryPluginSource(dkplog.NewNop())
+
+	tags, err := source.ListPluginTags(context.Background(), "package")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1.0.0", "v1.1.0"}, tags)
+	assert.Equal(t, "/v2/deckhouse/deckhouse-cli/plugins/package/tags/list", gotPath)
+}
+
+func TestInitLegacyRegistrySourceSelectsRegistryAndSkipsCluster(t *testing.T) {
+	resetLegacyFlags(t)
+
+	d8flags.SourceRegistryRepo = "registry.example.com/deckhouse/deckhouse-cli"
+
+	m := testManager()
+	require.NoError(t, m.initLegacyRegistrySource())
+
+	assert.IsType(t, &registryPluginSource{}, m.service)
+	assert.True(t, d8flags.SkipClusterChecks, "the --source bypass must skip cluster-side checks")
+}
+
+func TestLegacyRegistryHost(t *testing.T) {
+	cases := map[string]string{
+		"registry.example.com":                         "registry.example.com",
+		"registry.example.com/deckhouse/deckhouse-cli": "registry.example.com",
+		"registry.example.com:5000/foo":                "registry.example.com:5000",
+		"127.0.0.1:38574/deckhouse/deckhouse-cli":      "127.0.0.1:38574",
+	}
+
+	for source, want := range cases {
+		assert.Equalf(t, want, legacyRegistryHost(source), "source %q", source)
+	}
+}
+
+func TestLegacyRegistryAuthPriority(t *testing.T) {
+	logger := dkplog.NewNop()
+
+	t.Run("explicit login wins", func(t *testing.T) {
+		resetLegacyFlags(t)
+		d8flags.SourceRegistryLogin = "alice"
+		d8flags.SourceRegistryPassword = "secret"
+		d8flags.DeckhouseLicenseToken = "ignored"
+
+		cfg, err := legacyRegistryAuth("registry.example.com", logger).Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, "alice", cfg.Username)
+		assert.Equal(t, "secret", cfg.Password)
+	})
+
+	t.Run("license token maps to license-token user", func(t *testing.T) {
+		resetLegacyFlags(t)
+		d8flags.DeckhouseLicenseToken = "lic-123"
+
+		cfg, err := legacyRegistryAuth("registry.example.com", logger).Authorization()
+		require.NoError(t, err)
+		assert.Equal(t, "license-token", cfg.Username)
+		assert.Equal(t, "lic-123", cfg.Password)
+	})
+
+	t.Run("no credentials falls back to anonymous", func(t *testing.T) {
+		resetLegacyFlags(t)
+		// Point the Docker keychain at an empty config so the lookup finds nothing.
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+		assert.Equal(t, authn.Anonymous, legacyRegistryAuth("registry.example.com", logger))
+	})
+}
+
+func TestExtractPluginBinary(t *testing.T) {
+	t.Run("extracts the plugin entry, forced executable", func(t *testing.T) {
+		archive := plainTar(t, map[string]string{
+			"README":              "docs",
+			pluginBinaryEntryName: "#!/bin/sh\necho hi\n",
+		})
+
+		dest := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, extractPluginBinary(bytes.NewReader(archive), dest))
+
+		content, err := os.ReadFile(dest)
+		require.NoError(t, err)
+		assert.Equal(t, "#!/bin/sh\necho hi\n", string(content))
+
+		info, err := os.Stat(dest)
+		require.NoError(t, err)
+		assert.Equal(t, legacyExecutableMode, info.Mode().Perm())
+	})
+
+	t.Run("errors when no plugin entry is present", func(t *testing.T) {
+		archive := plainTar(t, map[string]string{"other": "x"})
+
+		err := extractPluginBinary(bytes.NewReader(archive), filepath.Join(t.TempDir(), "out"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+// plainTar builds an uncompressed tar (as an image's Extract() stream would be)
+// from name->content entries.
+func plainTar(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary

Re-add `--source` to `d8 plugins install` as a hidden escape hatch that pulls a plugin straight from a registry, bypassing the in-cluster registry-packages-proxy (RPP) and the cluster. 

**_This unblocks CI,_** which publishes plugins and installs the `package` plugin from a registry where no cluster is reachable.

## Context

#386 made the plugin machinery reach the registry exclusively through the in-cluster RPP, authenticated by the caller's kubeconfig identity. 

That removed `--source` and, with it, the only way to install a plugin without a cluster. CI has no cluster and no RPP: it logs in to a registry and installs the `package` plugin directly, so it needs the pre-#386 direct path back.

RPP stays the default and supported path. The bypass activates only when `--source` is passed.

## How it works

- Re-adds the pre-#386 flags as hidden flags: `--source`, `--source-login`, `--source-password`, `--license`, `--insecure`, `--tls-skip-verify`. An empty `--source` keeps RPP as the source.
- When `--source` is set, `InitPluginServices` builds a direct `registryPluginSource` (over go-containerregistry) instead of the RPP client, and skips cluster-side requirement checks - the bypass targets environments without a cluster, matching pre-#386 behavior.
- The pull path is `<--source>/plugins/<name>`, mirroring the RPP layout `deckhouse-cli/plugins/<name>`.
- Credential priority: `--source-login`/`--source-password`, then `--license`, then the Docker config (what `d8 dk cr login` writes), then anonymous.
- The bypass is isolated behind the grep marker `legacy --source`, in dedicated files with a removal checklist in their header:
  - `internal/plugins/flags/source_legacy.go`
  - `internal/plugins/source_legacy.go`

  Its only touch points in the main code are a three-line branch in `init.go` and one `AddLegacySourceFlags` call in `cmd/plugins.go`.

## Before / After

**Before:** `d8 plugins install <name> --source <registry>` fails with an unknown flag; every install needs a reachable cluster and RPP.
**After:**  `d8 plugins install <name> --source <registry>` pulls the plugin directly from the registry, with no cluster or proxy.

## Notes

- The bypass is temporary. Removal is self-contained: delete the two `*_legacy.go` files, drop the `AddLegacySourceFlags` call, and drop the `SourceRegistryRepo` branch in `init.go`.
- The flags are hidden on purpose: RPP is the supported path, `--source` is an escape hatch for cluster-less environments.
