### PR TITLE
[deckhouse-cli] Group Taskfile tasks and list them on bare `task`

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ export GOPRIVATE="flant.internal"
 go mod tidy
 ```
 
+Run `task` to see all available tasks.
+
 To build for all platforms run:
 `task build:dist:all`
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,19 @@ vars:
   goReleaseLDFlags: "-s -w -X 'github.com/deckhouse/deckhouse-cli/internal/version.Version={{ .version }}' {{ .werfLDFlags }} {{ .kubectlLDFlags }}"
 
 tasks:
+  default:
+    desc: List available tasks
+    silent: true
+    env:
+      # Emoji per task group; a new group without an entry gets a plain arrow.
+      TASKLIST_EMOJI: "build=🔨 package=📦 lint=🧹 check=🔍 release=🚀 misc=🧰"
+    cmds:
+      # The grouped listing needs sh and awk; Windows falls back to a plain list.
+      - cmd: ./tools/list-tasks.sh
+        platforms: [linux, darwin]
+      - cmd: task --list --sort none
+        platforms: [windows]
+
   _build:cgo:dev:
     internal: true
     cmds:
@@ -94,17 +107,24 @@ tasks:
     cmds:
       - go run gotest.tools/gotestsum@latest -f {{ .testsumFormat }} -- -count=1 -tags="{{ .cgoTags }}" ./...
 
+  _package:dist:
+    internal: true
+    dir: dist/{{ .version }}
+    cmds:
+      - cp ../../LICENSE ../../README.md {{ .target }}
+      - tar -zcf d8-{{ .version }}-{{ .target }}.tar.gz {{ .target }}
+
   build:
-    desc: Build d8 binary for personal usage
+    desc: Build d8 for local use (current OS/arch)
     run: once
-    deps: [checkKubectl]
+    deps: ["check:kubectl"]
     cmds:
       - task: build:dev:{{ OS }}:{{ .arch }}
         vars:
           outputDir: "."
 
   build:dev:linux:amd64:
-    desc: Build d8 dev binary for linux/amd64 (requires Linux or Docker)
+    desc: Build dev binary for linux/amd64 (requires Linux or Docker)
     cmds:
       - task: _build:cgo:dev
         vars:
@@ -113,7 +133,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dev:linux:amd64:cross:
-    desc: Cross-compile d8 dev binary for linux/amd64 from macOS (no CGO)
+    desc: Cross-compile dev binary for linux/amd64 from macOS (no CGO)
     summary: |
       Cross-compiles Linux binary from macOS without CGO.
 
@@ -131,7 +151,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dev:darwin:amd64:
-    desc: Build d8 dev binary for darwin/amd64
+    desc: Build dev binary for darwin/amd64
     cmds:
       - task: _build:go:dev
         vars:
@@ -140,7 +160,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dev:darwin:arm64:
-    desc: Build d8 dev binary for darwin/arm64
+    desc: Build dev binary for darwin/arm64
     cmds:
       - task: _build:go:dev
         vars:
@@ -149,7 +169,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dev:windows:amd64:
-    desc: Build d8 dev binary for windows/amd64
+    desc: Build dev binary for windows/amd64
     cmds:
       - task: _build:go:dev
         vars:
@@ -158,7 +178,7 @@ tasks:
           outputDir: "{{.outputDir}}"
 
   build:dist:all:
-    desc: Build all d8 release binaries in parallel
+    desc: Build release binaries for all platforms
     deps:
       - build:dist:linux:amd64
       - build:dist:darwin:amd64
@@ -166,7 +186,7 @@ tasks:
       - build:dist:windows:amd64
 
   build:dist:linux:amd64:
-    desc: Build d8 release binary for linux/amd64
+    desc: Build release binary for linux/amd64
     cmds:
       - task: _build:cgo:dist
         vars:
@@ -175,7 +195,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dist:darwin:amd64:
-    desc: Build d8 release binary for darwin/amd64
+    desc: Build release binary for darwin/amd64
     cmds:
       - task: _build:go:dist
         vars:
@@ -184,7 +204,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dist:darwin:arm64:
-    desc: Build d8 release binary for darwin/arm64
+    desc: Build release binary for darwin/arm64
     cmds:
       - task: _build:go:dist
         vars:
@@ -193,7 +213,7 @@ tasks:
           outputDir: "{{ .outputDir }}"
 
   build:dist:windows:amd64:
-    desc: Build d8 release binary for windows/amd64
+    desc: Build release binary for windows/amd64
     cmds:
       - task: _build:go:dist
         vars:
@@ -201,14 +221,8 @@ tasks:
           targetArch: "amd64"
           outputDir: "{{ .outputDir }}"
 
-  _package:dist:
-    dir: dist/{{ .version }}
-    cmds:
-      - cp ../../LICENSE ../../README.md {{ .target }}
-      - tar -zcf d8-{{ .version }}-{{ .target }}.tar.gz {{ .target }}
-
   package:dist:all:
-    desc: Package all release assets in parallel
+    desc: Package release assets for all platforms
     deps:
       - package:dist:linux:amd64
       - package:dist:darwin:amd64
@@ -247,8 +261,8 @@ tasks:
         vars:
           target: "windows-amd64"
 
-  checksum:
-    desc: Calculate sha256 checksum for release assets
+  package:checksum:
+    desc: Write sha256 checksums for release assets
     dir: dist/{{ .version }}
     cmds:
       - |
@@ -257,14 +271,14 @@ tasks:
         done
 
   build-and-package:
-    desc: Build and package all d8 binaries
+    desc: Build, package and checksum all release binaries
     cmds:
       - task: build:dist:all
       - task: package:dist:all
-      - task: checksum
+      - task: package:checksum
 
   test:
-    desc: Run go test for current project
+    desc: Run Go tests
     cmds:
       - task: _test:go
 
@@ -274,12 +288,12 @@ tasks:
       - golangci-lint run ./... --fix --build-tags="{{ .goTags }}"
 
   lint:check:
-    desc: Run golangci-lint without auto-fix (CI mode)
+    desc: Run golangci-lint without fixes (CI mode)
     cmds:
       - golangci-lint run ./... --build-tags="{{ .goTags }}"
 
-  checkKubectl:
-    desc: Verify that kubectlVersion in Taskfile.yml matches k8s.io/kubectl version in go.mod
+  check:kubectl:
+    desc: Check kubectlVersion matches k8s.io/kubectl in go.mod
     cmds:
       - |
         gomod_raw=$(grep 'k8s.io/kubectl ' go.mod | awk '{print $2}')
@@ -299,13 +313,13 @@ tasks:
         echo "kubectlVersion OK: {{ .kubectlVersion }}"
 
   clean:
-    desc: Clean all binaries
+    desc: Remove built binaries (build/, dist/, ./d8)
     cmds:
       - rm -rf ./build ./dist ./d8
 
   release:sign:
-    desc: "Sign last version tag + origin/main and push signatures."
-    deps: [checkKubectl]
+    desc: Sign latest tag + origin/main and push signatures
+    deps: ["check:kubectl"]
     preconditions:
       - sh: '[[ "{{.CLI_ARGS}}" =~ ^v\d+.\d+.\d+$ ]] || exit 1'
         msg: Provide valid semver prefixed with "v" (eg. task {{.TASK}} -- v1.2.3) to be used as version
@@ -322,7 +336,7 @@ tasks:
 
   release:publish-trdl-channels:
     desc: Publish release channels to TRDL
-    deps: [checkKubectl]
+    deps: ["check:kubectl"]
     preconditions:
       - sh: test $(git rev-parse --abbrev-ref HEAD) = "main"
         msg: This can only be done on main branch

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,8 @@
 # D8 (Deckhouse CLI) Installation Script
 
 This directory contains the installation script for D8 (Deckhouse CLI).
+It also holds `list-tasks.sh` - the grouped task listing behind bare `task`
+(invoked by the `default` task in `Taskfile.yml`).
 
 ## Quick Install
 

--- a/tools/list-tasks.sh
+++ b/tools/list-tasks.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+# Grouped, colored task list for bare `task` (invoked by the `default` task).
+#
+# Input is `task --list --json`, not the human-readable `--list` table: the JSON
+# is a machine-readable contract, and name/desc arrive as separate fields.
+#
+# Grouping rules:
+# - a group is the name segment before the first ':' (build:dist:all -> build)
+# - a colon-less task joins the same-named group when one exists (build, lint);
+#   otherwise it lands in a trailing `misc` bucket (test, clean)
+# - inside a group, tasks are split into blocks by their second segment, but a
+#   blank line is only drawn where a block holds more than one task
+# - group order and in-group order follow Taskfile definition order (--sort none)
+#
+# TASKLIST_EMOJI maps groups to header icons ("build=🔨 misc=🧰");
+# a group with no entry falls back to a plain arrow.
+set -eu
+
+# Color: on for a tty; FORCE_COLOR (the variable task honors) or
+# CLICOLOR_FORCE forces on; NO_COLOR wins over everything.
+color=1
+[ -t 1 ] || color=0
+if [ "${FORCE_COLOR:-0}" != 0 ] || [ "${CLICOLOR_FORCE:-0}" != 0 ]; then color=1; fi
+if [ -n "${NO_COLOR:-}" ]; then color=0; fi
+
+# Soft 256-color palette when the terminal advertises it, base ANSI otherwise.
+palette=16
+case "${COLORTERM:-}:${TERM:-}" in *truecolor* | *24bit* | *256color*) palette=256 ;; esac
+
+# Keep the command substitution: a pipe would swallow the exit code of task.
+tasks_json="$(task --list --json --sort none)" || exit $?
+
+printf '%s\n' "$tasks_json" | awk -v color="$color" -v palette="$palette" '
+BEGIN {
+  MISC = "\001"   # misc bucket key; a control char cannot collide with a task name
+  TITLE = "Deckhouse CLI · task <name> [-- args]"
+  KEY_NAME = "\"name\"[ \t]*:"
+}
+
+# Slurp the payload: JSON strings never span lines, so joining with a space is safe.
+{ json = json $0 " " }
+
+END {
+  parse_tasks(json)
+  parse_emoji(ENVIRON["TASKLIST_EMOJI"])
+  set_colors()
+  build_groups()
+  render()
+}
+
+# --- input ------------------------------------------------------------------
+
+# Cuts the payload into one chunk per task object and reads the fields out of
+# each. A chunk runs from one "name" key to the next; this relies on "name"
+# being the first string field of a task object, which is how task emits it.
+function parse_tasks(payload,   tail, chunk) {
+  if (!match(payload, KEY_NAME)) return
+  payload = substr(payload, RSTART)
+  while (payload != "") {
+    tail = substr(payload, 2)               # step over the current key
+    if (match(tail, KEY_NAME)) {
+      chunk = substr(payload, 1, RSTART)
+      payload = substr(tail, RSTART)
+    } else {
+      chunk = payload
+      payload = ""
+    }
+    add_task(chunk)
+  }
+}
+
+function add_task(chunk,   name) {
+  name = string_field(chunk, "name")
+  if (name == "" || name == "default") return   # do not list the lister itself
+  ntasks++
+  names[ntasks] = name
+  descs[ntasks] = string_field(chunk, "desc") alias_suffix(chunk)
+  if (length(name) > namewidth) namewidth = length(name)
+}
+
+# Value of a "<key>": "<value>" pair, JSON-unescaped. Empty when the key is absent.
+function string_field(chunk, key,   hit) {
+  if (!match(chunk, "\"" key "\"[ \t]*:[ \t]*\"([^\"\\\\]|\\\\.)*\"")) return ""
+  hit = substr(chunk, RSTART, RLENGTH)
+  sub(/^[^:]*:[ \t]*"/, "", hit)            # drop the key and the opening quote
+  sub(/"$/, "", hit)
+  return json_unescape(hit)
+}
+
+# Aliases rendered as "  (aliases: a, b)", the suffix `task --list` appends to a
+# description. Empty when the task has none.
+function alias_suffix(chunk,   body, n, i, item, out) {
+  if (!match(chunk, /"aliases"[ \t]*:[ \t]*\[[^]]*\]/)) return ""
+  body = substr(chunk, RSTART, RLENGTH)
+  sub(/^[^[]*\[/, "", body)
+  sub(/\]$/, "", body)
+  n = split(body, item, ",")
+  for (i = 1; i <= n; i++) {
+    gsub(/^[ \t"]+|[ \t"]+$/, "", item[i])
+    if (item[i] != "") out = (out == "") ? item[i] : out ", " item[i]
+  }
+  return (out == "") ? "" : "  (aliases: " out ")"
+}
+
+function json_unescape(s,   out, i, c, hex) {
+  for (i = 1; i <= length(s); i++) {
+    c = substr(s, i, 1)
+    if (c != "\\") { out = out c; continue }
+    i++
+    c = substr(s, i, 1)
+    if (c == "n" || c == "t" || c == "r") out = out " "   # keep one line per task
+    else if (c == "u") {
+      # Go json HTML-escapes & < > as \u00XX; other \uXXXX are not rendered.
+      hex = substr(s, i + 1, 4)
+      i += 4
+      if (hex == "0026") out = out "&"
+      else if (hex == "003c") out = out "<"
+      else if (hex == "003e") out = out ">"
+    }
+    else out = out c                                      # \" \\ \/ and friends
+  }
+  return out
+}
+
+function parse_emoji(spec,   ntok, i, tok, eq) {
+  ntok = split(spec, tok, " ")
+  for (i = 1; i <= ntok; i++) {
+    eq = index(tok[i], "=")
+    if (eq) emoji[substr(tok[i], 1, eq - 1)] = substr(tok[i], eq + 1)
+  }
+}
+
+# --- grouping ---------------------------------------------------------------
+
+function head_segment(name,   i) {
+  i = index(name, ":")
+  return i ? substr(name, 1, i - 1) : ""
+}
+
+function second_segment(name,   i, rest, j) {
+  i = index(name, ":")
+  if (!i) return ""
+  rest = substr(name, i + 1)
+  j = index(rest, ":")
+  return j ? substr(rest, 1, j - 1) : rest
+}
+
+# Assigns each task a group and a block, and counts block sizes.
+# Groups keep Taskfile order; the misc bucket, when present, goes last.
+function build_groups(   i, g) {
+  for (i = 1; i <= ntasks; i++)
+    if (head_segment(names[i]) != "") isgroup[head_segment(names[i])] = 1
+
+  for (i = 1; i <= ntasks; i++) {
+    g = head_segment(names[i])
+    if (g == "") g = isgroup[names[i]] ? names[i] : MISC
+    if (g == MISC && isgroup["misc"]) g = "misc"   # a real misc group absorbs the bucket
+    group[i] = g
+    block[i] = second_segment(names[i])
+    blocksize[g SUBSEP block[i]]++
+    if (g == MISC) hasmisc = 1
+    else if (!(g in seen)) { seen[g] = 1; grouporder[++ngroups] = g }
+  }
+  if (hasmisc) grouporder[++ngroups] = MISC
+}
+
+# --- output -----------------------------------------------------------------
+
+function set_colors() {
+  if (!color) { HEAD = ""; NAME = ""; DIM = ""; RESET = ""; return }
+  if (palette == 256) { HEAD = "\033[1;38;5;75m"; NAME = "\033[38;5;80m"; DIM = "\033[38;5;242m" }
+  else                { HEAD = "\033[1;34m";      NAME = "\033[36m";      DIM = "\033[2m" }
+  RESET = "\033[0m"
+}
+
+function render(   fmt, gi, g, label, i, prev, first) {
+  # Width is baked into the format: busybox awk rejects the "%-*s" specifier.
+  fmt = "    %s·%s %s%-" namewidth "s%s  %s\n"
+  printf "%s%s%s\n", DIM, TITLE, RESET
+  for (gi = 1; gi <= ngroups; gi++) {
+    g = grouporder[gi]
+    label = (g == MISC) ? "misc" : g
+    printf "\n%s %s%s%s\n", (label in emoji ? emoji[label] : "▸"), HEAD, label, RESET
+
+    prev = ""; first = 1
+    for (i = 1; i <= ntasks; i++) {
+      if (group[i] != g) continue
+      if (!first && block[i] != prev && \
+          (blocksize[g SUBSEP block[i]] > 1 || blocksize[g SUBSEP prev] > 1)) print ""
+      printf fmt, DIM, RESET, NAME, names[i], RESET, descs[i]
+      prev = block[i]; first = 0
+    }
+  }
+}'


### PR DESCRIPTION
## Summary

Bare `task` and `task --list` printed a flat wall of ~25 tasks with no structure. Now bare `task` prints them grouped by namespace.

- Add a `default` task running the new `tools/list-tasks.sh` (POSIX sh + awk, no new deps); Windows falls back to plain `task --list`.
- The script reads `task --list --json`, groups tasks by the segment before the first colon, and keeps Taskfile definition order. Per-group emoji come from `TASKLIST_EMOJI`; `NO_COLOR` / `FORCE_COLOR` are respected.
- Rename for consistency with existing namespaces: `checkKubectl` -> `check:kubectl`, `checksum` -> `package:checksum`.
- Mark `_package:dist` as `internal: true` and tighten task descriptions.

### Before 
<img width="3046" height="1266" alt="2026-07-13 AT 04 30@2x" src="https://github.com/user-attachments/assets/519d7443-ca01-42eb-9d74-7f834d9cc4b2" />

### After 
<img width="2386" height="1782" alt="2026-07-13 AT 04 29@2x" src="https://github.com/user-attachments/assets/b7bb937a-42c2-4638-8416-65c84924d834" />


## Notes

- CI is unaffected: `release.yaml` only calls `build-and-package`, `test`, `lint:check`, `build:dist:all`.
- The renames are user-facing - local scripts using `task checkKubectl` / `task checksum` need updating.
