### PR TITLE
[deckhouse-cli] Add the ability to use some d8 functions in Windows

### DIFF
--- a/internal/backup/cmd/flags.go
+++ b/internal/backup/cmd/flags.go
@@ -1,16 +1,13 @@
 package backup
 
 import (
-	"os"
-
 	"github.com/spf13/pflag"
+
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 func addPersistentFlags(flagSet *pflag.FlagSet) {
-	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		defaultKubeconfigPath = p
-	}
+	defaultKubeconfigPath := utilk8s.DefaultKubeconfigPath()
 
 	flagSet.StringP(
 		"kubeconfig", "k",

--- a/internal/backup/cmd/flags.go
+++ b/internal/backup/cmd/flags.go
@@ -12,7 +12,7 @@ func addPersistentFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringP(
 		"kubeconfig", "k",
 		defaultKubeconfigPath,
-		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
+		"Path to kubeconfig file. (default is $KUBECONFIG when it is set, otherwise the default kubeconfig path for the current OS user)",
 	)
 
 	flagSet.String("context", "", "The name of the kubeconfig context to use")

--- a/internal/plugins/flags/flags.go
+++ b/internal/plugins/flags/flags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	rppflags "github.com/deckhouse/deckhouse-cli/internal/rpp/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 const (
@@ -61,11 +62,7 @@ func skipClusterChecksDefault() bool {
 }
 
 func defaultKubeconfigPath() string {
-	if v := os.Getenv("KUBECONFIG"); v != "" {
-		return v
-	}
-
-	return os.ExpandEnv("$HOME/.kube/config")
+	return utilk8s.DefaultKubeconfigPath()
 }
 
 func AddFlags(flagSet *pflag.FlagSet) {

--- a/internal/status/cmd/flags.go
+++ b/internal/status/cmd/flags.go
@@ -17,21 +17,18 @@ limitations under the License.
 package status
 
 import (
-	"os"
-
 	"github.com/spf13/pflag"
+
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 func addPersistentFlags(flagSet *pflag.FlagSet) {
-	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		defaultKubeconfigPath = p
-	}
+	defaultKubeconfigPath := utilk8s.DefaultKubeconfigPath()
 
 	flagSet.StringP(
 		"kubeconfig", "k",
 		defaultKubeconfigPath,
-		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
+		"Path to kubeconfig file. (default is $KUBECONFIG when it is set, otherwise the default kubeconfig path for the current OS user)",
 	)
 
 	flagSet.String("context", "", "The name of the kubeconfig context to use")

--- a/internal/system/flags/flags.go
+++ b/internal/system/flags/flags.go
@@ -17,22 +17,19 @@ limitations under the License.
 package flags
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
+
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 func AddPersistentFlags(cmd *cobra.Command) {
-	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		defaultKubeconfigPath = p
-	}
+	defaultKubeconfigPath := utilk8s.DefaultKubeconfigPath()
 
 	cmd.PersistentFlags().StringP(
 		"kubeconfig",
 		"k",
 		defaultKubeconfigPath,
-		"KubeConfig of the cluster. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
+		"Path to kubeconfig file. (default is $KUBECONFIG when it is set, otherwise the default kubeconfig path for the current OS user)",
 	)
 
 	cmd.PersistentFlags().String("context", "", "The name of the kubeconfig context to use")

--- a/internal/tools/sigmigrate/cmd/flags.go
+++ b/internal/tools/sigmigrate/cmd/flags.go
@@ -17,11 +17,10 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/pflag"
 
 	"github.com/deckhouse/deckhouse-cli/internal/tools/sigmigrate"
+	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
 
 const (
@@ -47,10 +46,7 @@ func addFlags(flags *pflag.FlagSet) {
 		"Set the log level (INFO, DEBUG, TRACE). Defaults to DEBUG.",
 	)
 
-	defaultKubeconfigPath := os.ExpandEnv("$HOME/.kube/config")
-	if p := os.Getenv("KUBECONFIG"); p != "" {
-		defaultKubeconfigPath = p
-	}
+	defaultKubeconfigPath := utilk8s.DefaultKubeconfigPath()
 
 	flags.String(
 		"kubeconfig",

--- a/internal/tools/sigmigrate/cmd/flags.go
+++ b/internal/tools/sigmigrate/cmd/flags.go
@@ -51,7 +51,7 @@ func addFlags(flags *pflag.FlagSet) {
 	flags.String(
 		"kubeconfig",
 		defaultKubeconfigPath,
-		"Path to the kubeconfig file to use for CLI requests. (default is $KUBECONFIG when it is set, $HOME/.kube/config otherwise)",
+		"Path to the kubeconfig file to use for CLI requests. (default is $KUBECONFIG when it is set, otherwise the default kubeconfig path for the current OS user)",
 	)
 
 	flags.String(

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -20,6 +20,7 @@ func DefaultKubeconfigPath() string {
 	if p := os.Getenv(clientcmd.RecommendedConfigPathEnvVar); p != "" {
 		return p
 	}
+
 	return clientcmd.RecommendedHomeFile
 }
 

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -2,6 +2,7 @@ package utilk8s
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
@@ -10,6 +11,17 @@ import (
 )
 
 const DefaultKubeContext = ""
+
+// DefaultKubeconfigPath returns the default path to the kubeconfig file.
+// It respects the "KUBECONFIG" environment variable (clientcmd.RecommendedConfigPathEnvVar)
+// when set, and falls back to the platform-appropriate default path (clientcmd.RecommendedHomeFile).
+// This correctly resolves the home directory on all platforms, including "Windows" where $HOME is not set but %USERPROFILE% is.
+func DefaultKubeconfigPath() string {
+	if p := os.Getenv(clientcmd.RecommendedConfigPathEnvVar); p != "" {
+		return p
+	}
+	return clientcmd.RecommendedHomeFile
+}
 
 // SetupK8sClientSet reads kubeconfig file at kubeconfigPath and constructs a kubernetes clientset from it.
 // If contextName is not empty, context under that name is used instead of default.


### PR DESCRIPTION
Now, when executing some commands via **d8** on **Windows**, we may receive the error:
```
PS C:\Users\user\Desktop> .\d8.exe status
Error executing command: failed to setup Kubernetes client: failed to setup Kubernetes client: reading kubeconfig file: GetFileAttributesEx /.kube/config: The system cannot find the path specified.
```

The reason is that some functions calculate the path using the Go function `os.ExpandEnv("$HOME/.kube/config")`, which substitutes the `$HOME` environment variable. On **Windows**, this variable is not set by default. **Windows** uses `%USERPROFILE%` (e.g., `C:\Users\user`). The `$HOME` variable on **Windows** returns an empty string -> resulting in the error described above.

To fix this, a separate helper function, [defaultKubeconfigPath](https://github.com/deckhouse/deckhouse-cli/pull/402/changes#diff-fc15617e21f9fcc4239d2bbedde1b0d851b50bef213c65d326e2d9316bba26b6R15-R25), was created in the `utilk8s` package to avoid having to describe the same logic in five files. It will use the official constant from the Kubernetes client library, [clientcmd.RecommendedConfigPathEnvVar](https://pkg.go.dev/k8s.io/client-go/tools/clientcmd#pkg-constants), to calculate the path in a cross-platform manner.

