### PR TITLE
[deckhouse-cli] Adding new commands and build status in the debug archive

### DIFF
--- a/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
+++ b/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
@@ -395,6 +395,8 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 	tarWriter := tar.NewWriter(gzipWriter)
 	defer tarWriter.Close()
 
+	fmt.Fprintf(os.Stderr, "Collecting debug info from Deckhouse...\n")
+
 	for _, cmd := range commands {
 		if isFileExcluded(cmd.File, excludeMap) {
 			continue
@@ -408,7 +410,7 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 
 		executor, err := utilk8s.ExecInPod(config, kubeCl, fullCommand, podName, namespace, containerName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: failed to create executor for %s: %v\n", cmd.File, err)
+			fmt.Fprintf(os.Stderr, "  ERROR: failed to create executor for %s: %v\n", cmd.File, err)
 			continue
 		}
 
@@ -422,9 +424,9 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 
 		if streamErr != nil {
 			if errors.Is(streamErr, context.DeadlineExceeded) {
-				fmt.Fprintf(os.Stderr, "WARNING: timed out collecting %s after %s\n", cmd.File, commandTimeout)
+				fmt.Fprintf(os.Stderr, "  WARNING: timed out collecting %s after %s\n", cmd.File, commandTimeout)
 			} else {
-				fmt.Fprintf(os.Stderr, "ERROR: collecting %s: %s\n%s\n", cmd.File, strings.Join(fullCommand, " "), stderr.String())
+				fmt.Fprintf(os.Stderr, "  ERROR: collecting %s: %s\n%s\n", cmd.File, strings.Join(fullCommand, " "), stderr.String())
 			}
 		}
 
@@ -435,6 +437,8 @@ func Tarball(config *rest.Config, kubeCl kubernetes.Interface, excludeFiles []st
 		stdout.Reset()
 		stderr.Reset()
 	}
+
+	fmt.Fprintf(os.Stderr, "Debug archive collection completed.\n")
 
 	return nil
 }

--- a/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
+++ b/internal/system/cmd/collect-debug-info/debugtar/debugTar.go
@@ -146,14 +146,14 @@ var debugCommands = []Command{
 		Args: []string{"-n", "d8-system", "logs", "-l", "app=deckhouse", "--tail", "3000"},
 	},
 	{
-		File: "capi-controller-manager.json",
+		File: "capi-controller-manager-logs.txt",
 		Cmd:  "kubectl",
-		Args: []string{"-n", "d8-cloud-instance-manager", "get", "pods", "-l", "app=capi-controller-manager", "-o", "json", "--ignore-not-found=true"},
+		Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=capi-controller-manager", "--tail", "3000", "--ignore-errors=true"},
 	},
 	{
-		File: "caps-controller-manager.json",
+		File: "caps-controller-manager-logs.txt",
 		Cmd:  "kubectl",
-		Args: []string{"-n", "d8-cloud-instance-manager", "get", "pods", "-l", "app=caps-controller-manager", "-o", "json", "--ignore-not-found=true"},
+		Args: []string{"-n", "d8-cloud-instance-manager", "logs", "-l", "app=caps-controller-manager", "--tail", "3000", "--ignore-errors=true"},
 	},
 	{
 		File:           "machine-controller-manager.json",
@@ -347,6 +347,11 @@ var debugCommands = []Command{
 		File: "storage-deckhouse-io-terminating.txt",
 		Cmd:  "bash",
 		Args: []string{"-c", `kubectl get $(kubectl api-resources --api-group=storage.deckhouse.io --verbs=list -o name | paste -sd, -) --ignore-not-found -A --chunk-size=200 -o json | jq -r '.items[] | select(.apiVersion == "storage.deckhouse.io/v1alpha1") | select(.metadata.deletionTimestamp != null) | "[\(.kind)] \(.metadata.namespace // "-")/\(.metadata.name)"'`},
+	},
+	{
+		File: "ingressnginxcontrollers.json",
+		Cmd:  "kubectl",
+		Args: []string{"get", "ingressnginxcontrollers.deckhouse.io", "-o", "json", "--ignore-not-found=true"},
 	},
 }
 


### PR DESCRIPTION
- Replaced the assembly of yaml manifests capi and caps with the assembly of logs from these pods. yaml of the pods themselves is in d8-all.json.
- Added ingressnginxcontrollers.json to the side.
- Added a small interactive element to make it clear that the archive build process has begun:
```
# d8 system collect-debug-info > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
Collecting debug info from Deckhouse...
Debug archive collection completed.
```
```
# d8 system collect-debug-info > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
Collecting debug info from Deckhouse...
  WARNING: timed out collecting events.json after 2m0s
Debug archive collection completed.
```