### PR TITLE
[deckhouse-cli] Update built-in package command to v0.0.25

### DIFF
--- a/cmd/d8/root.go
+++ b/cmd/d8/root.go
@@ -129,7 +129,12 @@ func (r *RootCommand) registerCommands() {
 
 	r.cmd.AddCommand(packagecmd.NewCommand())
 
-	r.cmd.AddCommand(pluginscmd.NewCommand(r.logger.Named("plugins-command"), []string{commands.DeliveryKitCommandName}))
+	// delivery-kit and package ship as built-in commands, not as plugins. Declaring
+	// them here satisfies a plugin's dependency on either name without a registry lookup.
+	r.cmd.AddCommand(pluginscmd.NewCommand(
+		r.logger.Named("plugins-command"),
+		[]string{commands.DeliveryKitCommandName, pluginscmd.PackagePluginName},
+	))
 
 	r.cmd.AddCommand(selfupdatecmd.NewCommand(r.logger.Named("cli-command")))
 }

--- a/internal/packagecmd/internal/packages/render.go
+++ b/internal/packagecmd/internal/packages/render.go
@@ -63,7 +63,7 @@ func Render(ctx context.Context, def Definition, path string) ([]render.Object, 
 		Path:                path,
 		ValuesPaths:         []string{valuesPath},
 		RootValues:          fmt.Sprintf("Application=%s", marshalled),
-		ExtraCapabilitities: []string{"autoscaling.k8s.io/v1/VerticalPodAutoscaler"},
+		ExtraCapabilitities: []string{"autoscaling.k8s.io/v1/VerticalPodAutoscaler", "cert-manager.io/v1"},
 	}
 
 	result, err := render.Render(ctx, "test", "default.test", opts)

--- a/internal/packagecmd/internal/packages/render/render.go
+++ b/internal/packagecmd/internal/packages/render/render.go
@@ -67,7 +67,7 @@ func Render(ctx context.Context, namespace, releaseName string, opts Options) ([
 		return nil, fmt.Errorf("render nelm chart '%s': %w", opts.Path, err)
 	}
 
-	result := make([]Object, 0, len(res.Resources))
+	var result []Object
 
 	for _, resource := range res.Resources {
 		_, path, _ := strings.Cut(resource.FilePath, "/")

--- a/internal/packagecmd/internal/verify/lint/linters/images/linter.go
+++ b/internal/packagecmd/internal/verify/lint/linters/images/linter.go
@@ -27,7 +27,8 @@ type LinterSettings struct {
 
 // RulesSettings holds the severity configuration for each rule in the images linter.
 type RulesSettings struct {
-	Patches lint.RuleSettings
+	Patches   lint.RuleSettings
+	ImageName lint.RuleSettings
 }
 
 // NewLinter constructs a Linter from cfg, scoping its diagnostics to this linter and capping severity at the configured level.
@@ -57,6 +58,7 @@ func (l *Linter) Lint(ctx context.Context) {
 	}
 
 	rules.NewPatchesRule(l.config.Path, l.collector.With(diag.MaxLevel(l.settings.Patches.Impact))).Check(ctx)
+	rules.NewImageNameRule(l.config.Path, l.collector.With(diag.MaxLevel(l.settings.ImageName.Impact))).Check(ctx)
 }
 
 // hasImagesDir reports whether images/ exists as a directory in the package root.

--- a/internal/packagecmd/internal/verify/lint/linters/images/rules/image_name.go
+++ b/internal/packagecmd/internal/verify/lint/linters/images/rules/image_name.go
@@ -1,0 +1,111 @@
+package rules
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
+)
+
+// Rule purpose: forbid underscores in image names — both the images/<name> directory
+// names and the image: fields declared in images/<name>/werf.inc.yaml. werf builds each
+// image as "images/<name>", so an underscore there is not a valid image name.
+
+// ImageNameRuleID is the stable identifier used to reference this rule in configuration.
+const ImageNameRuleID = "image-name"
+
+const (
+	dockerfileName  = "Dockerfile"
+	werfIncFileName = "werf.inc.yaml"
+)
+
+// imageDeclPattern captures the value of a top-level image: declaration in a werf.inc.yaml file.
+var imageDeclPattern = regexp.MustCompile(`(?m)^image:[ \t]+(.+?)[ \t]*$`)
+
+// ImageNameRule rejects underscores in package image names.
+type ImageNameRule struct {
+	collector *diag.Collector
+	path      string
+}
+
+// NewImageNameRule constructs an ImageNameRule scoped to path, tagging diagnostics with the rule ID.
+func NewImageNameRule(path string, res *diag.Collector) *ImageNameRule {
+	return &ImageNameRule{
+		path:      path,
+		collector: res.With(diag.RuleID(ImageNameRuleID)),
+	}
+}
+
+// Check reports underscores in image directory names and in werf.inc.yaml image declarations.
+func (r *ImageNameRule) Check(_ context.Context) {
+	imagesDir := filepath.Join(r.path, imagesDirName)
+
+	entries, err := os.ReadDir(imagesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+
+		r.collector.With(
+			diag.Path(imagesDirName),
+			diag.Value(err.Error())).
+			Error("cannot scan package images")
+
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		imageDir := filepath.Join(imagesDir, entry.Name())
+		werfInc := filepath.Join(imageDir, werfIncFileName)
+
+		hasWerfInc := isFile(werfInc)
+		if !hasWerfInc && !isFile(filepath.Join(imageDir, dockerfileName)) {
+			// Not a build image directory: no Dockerfile and no werf.inc.yaml.
+			continue
+		}
+
+		if strings.Contains(entry.Name(), "_") {
+			r.collector.With(
+				diag.Path(packageRelativePath(r.path, imageDir)),
+				diag.Value(entry.Name())).
+				Error("image name %q must not contain underscores", entry.Name())
+		}
+
+		if hasWerfInc {
+			r.checkWerfInc(werfInc)
+		}
+	}
+}
+
+// checkWerfInc reports underscores in every top-level image: declaration of a werf.inc.yaml file.
+func (r *ImageNameRule) checkWerfInc(werfInc string) {
+	content, err := os.ReadFile(werfInc)
+	if err != nil {
+		return
+	}
+
+	rel := packageRelativePath(r.path, werfInc)
+
+	for _, match := range imageDeclPattern.FindAllStringSubmatch(string(content), -1) {
+		image := match[1]
+		if strings.Contains(image, "_") {
+			r.collector.With(
+				diag.Path(rel),
+				diag.Value(image)).
+				Error("image name %q in werf.inc.yaml must not contain underscores", image)
+		}
+	}
+}
+
+// isFile reports whether path exists and is a regular file.
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/pdb.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/pdb.go
@@ -64,7 +64,7 @@ func (r *PDBRule) Check(_ context.Context) {
 
 // collectPDBSelectors parses every PDB object into a namespace-scoped selector.
 func (r *PDBRule) collectPDBSelectors() []pdbSelector {
-	selectors := make([]pdbSelector, 0, len(r.objects))
+	var selectors []pdbSelector
 
 	for _, obj := range r.objects {
 		if obj.GetKind() != "PodDisruptionBudget" {

--- a/internal/packagecmd/internal/verify/lint/settings/load.go
+++ b/internal/packagecmd/internal/verify/lint/settings/load.go
@@ -79,6 +79,7 @@ func defaultLintersSettings() *Root {
 
 	r.Images.Impact = lint.Error.Ptr()
 	r.Images.RulesSettings.Patches.SetLevel("error", nil)
+	r.Images.RulesSettings.ImageName.SetLevel("error", nil)
 
 	r.Icon.Impact = lint.Error.Ptr()
 	r.Icon.RulesSettings.Ext.SetLevel("error", nil)
@@ -118,6 +119,7 @@ func remapLintersSettings(cfg Config) *Root {
 
 	r.Images.SetLevel(cfg.Linters.Images.Impact)
 	r.Images.RulesSettings.Patches.SetLevel(cfg.Linters.Images.Rules.Patches.Impact, lint.Error.Ptr())
+	r.Images.RulesSettings.ImageName.SetLevel(cfg.Linters.Images.Rules.ImageName.Impact, lint.Error.Ptr())
 
 	r.Icon.SetLevel(cfg.Linters.Icon.Impact)
 	r.Icon.RulesSettings.Ext.SetLevel(cfg.Linters.Icon.Rules.Ext.Impact, lint.Error.Ptr())

--- a/internal/packagecmd/internal/verify/lint/settings/settings.go
+++ b/internal/packagecmd/internal/verify/lint/settings/settings.go
@@ -106,6 +106,8 @@ type ImagesSettings struct {
 type ImagesRulesSettings struct {
 	// Patches configures checks that validate image patch layout and documentation.
 	Patches RuleSettings `mapstructure:"patches"`
+	// ImageName configures checks that reject underscores in image names.
+	ImageName RuleSettings `mapstructure:"image-name"`
 }
 
 // IconSettings configures the icon linter and its rules.

--- a/internal/packagecmd/packagecmd.go
+++ b/internal/packagecmd/packagecmd.go
@@ -10,6 +10,13 @@ import (
 // d8-cli (cmd/d8/root.go) can register via the standard NewCommand() entry
 // point used by other built-ins; the actual command tree lives under pkg/cmd
 // to mirror the original d8-package-plugin layout.
+//
+// Two things from the upstream plugin are deliberately left out: its standalone
+// entry point (cmd/package/main.go) and the "version" subcommand, whose value is
+// injected by the plugin's own ldflags. d8 reports its version itself.
+//
+// Vendored from d8-package-plugin v0.0.25 (4458426). Keep this in sync when
+// re-syncing internal/, pkg/ and templates/ from upstream.
 func NewCommand() *cobra.Command {
 	return pkgcmd.NewCmdRoot()
 }

--- a/internal/packagecmd/pkg/cmd/cmd.go
+++ b/internal/packagecmd/pkg/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/pkg/cmd/bootstrap"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/pkg/cmd/build"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/pkg/cmd/render"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/pkg/cmd/verify"
 )
 
@@ -25,6 +26,7 @@ This plugin helps you:
 
 	cmd.AddCommand(bootstrap.NewCmdBootstrap())
 	cmd.AddCommand(build.NewCmdBuild())
+	cmd.AddCommand(render.NewCmdRender())
 	cmd.AddCommand(verify.NewCmdVerify())
 
 	return cmd

--- a/internal/packagecmd/pkg/cmd/render/render.go
+++ b/internal/packagecmd/pkg/cmd/render/render.go
@@ -1,0 +1,145 @@
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages"
+	pkgrender "github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages/render"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/utils/find"
+)
+
+var (
+	// file filters the output to manifests rendered from the template whose file name equals it.
+	file string
+	// renderFile, when set, is the path the clean render (no '# Source:' headers) is written to.
+	renderFile string
+)
+
+// NewCmdRender creates a command that renders a package's templates to
+// Kubernetes manifests and prints them to stdout using stubbed runtime values.
+func NewCmdRender() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "Render package templates to Kubernetes manifests",
+		Long: `Render a package's templates to Kubernetes manifests using stubbed runtime values.
+
+Use 'package render' in a package directory to preview the manifests that would be
+installed in a cluster. Image digests, registry and credentials are stubbed, so the
+output is a smoke-check preview, not a faithful representation of a real cluster.
+
+Use --file to print only the manifests rendered from the template with that file
+name, and --render-file to write a clean render (without '# Source:' headers) to a file.`,
+		Example: `
+  # Render the current package
+  package render
+
+  # Render and dry-run apply with kubectl
+  package render | kubectl apply --dry-run=client -f -
+
+  # Print only the manifests from one template
+  package render --file deployment.yaml
+
+  # Write a clean render (no '# Source:' headers) to a file
+  package render --render-file rendered.yaml
+
+  # Write a clean render of a single template to a file
+  package render --file deployment.yaml --render-file deployment.out.yaml`,
+		Args:         cobra.MaximumNArgs(0),
+		SilenceUsage: true,
+		RunE:         render,
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Show only manifests rendered from the template with this file name")
+	cmd.Flags().StringVar(&renderFile, "render-file", "", "Write the clean render (without '# Source:' headers) to this file path")
+
+	return cmd
+}
+
+// render finds the current package, renders its templates, and either prints the
+// resulting manifests to stdout or writes a clean render to the --render-file path.
+func render(cmd *cobra.Command, _ []string) error {
+	path, err := find.PackageDir()
+	if err != nil {
+		return fmt.Errorf("find package dir: %w", err)
+	}
+
+	def, err := packages.LoadDefinitionByDir(path)
+	if err != nil {
+		return fmt.Errorf("load definition: %w", err)
+	}
+
+	objects, err := packages.Render(cmd.Context(), def, path)
+	if err != nil {
+		return fmt.Errorf("render templates: %w", err)
+	}
+
+	if file != "" {
+		objects = filterByFile(objects, file)
+		if len(objects) == 0 {
+			return fmt.Errorf("no rendered template matches %q", file)
+		}
+	}
+
+	if renderFile != "" {
+		return writeRenderFile(renderFile, objects)
+	}
+
+	return writeObjects(os.Stdout, objects, true)
+}
+
+// filterByFile returns the objects rendered from a template whose file name equals name.
+func filterByFile(objects []pkgrender.Object, name string) []pkgrender.Object {
+	matched := make([]pkgrender.Object, 0, len(objects))
+	for _, obj := range objects {
+		if filepath.Base(obj.FilePath) == name {
+			matched = append(matched, obj)
+		}
+	}
+
+	return matched
+}
+
+// writeRenderFile writes a clean render (no '# Source:' headers) of objects to path.
+func writeRenderFile(path string, objects []pkgrender.Object) error {
+	var buf bytes.Buffer
+	if err := writeObjects(&buf, objects, false); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write render file: %w", err)
+	}
+
+	return nil
+}
+
+// writeObjects writes each object as a '---'-separated YAML document. When
+// withSource is true, each document is prefixed with a '# Source: <template>'
+// comment naming the template it was rendered from.
+func writeObjects(w io.Writer, objects []pkgrender.Object, withSource bool) error {
+	for _, obj := range objects {
+		manifest, err := yaml.Marshal(obj.Object)
+		if err != nil {
+			return fmt.Errorf("marshal %s: %w", obj.ObjectID(), err)
+		}
+
+		if withSource {
+			_, err = fmt.Fprintf(w, "---\n# Source: %s\n%s", obj.FilePath, manifest)
+		} else {
+			_, err = fmt.Fprintf(w, "---\n%s", manifest)
+		}
+
+		if err != nil {
+			return fmt.Errorf("write manifest: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/packagecmd/templates/APPLICATION.md
+++ b/internal/packagecmd/templates/APPLICATION.md
@@ -1,0 +1,249 @@
+# Шаблоны чарта пакета-приложения (`templates/`)
+
+Справочник по каталогу `templates/` пакета типа `Application`: что в нём лежит, как заполнять
+манифесты, какие конструкции шаблонизатора использовать и какие хелперы доступны.
+
+Каталог `templates/` — это **Helm-совместимый чарт**. При сборке и развёртывании его рендерит движок
+`nelm`/`delivery-kit`: платформа подставляет реальные значения (`.Application`, `.Platform`,
+`.Capabilities`), доступны функции [Sprig](http://masterminds.github.io/sprig/) и `include`.
+Посмотреть результат локально: `package render` (см. [в конце](#предпросмотр)).
+
+> Для модулей набор контекста и хелперов другой — см. [MODULE.md](MODULE.md).
+
+---
+
+## Оглавление
+
+- [Что лежит в `templates/`](#что-лежит-в-templates)
+- [Контекст: какие данные доступны](#контекст-какие-данные-доступны)
+- [Конструкции шаблонизатора](#конструкции-шаблонизатора)
+  - [Базовый синтаксис Go template](#базовый-синтаксис-go-template)
+  - [Функции Sprig](#функции-sprig)
+- [Манифесты](#манифесты)
+- [Хелперы `_helpers/*.tpl`](#хелперы-_helperstpl)
+- [Предпросмотр](#предпросмотр)
+
+---
+
+## Что лежит в `templates/`
+
+```
+templates/
+├── deployment.yaml        # Deployment приложения
+├── service.yaml           # ClusterIP-сервис
+├── pdb.yaml               # PodDisruptionBudget
+├── vpa.yaml               # VerticalPodAutoscaler
+├── registry-secret.yaml   # секрет доступа к реестру образов
+└── _helpers/              # хелперы — вызываются через include, сами ресурсов не создают
+    ├── quantity_bytes.tpl
+    ├── bytes_quantity.tpl
+    └── public_domain.tpl
+```
+
+Каждый `*.yaml` рендерится в Kubernetes-манифест. Файлы в `_helpers/` (по соглашению с префиксом `_`)
+не дают собственных ресурсов — это библиотека именованных шаблонов для переиспользования.
+
+Ключевая идея приложения — **мультиэкземплярность**: все имена и неймспейсы строятся от
+`.Application.Instance`, чтобы несколько установок пакета в кластере не конфликтовали.
+
+---
+
+## Контекст: какие данные доступны
+
+Внутри манифестов `.` — это корневой контекст со значениями, которые подставляет платформа:
+
+| Выражение | Что это |
+|-----------|---------|
+| `.Application.Instance.Name` | имя конкретного экземпляра приложения |
+| `.Application.Instance.Namespace` | неймспейс экземпляра |
+| `.Application.Settings.<x>` | пользовательские настройки из `openapi/settings.yaml` (`.replicas`, `.msg`, …) |
+| `.Application.Package.Images` | map «имя образа → ссылка»; доступ через `index … "<name>"` |
+| `.Application.Package.Registry.dockercfg` | dockerconfig для секрета доступа к реестру |
+| `.Platform.applications.publicDomainTemplate` | шаблон публичного FQDN (для хелпера `public_domain`) |
+| `.Capabilities.APIVersions.Has "<gvk>"` | есть ли данный API/CRD в кластере |
+
+> Поля `.Application.Settings.*` берутся из схемы `openapi/settings.yaml`: что объявлено там —
+> то и доступно здесь. Внутренние значения (не задаваемые пользователем) лежат в `.Application`
+> согласно `openapi/values.yaml`.
+
+---
+
+## Конструкции шаблонизатора
+
+### Базовый синтаксис Go template
+
+| Конструкция | Назначение | Пример |
+|-------------|-----------|--------|
+| `{{ expr }}` | подставить значение | `name: {{ .Application.Instance.Name }}` |
+| `\| pipe` | передать значение в функцию | `{{ .Application.Settings.msg \| quote }}` |
+| `{{- ... -}}` | обрезать пробелы/перевод строки слева/справа | `{{- if … }}` |
+| `{{ $x := expr }}` | объявить переменную | `{{ $mem := include "quantity_bytes" "70Mi" \| int64 }}` |
+| `{{ if … }}…{{ else }}…{{ end }}` | условие | см. `vpa.yaml` |
+| `{{ range $i, $v := list }}…{{ end }}` | цикл | перебор коллекций |
+| `{{ with expr }}…{{ end }}` | сменить `.` на expr в блоке | работа с вложенным объектом |
+| `{{ define "name" }}…{{ end }}` | объявить именованный шаблон | в `_helpers/*.tpl` |
+| `{{ include "name" arg }}` | вызвать именованный шаблон/хелпер | `{{ include "quantity_bytes" "50Mi" }}` |
+| `{{ fail "msg" }}` | прервать рендер с ошибкой | валидация входных данных |
+
+Практические правила:
+
+- **Отступы в YAML** делайте через `nindent` / `indent`, а не пробелами в шаблоне:
+  `{{- include "server_resources" . | nindent 14 }}` — вставит блок с отступом 14 и переносом строки.
+- **`| quote`** для строковых значений, попадающих в YAML (`args`, `env.value`), чтобы не сломать
+  синтаксис спецсимволами.
+- **`| default`** страхует от пустых значений: `{{ .Application.Settings.replicas | default 1 }}`.
+- **`{{- -}}`** используйте, чтобы условные блоки не оставляли пустых строк в выводе.
+
+### Функции Sprig
+
+Часто используемые в этих чартах (полный список — в [документации Sprig](http://masterminds.github.io/sprig/)):
+
+| Функция | Назначение |
+|---------|-----------|
+| `default d x` | значение по умолчанию, если `x` пуст |
+| `quote` / `squote` | обернуть в двойные/одинарные кавычки |
+| `index m "k"` | доступ к элементу map/списка по ключу/индексу |
+| `nindent n` / `indent n` | отступ блока (с переносом строки / без) |
+| `toString` / `atoi` | преобразование в строку / в int |
+| `int64` / `float64` | приведение к числовым типам |
+| `mul` / `div` / `mod` | целочисленная арифметика |
+| `mulf` / `divf` / `addf` | арифметика с плавающей точкой |
+| `floor` / `ceil` / `round` | округление |
+| `hasSuffix` / `trimSuffix` / `contains` / `trim` | работа со строками |
+| `dict "k" v …` / `list a b …` | собрать map / список (для передачи в хелперы) |
+
+---
+
+## Манифесты
+
+Эталон — [deployment.yaml](application/templates/deployment.yaml):
+
+```yaml
+{{- define "server_resources" }}          # локальный именованный шаблон
+cpu: 30m
+memory: 70Mi
+{{- end }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Application.Instance.Name }}-server      # имя привязано к экземпляру
+spec:
+  replicas: {{ .Application.Settings.replicas | default 1 }}   # значение из openapi/settings
+  ...
+      containers:
+        - name: server
+          image: {{ index .Application.Package.Images "echo" }}   # образ пакета по имени
+          args:
+            - -text={{ .Application.Settings.msg | default "hello world" | quote }}
+          env:
+            - name: EPHEMERAL_STORAGE_BYTES
+              value: {{ include "quantity_bytes" "50Mi" | quote }}     # хелпер, см. ниже
+            {{- $memBytes := include "quantity_bytes" "70Mi" | int64 }}
+            {{- $cacheBytes := mulf (float64 $memBytes) 0.5 | floor | int64 }}
+            - name: CACHE_MAX_BYTES
+              value: {{ $cacheBytes | quote }}
+            - name: CACHE_MAX_SIZE
+              value: {{ include "bytes_quantity" $cacheBytes | quote }}  # обратный хелпер
+          resources:
+            requests:
+              ephemeral-storage: 50Mi
+              {{- include "server_resources" . | nindent 14 }}
+```
+
+Что важно и почему:
+
+- **`{{ .Application.Instance.Name }}-server`** — единый префикс имён на весь пакет (его же
+  используют `service.yaml`, `pdb.yaml`, `vpa.yaml`), чтобы селекторы совпадали, а два экземпляра не
+  пересекались. Префикс экземпляра проверяет линтер `templates`.
+- **`index .Application.Package.Images "echo"`** — ссылка на образ по имени; ключ `echo`
+  соответствует каталогу `images/echo/`.
+- **`securityContext`** прописан явно (`runAsNonRoot`, `readOnlyRootFilesystem`, `drop: ALL`).
+  В приложении нет `helm_lib_*`, поэтому политики безопасности задаются руками — не удаляйте их.
+- **`resources.requests`** обязателен; Deployment должен покрываться PDB и VPA (линтер `templates`:
+  правила `pdb`, `vpa`).
+
+Остальные манифесты:
+
+| Файл | Назначение | На что обратить внимание |
+|------|-----------|--------------------------|
+| [service.yaml](application/templates/service.yaml) | ClusterIP-сервис | `targetPort: http` — **именованный** порт (правило `service-port` запрещает числовые) |
+| [pdb.yaml](application/templates/pdb.yaml) | PodDisruptionBudget | селектор совпадает с Deployment; обязателен |
+| [vpa.yaml](application/templates/vpa.yaml) | VerticalPodAutoscaler | обёрнут в `{{ if .Capabilities.APIVersions.Has … }}` — рендерится только при наличии CRD; задайте `minAllowed`/`maxAllowed` |
+| [registry-secret.yaml](application/templates/registry-secret.yaml) | dockerconfig для pull образов | `.Application.Package.Registry.dockercfg` подставляется платформой |
+
+---
+
+## Хелперы `_helpers/*.tpl`
+
+Хелперы — именованные шаблоны (`{{ define "name" }}…{{ end }}`), вызываемые через
+`{{ include "name" аргумент }}`. Аргумент передаётся один; чтобы отдать несколько значений,
+собирают `list` или `dict`. В приложении доступны три хелпера.
+
+### `quantity_bytes` — quantity → байты
+
+[quantity_bytes.tpl](application/templates/_helpers/quantity_bytes.tpl) превращает
+Kubernetes-quantity (строку) в целое число байт.
+
+```yaml
+{{ include "quantity_bytes" "2Gi" }}    # -> 2147483648
+{{ include "quantity_bytes" "512Mi" }}  # -> 536870912
+{{ include "quantity_bytes" "1G" }}     # -> 1000000000  (десятичный суффикс)
+{{ include "quantity_bytes" "1024" }}   # -> 1024        (без суффикса)
+```
+
+- Поддерживает бинарные суффиксы (`Ki`,`Mi`,`Gi`,`Ti`,`Pi`,`Ei`), десятичные SI (`k`,`M`,`G`,`T`,`P`,`E`)
+  и голые числа. Целые мантиссы умножаются точно, дробные (`1.5Gi`) — через `float` с округлением вниз.
+- **Для чего:** приложению внутри контейнера нужно число байт (лимит буфера, размер кэша), а в
+  манифесте удобнее писать `50Mi`. Хелпер убирает ручной пересчёт и рассинхрон.
+
+### `bytes_quantity` — байты → quantity (обратный)
+
+[bytes_quantity.tpl](application/templates/_helpers/bytes_quantity.tpl) — инверсия предыдущего.
+
+```yaml
+{{ include "bytes_quantity" 536870912 }}                                # -> 512Mi
+{{ include "bytes_quantity" 2147483648 }}                               # -> 2Gi
+{{ include "bytes_quantity" (dict "bytes" 1000000 "base" "decimal") }}  # -> 1M
+{{ include "bytes_quantity" 500 }}                                      # -> 500
+```
+
+- Выбирает наибольший суффикс, на который байты делятся нацело; если ровно не делится — наибольший
+  подходящий с двумя знаками (`1.5Gi`). По умолчанию бинарные суффиксы; для SI передайте
+  `dict "bytes" N "base" "decimal"`.
+- **Для чего:** посчитали что-то в байтах (например, «половина запрошенной памяти под кэш») и хотите
+  вернуть значение в опрятную quantity. См. round-trip в `deployment.yaml` (`CACHE_MAX_BYTES` /
+  `CACHE_MAX_SIZE`).
+
+### `public_domain` — публичный FQDN приложения
+
+[public_domain.tpl](application/templates/_helpers/public_domain.tpl) собирает публичный домен
+экземпляра из шаблона платформы.
+
+```yaml
+{{ include "public_domain" (list . "server") }}
+```
+
+- Аргумент — `list`: первый элемент контекст (`.`), второй — имя компонента.
+- Берёт `.Platform.applications.publicDomainTemplate` и подставляет три `%s` **строго в порядке**:
+  компонент, `.Application.Instance.Name`, `.Application.Instance.Namespace`.
+- Если в шаблоне платформы не ровно три `%s` — прерывает рендер понятной ошибкой (`fail`).
+- **Для чего:** единообразно строить внешний адрес приложения (Ingress/ссылки), не хардкодя
+  доменную схему в каждом манифесте.
+
+
+---
+
+## Предпросмотр
+
+Отрендерить чарт с подставными значениями и увидеть итоговые манифесты:
+
+```bash
+cd my-app
+package render                                  # все манифесты в stdout
+package render --file deployment.yaml           # только один шаблон
+package render | kubectl apply --dry-run=client -f -   # синтаксическая проверка
+```
+
+Контракты шаблонов (мультиэкземплярность, PDB/VPA, именованные порты) проверяет `package verify`.
+Подробности по командам — в корневом [README.md](../README.md).

--- a/internal/packagecmd/templates/MODULE.md
+++ b/internal/packagecmd/templates/MODULE.md
@@ -1,0 +1,261 @@
+# Шаблоны чарта пакета-модуля (`templates/`)
+
+Справочник по каталогу `templates/` пакета типа `Module`: что в нём лежит, как заполнять манифесты,
+какие конструкции шаблонизатора использовать и какие хелперы доступны.
+
+Каталог `templates/` — это **Helm-совместимый чарт**. При сборке и развёртывании его рендерит движок
+`nelm`/`delivery-kit`: платформа подставляет глобальные `.Values`, подключается библиотека хелперов
+`helm_lib_*` (чарт `deckhouse_lib_helm` в `charts/`), доступны функции
+[Sprig](http://masterminds.github.io/sprig/) и `include`. Посмотреть результат локально:
+`package render` (см. [в конце](#предпросмотр)).
+
+> Модуль — это полноценный Deckhouse-модуль: глобальные `.Values`, библиотека `helm_lib_*`, обычно
+> один экземпляр в кластере. Приложение устроено иначе (контекст `.Application`, мультиэкземплярность)
+> — см. [APPLICATION.md](APPLICATION.md).
+
+---
+
+## Оглавление
+
+- [Что лежит в `templates/`](#что-лежит-в-templates)
+- [Контекст: какие данные доступны](#контекст-какие-данные-доступны)
+- [Конструкции шаблонизатора](#конструкции-шаблонизатора)
+  - [Базовый синтаксис Go template](#базовый-синтаксис-go-template)
+  - [Функции Sprig](#функции-sprig)
+- [Библиотека `helm_lib_*`](#библиотека-helm_lib_)
+- [Манифесты](#манифесты)
+- [Локальные хелперы `_helpers/*.tpl`](#локальные-хелперы-_helperstpl)
+- [Предпросмотр](#предпросмотр)
+
+---
+
+## Что лежит в `templates/`
+
+```
+templates/
+├── namespace.yaml         # неймспейс модуля
+├── deployment.yaml        # Deployment
+├── service.yaml           # ClusterIP-сервис
+├── ingress.yaml           # внешний доступ (Ingress + TLS)
+├── pdb.yaml               # PodDisruptionBudget
+├── vpa.yaml               # VerticalPodAutoscaler
+├── registry-secret.yaml   # секрет доступа к реестру образов
+└── _helpers/              # локальные хелперы (в дополнение к helm_lib_*)
+    ├── quantity_bytes.tpl
+    └── bytes_quantity.tpl
+```
+
+Каждый `*.yaml` рендерится в Kubernetes-манифест. Файлы в `_helpers/` (по соглашению с префиксом `_`)
+не дают собственных ресурсов — это библиотека именованных шаблонов. В отличие от приложения, модуль
+активно использует **библиотеку `helm_lib_*`** для образов, лейблов, security-контекстов, доменов и TLS.
+
+Ресурсы модуля привязаны к фиксированному неймспейсу (в шаблоне — `test`; замените на неймспейс
+своего модуля).
+
+---
+
+## Контекст: какие данные доступны
+
+Внутри манифестов `.` — корневой контекст со значениями, которые подставляет платформа:
+
+| Выражение | Что это |
+|-----------|---------|
+| `.Values.<x>` | значения модуля из `openapi/settings.yaml` + `values.yaml` (`.replicas`, `.msg`, `.internal.*`) |
+| `.Module.Package.Registry.dockercfg` | dockerconfig для секрета доступа к реестру |
+| `.Capabilities.APIVersions.Has "<gvk>"` | есть ли данный API/CRD в кластере |
+
+> Различие с приложением: в модуле пользовательские настройки читаются как `.Values.replicas`, а в
+> приложении — как `.Application.Settings.replicas`. Что объявлено в `openapi/settings.yaml` — то и
+> доступно в `.Values`; внутренние значения описываются в `openapi/values.yaml` (`.Values.internal.*`).
+
+---
+
+## Конструкции шаблонизатора
+
+### Базовый синтаксис Go template
+
+| Конструкция | Назначение | Пример |
+|-------------|-----------|--------|
+| `{{ expr }}` | подставить значение | `replicas: {{ .Values.replicas }}` |
+| `\| pipe` | передать значение в функцию | `{{ .Values.msg \| quote }}` |
+| `{{- ... -}}` | обрезать пробелы/перевод строки слева/справа | `{{- if … }}` |
+| `{{ $x := expr }}` | объявить переменную | `{{ $mem := include "quantity_bytes" "70Mi" \| int64 }}` |
+| `{{ if … }}…{{ else }}…{{ end }}` | условие | TLS-блок в `ingress.yaml` |
+| `{{ range $i, $v := list }}…{{ end }}` | цикл | перебор коллекций |
+| `{{ with expr }}…{{ end }}` | сменить `.` на expr в блоке | работа с вложенным объектом |
+| `{{ define "name" }}…{{ end }}` | объявить именованный шаблон | в `_helpers/*.tpl` |
+| `{{ include "name" arg }}` | вызвать шаблон/хелпер/функцию библиотеки | `{{ include "helm_lib_module_image" (list . "echo") }}` |
+| `{{ fail "msg" }}` | прервать рендер с ошибкой | валидация входных данных |
+
+Практические правила:
+
+- **Отступы в YAML** — через `nindent` / `indent`, а не пробелами в шаблоне. Библиотечные хелперы
+  почти всегда вставляются так: `{{- include "helm_lib_module_labels" (list . (dict "app" "server")) | nindent 2 }}`.
+- **Аргументы библиотечных хелперов** — это `list`, где **первый элемент всегда контекст `.`**, далее
+  доп. параметры (часто через `dict`).
+- **`| quote`** для строковых значений в YAML; **`| default`** — от пустых значений.
+- **`{{- -}}`** — чтобы условные блоки не оставляли пустых строк.
+
+### Функции Sprig
+
+Часто используемые (полный список — в [документации Sprig](http://masterminds.github.io/sprig/)):
+
+| Функция | Назначение |
+|---------|-----------|
+| `default d x` | значение по умолчанию, если `x` пуст |
+| `quote` / `squote` | обернуть в кавычки |
+| `index m "k"` | доступ к элементу map/списка |
+| `nindent n` / `indent n` | отступ блока (с переносом / без) |
+| `toString` / `atoi` | преобразование в строку / int |
+| `int64` / `float64` | приведение к числовым типам |
+| `mul` / `div` / `mod` | целочисленная арифметика |
+| `mulf` / `divf` / `addf` | арифметика с плавающей точкой |
+| `floor` / `ceil` / `round` | округление |
+| `hasSuffix` / `trimSuffix` / `contains` / `trim` | работа со строками |
+| `dict "k" v …` / `list a b …` | собрать map / список (для передачи в хелперы) |
+
+---
+
+## Библиотека `helm_lib_*`
+
+Файл `charts/deckhouse_lib_helm-*.tgz` — упакованная чарт-библиотека Deckhouse. Она подключается как
+зависимость и даёт функции `helm_lib_*`, вызываемые через `include`. **Не распаковывайте и не
+редактируйте** архив; для обновления замените `.tgz` на новую версию.
+
+Функции, используемые в шаблонах модуля, и для чего они:
+
+| Хелпер | Для чего |
+|--------|----------|
+| `helm_lib_module_labels` | стандартные лейблы ресурса модуля; аргумент `(list . (dict "app" "server"))` |
+| `helm_lib_module_image` | ссылка на образ по имени; `(list . "echo")` |
+| `helm_lib_module_public_domain` | публичный FQDN компонента; `(list . "server")` |
+| `helm_lib_module_ingress_class` | класс Ingress модуля |
+| `helm_lib_module_https_ingress_tls_enabled` | включён ли TLS для Ingress (для условия) |
+| `helm_lib_module_https_secret_name` | имя TLS-секрета; `(list . "ingress-tls")` |
+| `helm_lib_module_ephemeral_storage_only_logs` | requests ephemeral-storage под логи |
+| `helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted` | security-контекст контейнера по PSS |
+| `helm_lib_module_pod_security_context_run_as_user_deckhouse` | security-контекст пода |
+
+> Именно из-за библиотеки в модуле **нет** локального хелпера `public_domain` (как в приложении):
+> его роль выполняет `helm_lib_module_public_domain`. Прежде чем писать свой хелпер, проверьте, нет
+> ли готового `helm_lib_*`.
+
+---
+
+## Манифесты
+
+Эталон — [deployment.yaml](module/templates/deployment.yaml):
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+  namespace: test
+  {{- include "helm_lib_module_labels" (list . (dict "app" "server")) | nindent 2 }}   # лейблы модуля
+spec:
+  replicas: {{ .Values.replicas | default 1 }}          # значение из openapi/settings
+  ...
+      containers:
+        - name: server
+          image: {{ include "helm_lib_module_image" (list . "echo") }}   # образ через библиотеку
+          args:
+            - -text={{ .Values.msg | default "hello world" | quote }}
+          env:
+            - name: EPHEMERAL_STORAGE_BYTES
+              value: {{ include "quantity_bytes" "50Mi" | quote }}       # локальный хелпер, см. ниже
+            {{- $memBytes := include "quantity_bytes" "70Mi" | int64 }}
+            {{- $cacheBytes := mulf (float64 $memBytes) 0.5 | floor | int64 }}
+            - name: CACHE_MAX_BYTES
+              value: {{ $cacheBytes | quote }}
+            - name: CACHE_MAX_SIZE
+              value: {{ include "bytes_quantity" $cacheBytes | quote }}  # обратный хелпер
+          resources:
+            requests:
+              {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
+          {{- include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . | nindent 10 }}
+          {{- "readOnlyRootFilesystem: true" | nindent 12 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+```
+
+Что важно и почему:
+
+- **`helm_lib_module_labels`** и прочие библиотечные хелперы вызываются с контекстом `.` первым
+  элементом `list`; вставляются через `nindent`, чтобы не сломать отступы YAML.
+- **`helm_lib_module_image (list . "echo")`** — ссылка на образ по имени; ключ `echo` соответствует
+  каталогу `images/echo/`. Библиотека сама подставит корректный путь/digest.
+- **security-контексты** задаются хелперами (`…_container_security_context_…`,
+  `…_pod_security_context_…`) — это соответствие стандартам PSS Deckhouse; не заменяйте их ручными
+  блоками без причины.
+- Deployment должен покрываться PDB и VPA (линтер `templates`: правила `pdb`, `vpa`).
+
+Остальные манифесты:
+
+| Файл | Назначение | На что обратить внимание |
+|------|-----------|--------------------------|
+| [namespace.yaml](module/templates/namespace.yaml) | неймспейс модуля | замените `test` на реальное имя; лейблы через `helm_lib_module_labels` |
+| [service.yaml](module/templates/service.yaml) | ClusterIP-сервис | `targetPort: http` — **именованный** порт (правило `service-port`) |
+| [ingress.yaml](module/templates/ingress.yaml) | внешний доступ | хост — `helm_lib_module_public_domain`, класс — `helm_lib_module_ingress_class`, TLS — блок `{{ if (include "helm_lib_module_https_ingress_tls_enabled" .) }}` |
+| [pdb.yaml](module/templates/pdb.yaml) | PodDisruptionBudget | селектор совпадает с Deployment; обязателен |
+| [vpa.yaml](module/templates/vpa.yaml) | VerticalPodAutoscaler | задайте `minAllowed`/`maxAllowed` |
+| [registry-secret.yaml](module/templates/registry-secret.yaml) | dockerconfig для pull образов | `.Module.Package.Registry.dockercfg` подставляется платформой |
+
+---
+
+## Локальные хелперы `_helpers/*.tpl`
+
+Локальные хелперы — именованные шаблоны пакета в дополнение к библиотеке `helm_lib_*`. Вызываются
+через `{{ include "name" аргумент }}`. В модуле их два (домены/TLS/образы закрывает библиотека,
+поэтому `public_domain` здесь не нужен).
+
+### `quantity_bytes` — quantity → байты
+
+[quantity_bytes.tpl](module/templates/_helpers/quantity_bytes.tpl) превращает Kubernetes-quantity
+(строку) в целое число байт.
+
+```yaml
+{{ include "quantity_bytes" "2Gi" }}    # -> 2147483648
+{{ include "quantity_bytes" "512Mi" }}  # -> 536870912
+{{ include "quantity_bytes" "1G" }}     # -> 1000000000  (десятичный суффикс)
+{{ include "quantity_bytes" "1024" }}   # -> 1024        (без суффикса)
+```
+
+- Поддерживает бинарные суффиксы (`Ki`,`Mi`,`Gi`,`Ti`,`Pi`,`Ei`), десятичные SI (`k`,`M`,`G`,`T`,`P`,`E`)
+  и голые числа. Целые мантиссы умножаются точно, дробные (`1.5Gi`) — через `float` с округлением вниз.
+- **Для чего:** приложению внутри контейнера нужно число байт (лимит буфера, размер кэша), а в
+  манифесте удобнее писать `50Mi`. Хелпер убирает ручной пересчёт и рассинхрон.
+
+### `bytes_quantity` — байты → quantity (обратный)
+
+[bytes_quantity.tpl](module/templates/_helpers/bytes_quantity.tpl) — инверсия предыдущего.
+
+```yaml
+{{ include "bytes_quantity" 536870912 }}                                # -> 512Mi
+{{ include "bytes_quantity" 2147483648 }}                               # -> 2Gi
+{{ include "bytes_quantity" (dict "bytes" 1000000 "base" "decimal") }}  # -> 1M
+{{ include "bytes_quantity" 500 }}                                      # -> 500
+```
+
+- Выбирает наибольший суффикс, на который байты делятся нацело; если ровно не делится — наибольший
+  подходящий с двумя знаками (`1.5Gi`). По умолчанию бинарные суффиксы; для SI передайте
+  `dict "bytes" N "base" "decimal"`.
+- **Для чего:** посчитали что-то в байтах (например, «половина запрошенной памяти под кэш») и хотите
+  вернуть значение в опрятную quantity. См. round-trip в `deployment.yaml` (`CACHE_MAX_BYTES` /
+  `CACHE_MAX_SIZE`).
+
+
+---
+
+## Предпросмотр
+
+Отрендерить чарт с подставными значениями и увидеть итоговые манифесты:
+
+```bash
+cd my-module
+package render                                  # все манифесты в stdout
+package render --file deployment.yaml           # только один шаблон
+package render | kubectl apply --dry-run=client -f -   # синтаксическая проверка
+```
+
+Контракты шаблонов (PDB/VPA, именованные порты) проверяет `package verify`. Подробности по командам —
+в корневом [README.md](../README.md).

--- a/internal/packagecmd/templates/application/.gitlab-ci.yml.tmpl
+++ b/internal/packagecmd/templates/application/.gitlab-ci.yml.tmpl
@@ -1,3 +1,4 @@
+# templates link: https://fox.flant.com/team/foxtrot/packages-gitlab-ci
 include:
   - project: 'team/foxtrot/packages-gitlab-ci'
     ref: main
@@ -8,6 +9,17 @@ include:
   - project: 'team/foxtrot/packages-gitlab-ci'
     ref: main
     file: 'templates/Publish.gitlab-ci.yml'
+
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+
+default:
+  # Mark all jobs as interruptible to cancel previous builds if new one is started
+  interruptible: true
+  # Use kubernetes runner by default
+  tags:
+  - werf-2-stable
 
 variables:
   PACKAGE_NAME: {{ .PackageName }}
@@ -27,20 +39,8 @@ variables:
   # PLUGINS_REGISTRY_LOGIN:
   # PLUGINS_REGISTRY_PASSWORD:
 
-default:
-  tags:
-  - werf-2-stable
 
-# --- Test stage ---
-Gotest:
-  extends: .go-test
-  allow_failure: false
-
-
-# --- Lint stage ---
-Golangci-lint:
-  extends: .golangci-lint
-
+# --- Test, Lint, Verify ---
 Verify:
   extends: .verify
   variables:
@@ -48,16 +48,30 @@ Verify:
     PACKAGES_REGISTRY_LOGIN: $DEV_PACKAGES_REGISTRY_LOGIN
     PACKAGES_REGISTRY_PASSWORD: $DEV_PACKAGES_REGISTRY_PASSWORD
 
+Golangci-lint:
+  extends: .golangci-lint
+  allow_failure: false
+
+Gotest:
+  extends: .go-test
+  allow_failure: false
+
+
 # --- Build ---
+# test for successful build
 Build dev:
   extends: .build
   variables:
     PACKAGES_REGISTRY: $DEV_PACKAGES_REGISTRY
     PACKAGES_REGISTRY_LOGIN: $DEV_PACKAGES_REGISTRY_LOGIN
     PACKAGES_REGISTRY_PASSWORD: $DEV_PACKAGES_REGISTRY_PASSWORD
+  # Empty needs decouples this job from stage ordering so it always runs,
+  # even if Verify/Golangci-lint/Gotest fail. Dev builds must stay available.
+  needs: []
   rules:
   - if: $CI_COMMIT_TAG
 
+# only build for prod will be used in future, build for dev will be replaced with d8 try command (when it will be implemented)
 Build prod:
   extends: .build
   variables:
@@ -78,12 +92,12 @@ Build prod:
 .editions-matrix:
   parallel:
     matrix:
-      - RELEASE_CHANNEL:
-          - alpha
-          - beta
-          - early-access
-          - stable
-          - rock-solid
+    - RELEASE_CHANNEL:
+      - alpha
+      - beta
+      - early-access
+      - stable
+      - rock-solid
 
 Publish dev:
   stage: publish

--- a/internal/packagecmd/templates/application/.pkglint.yaml
+++ b/internal/packagecmd/templates/application/.pkglint.yaml
@@ -68,6 +68,9 @@ linters:
       # Validates image patch placement, file naming, and README references.
       patches:
         impact: error
+      # Forbids underscores in image names (images/<name> dirs and image: in werf.inc.yaml).
+      image-name:
+        impact: error
 
   # Controls checks for the package icon (icon.<ext> at the package root).
   # Existence is enforced separately by the layout linter's icon rule.

--- a/internal/packagecmd/templates/application/package.yaml.tmpl
+++ b/internal/packagecmd/templates/application/package.yaml.tmpl
@@ -4,3 +4,8 @@ name: {{ .PackageName }}
 stage: Preview
 category: Misc
 version: dev # will be injected by CI/CD from the tag
+requirements:
+   deckhouse:
+     constraint: ">= v1.77"
+   kubernetes:
+     constraint: ">= v1.35"

--- a/internal/packagecmd/templates/application/templates/_helpers/bytes_quantity.tpl
+++ b/internal/packagecmd/templates/application/templates/_helpers/bytes_quantity.tpl
@@ -1,0 +1,64 @@
+{{- /*
+bytes_quantity converts an integer number of bytes back into a Kubernetes
+quantity string. It is the inverse of quantity_bytes.
+
+It picks the largest unit that divides the byte count exactly so the result
+stays an integer (e.g. 536870912 -> "512Mi"). When no unit divides evenly it
+falls back to the largest fitting unit with two decimals (e.g. "1.5Gi"). Values
+smaller than the smallest unit are emitted as a plain number.
+
+By default binary suffixes (Ki, Mi, Gi, Ti, Pi, Ei) are used. Pass a dict with
+"base" set to "decimal" to use SI suffixes (k, M, G, T, P, E) instead.
+
+Usage:
+  {{ include "bytes_quantity" 536870912 }}                              -> 512Mi
+  {{ include "bytes_quantity" 2147483648 }}                             -> 2Gi
+  {{ include "bytes_quantity" (dict "bytes" 1000000 "base" "decimal") }} -> 1M
+  {{ include "bytes_quantity" 1024 }}                                   -> 1Ki
+  {{ include "bytes_quantity" 500 }}                                    -> 500
+*/ -}}
+{{- define "bytes_quantity" -}}
+{{- $bytes := 0 -}}
+{{- $base := "binary" -}}
+{{- if kindIs "map" . -}}
+  {{- $bytes = .bytes | int64 -}}
+  {{- $base = .base | default "binary" -}}
+{{- else -}}
+  {{- $bytes = . | int64 -}}
+{{- end -}}
+{{- $units := list
+  (dict "suffix" "Ei" "factor" 1152921504606846976)
+  (dict "suffix" "Pi" "factor" 1125899906842624)
+  (dict "suffix" "Ti" "factor" 1099511627776)
+  (dict "suffix" "Gi" "factor" 1073741824)
+  (dict "suffix" "Mi" "factor" 1048576)
+  (dict "suffix" "Ki" "factor" 1024)
+-}}
+{{- if eq $base "decimal" -}}
+  {{- $units = list
+    (dict "suffix" "E" "factor" 1000000000000000000)
+    (dict "suffix" "P" "factor" 1000000000000000)
+    (dict "suffix" "T" "factor" 1000000000000)
+    (dict "suffix" "G" "factor" 1000000000)
+    (dict "suffix" "M" "factor" 1000000)
+    (dict "suffix" "k" "factor" 1000)
+  -}}
+{{- end -}}
+{{- $out := "" -}}
+{{- range $unit := $units -}}
+  {{- if and (eq $out "") (ge $bytes $unit.factor) (eq (mul (div $bytes $unit.factor) $unit.factor) $bytes) -}}
+    {{- $out = printf "%d%s" (div $bytes $unit.factor) $unit.suffix -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $out "" -}}
+  {{- range $unit := $units -}}
+    {{- if and (eq $out "") (ge $bytes $unit.factor) -}}
+      {{- $out = printf "%v%s" (round (divf (float64 $bytes) (float64 $unit.factor)) 2) $unit.suffix -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $out "" -}}
+  {{- $out = printf "%d" $bytes -}}
+{{- end -}}
+{{- $out -}}
+{{- end -}}

--- a/internal/packagecmd/templates/application/templates/_helpers/public_domain.tpl
+++ b/internal/packagecmd/templates/application/templates/_helpers/public_domain.tpl
@@ -1,0 +1,13 @@
+{{- /* Usage: {{ include "public_domain" (list . "<component>") }} */ -}}
+{{- /* returns rendered publicDomainTemplate as the application public fqdn */ -}}
+{{- /* verbs order: "%s" component, "%s" instance name, "%s" instance namespace */ -}}
+{{- define "public_domain" }}
+  {{- $context   := index . 0 -}} {{- /* Template context with .Application, .Platform, etc */ -}}
+  {{- $component := index . 1 -}} {{- /* Component name portion */ -}}
+
+  {{- $template := $context.Platform.applications.publicDomainTemplate -}}
+  {{- if ne (int (sub (len (splitList "%s" $template)) 1)) 3 }}
+    {{ fail "Error!!! Platform.applications.publicDomainTemplate must contain exactly three \"%s\" patterns (component, instance name, instance namespace) to render application fqdn!" }}
+  {{- end }}
+  {{- printf $template $component $context.Application.Instance.Name $context.Application.Instance.Namespace -}}
+{{- end }}

--- a/internal/packagecmd/templates/application/templates/_helpers/quantity_bytes.tpl
+++ b/internal/packagecmd/templates/application/templates/_helpers/quantity_bytes.tpl
@@ -1,0 +1,49 @@
+{{- /*
+quantity_bytes converts a Kubernetes quantity string into an integer number of bytes.
+
+It accepts binary suffixes (Ki, Mi, Gi, Ti, Pi, Ei), decimal SI suffixes
+(k, M, G, T, P, E) and plain numbers without a suffix. Integer mantissas are
+multiplied exactly, fractional ones (e.g. "1.5Gi") fall back to float math.
+
+Usage:
+  {{ include "quantity_bytes" "2Gi" }}    -> 2147483648
+  {{ include "quantity_bytes" "512Mi" }}  -> 536870912
+  {{ include "quantity_bytes" "1G" }}     -> 1000000000
+  {{ include "quantity_bytes" "1024" }}   -> 1024
+*/ -}}
+{{- define "quantity_bytes" -}}
+{{- $q := . | toString | trim -}}
+{{- $units := list
+  (dict "suffix" "Ki" "factor" 1024)
+  (dict "suffix" "Mi" "factor" 1048576)
+  (dict "suffix" "Gi" "factor" 1073741824)
+  (dict "suffix" "Ti" "factor" 1099511627776)
+  (dict "suffix" "Pi" "factor" 1125899906842624)
+  (dict "suffix" "Ei" "factor" 1152921504606846976)
+  (dict "suffix" "k"  "factor" 1000)
+  (dict "suffix" "M"  "factor" 1000000)
+  (dict "suffix" "G"  "factor" 1000000000)
+  (dict "suffix" "T"  "factor" 1000000000000)
+  (dict "suffix" "P"  "factor" 1000000000000000)
+  (dict "suffix" "E"  "factor" 1000000000000000000)
+-}}
+{{- $bytes := "" -}}
+{{- range $unit := $units -}}
+  {{- if and (eq $bytes "") (hasSuffix $unit.suffix $q) -}}
+    {{- $num := trimSuffix $unit.suffix $q -}}
+    {{- if contains "." $num -}}
+      {{- $bytes = mulf (float64 $num) (float64 $unit.factor) | floor | int64 | toString -}}
+    {{- else -}}
+      {{- $bytes = mul (atoi $num) $unit.factor | toString -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $bytes "" -}}
+  {{- if contains "." $q -}}
+    {{- $bytes = $q | float64 | floor | int64 | toString -}}
+  {{- else -}}
+    {{- $bytes = $q | atoi | toString -}}
+  {{- end -}}
+{{- end -}}
+{{- $bytes -}}
+{{- end -}}

--- a/internal/packagecmd/templates/application/templates/deployment.yaml
+++ b/internal/packagecmd/templates/application/templates/deployment.yaml
@@ -33,6 +33,20 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - -text={{ .Application.Settings.msg | default "hello world" | quote}}
+          env:
+            # Example of the quantity_bytes helper: turns the ephemeral-storage
+            # request "50Mi" into a plain byte count for the app to consume.
+            - name: EPHEMERAL_STORAGE_BYTES
+              value: {{ include "quantity_bytes" "50Mi" | quote }}
+            # Round-trip example: parse the memory request into bytes, take half
+            # of it for an in-memory cache, then format the result back into a
+            # Kubernetes quantity with the bytes_quantity helper.
+            {{- $memBytes := include "quantity_bytes" "70Mi" | int64 }}
+            {{- $cacheBytes := mulf (float64 $memBytes) 0.5 | floor | int64 }}
+            - name: CACHE_MAX_BYTES
+              value: {{ $cacheBytes | quote }}
+            - name: CACHE_MAX_SIZE
+              value: {{ include "bytes_quantity" $cacheBytes | quote }}
           ports:
             - name: http
               containerPort: 5678

--- a/internal/packagecmd/templates/module/.gitlab-ci.yml.tmpl
+++ b/internal/packagecmd/templates/module/.gitlab-ci.yml.tmpl
@@ -40,6 +40,7 @@ Gotest:
 # --- Lint stage ---
 Golangci-lint:
   extends: .golangci-lint
+  allow_failure: false
 
 Verify:
   extends: .verify
@@ -55,6 +56,9 @@ Build dev:
     PACKAGES_REGISTRY: $DEV_PACKAGES_REGISTRY
     PACKAGES_REGISTRY_LOGIN: $DEV_PACKAGES_REGISTRY_LOGIN
     PACKAGES_REGISTRY_PASSWORD: $DEV_PACKAGES_REGISTRY_PASSWORD
+  # Empty needs decouples this job from stage ordering so it always runs,
+  # even if Verify/Golangci-lint/Gotest fail. Dev builds must stay available.
+  needs: []
   rules:
   - if: $CI_COMMIT_TAG
 

--- a/internal/packagecmd/templates/module/package.yaml.tmpl
+++ b/internal/packagecmd/templates/module/package.yaml.tmpl
@@ -4,3 +4,8 @@ name: {{ .PackageName }}
 stage: Preview
 category: Misc
 version: dev # will be injected by CI/CD from the tag
+requirements:
+  deckhouse:
+    constraint: ">= v1.77"
+  kubernetes:
+    constraint: ">= v1.35"

--- a/internal/packagecmd/templates/module/templates/_helpers/bytes_quantity.tpl
+++ b/internal/packagecmd/templates/module/templates/_helpers/bytes_quantity.tpl
@@ -1,0 +1,64 @@
+{{- /*
+bytes_quantity converts an integer number of bytes back into a Kubernetes
+quantity string. It is the inverse of quantity_bytes.
+
+It picks the largest unit that divides the byte count exactly so the result
+stays an integer (e.g. 536870912 -> "512Mi"). When no unit divides evenly it
+falls back to the largest fitting unit with two decimals (e.g. "1.5Gi"). Values
+smaller than the smallest unit are emitted as a plain number.
+
+By default binary suffixes (Ki, Mi, Gi, Ti, Pi, Ei) are used. Pass a dict with
+"base" set to "decimal" to use SI suffixes (k, M, G, T, P, E) instead.
+
+Usage:
+  {{ include "bytes_quantity" 536870912 }}                              -> 512Mi
+  {{ include "bytes_quantity" 2147483648 }}                             -> 2Gi
+  {{ include "bytes_quantity" (dict "bytes" 1000000 "base" "decimal") }} -> 1M
+  {{ include "bytes_quantity" 1024 }}                                   -> 1Ki
+  {{ include "bytes_quantity" 500 }}                                    -> 500
+*/ -}}
+{{- define "bytes_quantity" -}}
+{{- $bytes := 0 -}}
+{{- $base := "binary" -}}
+{{- if kindIs "map" . -}}
+  {{- $bytes = .bytes | int64 -}}
+  {{- $base = .base | default "binary" -}}
+{{- else -}}
+  {{- $bytes = . | int64 -}}
+{{- end -}}
+{{- $units := list
+  (dict "suffix" "Ei" "factor" 1152921504606846976)
+  (dict "suffix" "Pi" "factor" 1125899906842624)
+  (dict "suffix" "Ti" "factor" 1099511627776)
+  (dict "suffix" "Gi" "factor" 1073741824)
+  (dict "suffix" "Mi" "factor" 1048576)
+  (dict "suffix" "Ki" "factor" 1024)
+-}}
+{{- if eq $base "decimal" -}}
+  {{- $units = list
+    (dict "suffix" "E" "factor" 1000000000000000000)
+    (dict "suffix" "P" "factor" 1000000000000000)
+    (dict "suffix" "T" "factor" 1000000000000)
+    (dict "suffix" "G" "factor" 1000000000)
+    (dict "suffix" "M" "factor" 1000000)
+    (dict "suffix" "k" "factor" 1000)
+  -}}
+{{- end -}}
+{{- $out := "" -}}
+{{- range $unit := $units -}}
+  {{- if and (eq $out "") (ge $bytes $unit.factor) (eq (mul (div $bytes $unit.factor) $unit.factor) $bytes) -}}
+    {{- $out = printf "%d%s" (div $bytes $unit.factor) $unit.suffix -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $out "" -}}
+  {{- range $unit := $units -}}
+    {{- if and (eq $out "") (ge $bytes $unit.factor) -}}
+      {{- $out = printf "%v%s" (round (divf (float64 $bytes) (float64 $unit.factor)) 2) $unit.suffix -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $out "" -}}
+  {{- $out = printf "%d" $bytes -}}
+{{- end -}}
+{{- $out -}}
+{{- end -}}

--- a/internal/packagecmd/templates/module/templates/_helpers/quantity_bytes.tpl
+++ b/internal/packagecmd/templates/module/templates/_helpers/quantity_bytes.tpl
@@ -1,0 +1,49 @@
+{{- /*
+quantity_bytes converts a Kubernetes quantity string into an integer number of bytes.
+
+It accepts binary suffixes (Ki, Mi, Gi, Ti, Pi, Ei), decimal SI suffixes
+(k, M, G, T, P, E) and plain numbers without a suffix. Integer mantissas are
+multiplied exactly, fractional ones (e.g. "1.5Gi") fall back to float math.
+
+Usage:
+  {{ include "quantity_bytes" "2Gi" }}    -> 2147483648
+  {{ include "quantity_bytes" "512Mi" }}  -> 536870912
+  {{ include "quantity_bytes" "1G" }}     -> 1000000000
+  {{ include "quantity_bytes" "1024" }}   -> 1024
+*/ -}}
+{{- define "quantity_bytes" -}}
+{{- $q := . | toString | trim -}}
+{{- $units := list
+  (dict "suffix" "Ki" "factor" 1024)
+  (dict "suffix" "Mi" "factor" 1048576)
+  (dict "suffix" "Gi" "factor" 1073741824)
+  (dict "suffix" "Ti" "factor" 1099511627776)
+  (dict "suffix" "Pi" "factor" 1125899906842624)
+  (dict "suffix" "Ei" "factor" 1152921504606846976)
+  (dict "suffix" "k"  "factor" 1000)
+  (dict "suffix" "M"  "factor" 1000000)
+  (dict "suffix" "G"  "factor" 1000000000)
+  (dict "suffix" "T"  "factor" 1000000000000)
+  (dict "suffix" "P"  "factor" 1000000000000000)
+  (dict "suffix" "E"  "factor" 1000000000000000000)
+-}}
+{{- $bytes := "" -}}
+{{- range $unit := $units -}}
+  {{- if and (eq $bytes "") (hasSuffix $unit.suffix $q) -}}
+    {{- $num := trimSuffix $unit.suffix $q -}}
+    {{- if contains "." $num -}}
+      {{- $bytes = mulf (float64 $num) (float64 $unit.factor) | floor | int64 | toString -}}
+    {{- else -}}
+      {{- $bytes = mul (atoi $num) $unit.factor | toString -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $bytes "" -}}
+  {{- if contains "." $q -}}
+    {{- $bytes = $q | float64 | floor | int64 | toString -}}
+  {{- else -}}
+    {{- $bytes = $q | atoi | toString -}}
+  {{- end -}}
+{{- end -}}
+{{- $bytes -}}
+{{- end -}}

--- a/internal/packagecmd/templates/module/templates/deployment.yaml
+++ b/internal/packagecmd/templates/module/templates/deployment.yaml
@@ -24,6 +24,20 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - -text={{ .Values.msg | default "hello world" | quote}}
+          env:
+            # Example of the quantity_bytes helper: turns the ephemeral-storage
+            # request "50Mi" into a plain byte count for the app to consume.
+            - name: EPHEMERAL_STORAGE_BYTES
+              value: {{ include "quantity_bytes" "50Mi" | quote }}
+            # Round-trip example: parse the memory request into bytes, take half
+            # of it for an in-memory cache, then format the result back into a
+            # Kubernetes quantity with the bytes_quantity helper.
+            {{- $memBytes := include "quantity_bytes" "70Mi" | int64 }}
+            {{- $cacheBytes := mulf (float64 $memBytes) 0.5 | floor | int64 }}
+            - name: CACHE_MAX_BYTES
+              value: {{ $cacheBytes | quote }}
+            - name: CACHE_MAX_SIZE
+              value: {{ include "bytes_quantity" $cacheBytes | quote }}
           ports:
             - name: http
               containerPort: 5678

--- a/internal/plugins/cmd/plugin.go
+++ b/internal/plugins/cmd/plugin.go
@@ -31,7 +31,11 @@ import (
 
 const (
 	SystemPluginName = "system"
-	// PackagePluginName = "package" TODO(Glitchy-Sheep): will be added later during full plugin system implementation
+	// PackagePluginName names the capability, not a wrapper command: `d8 package`
+	// is always built in (cmd/d8/root.go). It is passed to SetBuiltinCommands so a
+	// plugin depending on "package" is satisfied without a registry lookup.
+	// TODO(Glitchy-Sheep): swap the built-in for NewPluginCommand during full plugin system implementation.
+	PackagePluginName = "package"
 )
 
 // NewPluginCommand returns the wrapper command that runs an installed plugin


### PR DESCRIPTION
## Summary

Updates the built-in `d8 package` command to upstream `d8-package-plugin` v0.0.25.

## Why

- `d8 package` is compiled into d8 (#370), not installed from the registry
- So it never updates on its own, and slowly falls behind upstream
- Upstream released 6 versions since we copied the code in May

## What changed

Brought over from upstream:

- `package render` - render package templates into Kubernetes manifests
  - `--file` - print manifests from one template only
  - `--render-file` - write a clean render to a file, without `# Source:` headers
- New template helpers:
  - `quantity_bytes` and `bytes_quantity` - convert between Kubernetes quantities and bytes
  - `public_domain` - for the application template
- New lint rule `images/image-name` - image names cannot contain underscores
- `cert-manager.io/v1` added to the default nelm capabilities
- Updated CI/CD templates and the `APPLICATION.md` / `MODULE.md` docs

Also:

- `package` is now passed to `SetBuiltinCommands`, so a plugin that depends on it works without a registry lookup

Left out on purpose:

- Upstream's standalone entry point (`cmd/package/main.go`)
- Upstream's `version` subcommand - d8 prints its own version

## Verification

Compared the copied tree with upstream v0.0.25 file by file:

- 136 of 137 files are the same, byte for byte
- The one difference is the `version` subcommand we dropped on purpose
- Upstream has no tests, so there were none to bring over

Checked on a built binary:

- `d8 package render --help` shows `--file` and `--render-file`
- Helpers work in a rendered package: `50Mi` -> `52428800`, `36700160` -> `35Mi`
- `d8 package verify` rejects `images/bad_name`
- `task build` and `task test` pass

## Notes

- `internal/plugins/builtins_test.go` only covers `delivery-kit` as a built-in. A case for `package` would be a good follow-up.
- `werf/nelm v1.24.1` matches upstream exactly. `cobra` and `go-containerregistry` are a few patch versions behind, with no visible effect.

