### PR TITLE
[deckhouse-cli] Fix misleading error message for registry path

### DIFF
--- a/internal/mirror/README.MD
+++ b/internal/mirror/README.MD
@@ -323,7 +323,7 @@ d8 mirror push <images-bundle-path> <registry> [flags]
 ### Arguments
 
 - `<images-bundle-path>` - Path to the directory containing the bundle created by `d8 mirror pull`
-- `<registry>` - Target registry address (format: `registry-host[:port]/path`)
+- `<registry>` - Target registry address (format: `registry-host[:port]/path`, e.g. `registry.corp.local:5000/deckhouse`)
 
 ### Flags
 

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -104,7 +104,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 		&SourceRegistryRepo,
 		"source",
 		EnterpriseEditionRepo,
-		"Source registry to pull Deckhouse images from.",
+		"Source registry to pull Deckhouse images from (format: registry-host[:port]/path).",
 	)
 	flagSet.StringVar(
 		&SourceRegistryLogin,

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -66,15 +66,26 @@ func validateSourceRegistry() error {
 		return nil // Default is fine
 	}
 
+	source := pullflags.SourceRegistryRepo
+
+	// Check the "host:port" format of the user-provided repository URL.
+	// It must have a path after the host and port.
+	if _, repoPath, _ := strings.Cut(source, "/"); repoPath == "" {
+		return fmt.Errorf(
+			"--source %q is missing the repository path: expected format registry-host[:port]/path, e.g. %q",
+			source, strings.TrimRight(source, "/")+"/deckhouse/ee",
+		)
+	}
+
 	// We first validate that passed repository reference is correct and can be parsed
-	if _, err := name.NewRepository(pullflags.SourceRegistryRepo); err != nil {
-		return fmt.Errorf("Validate registry address: %w", err)
+	if _, err := name.NewRepository(source); err != nil {
+		return fmt.Errorf("--source %q is not a valid registry address: %w", source, err)
 	}
 
 	// Then we parse it as URL to validate that it contains everything we need
-	registryURL, err := url.ParseRequestURI("docker://" + pullflags.SourceRegistryRepo)
+	registryURL, err := url.ParseRequestURI("docker://" + source)
 	if err != nil {
-		return fmt.Errorf("Validate source registry parameter: %w", err)
+		return fmt.Errorf("Parse --source registry address %q: %w", source, err)
 	}
 
 	if registryURL.Host == "" {

--- a/internal/mirror/cmd/pull/validation_test.go
+++ b/internal/mirror/cmd/pull/validation_test.go
@@ -58,7 +58,19 @@ func TestValidationValidateSourceRegistry(t *testing.T) {
 			name:        "invalid registry format - no path",
 			registry:    "registry.example.com",
 			expectError: true,
-			errorMsg:    "no registry path",
+			errorMsg:    "is missing the repository path",
+		},
+		{
+			name:        "host with port but no path",
+			registry:    "localhost:5000",
+			expectError: true,
+			errorMsg:    `--source "localhost:5000" is missing the repository path: expected format registry-host[:port]/path, e.g. "localhost:5000/deckhouse/ee"`,
+		},
+		{
+			name:        "trailing slash without path",
+			registry:    "registry.example.com/",
+			expectError: true,
+			errorMsg:    "is missing the repository path",
 		},
 		{
 			name:        "invalid registry - malformed",

--- a/internal/mirror/cmd/push/validation.go
+++ b/internal/mirror/cmd/push/validation.go
@@ -215,15 +215,24 @@ func parseAndValidateRegistryURLArg(registryArg string) error {
 		return errors.New("<registry> argument is empty")
 	}
 
+	// Check the "host:port" format of the user-provided repository URL.
+	// It must have a path after the host and port.
+	if _, repoPath, _ := strings.Cut(registry, "/"); repoPath == "" {
+		return fmt.Errorf(
+			"<registry> %q is missing the repository path (pushing to a registry root is not supported): expected format registry-host[:port]/path, e.g. %q",
+			registry, strings.TrimRight(registry, "/")+"/deckhouse",
+		)
+	}
+
 	// We first validate that passed repository reference is correct and can be parsed
 	if _, err := name.NewRepository(registry); err != nil {
-		return fmt.Errorf("Validate registry address: %w", err)
+		return fmt.Errorf("<registry> %q is not a valid registry address: %w", registry, err)
 	}
 
 	// Then we parse it as URL to validate that it contains everything we need
 	registryURL, err := url.ParseRequestURI("docker://" + registry)
 	if err != nil {
-		return fmt.Errorf("Validate registry address: %w", err)
+		return fmt.Errorf("Parse <registry> address %q: %w", registry, err)
 	}
 
 	RegistryHost = registryURL.Host

--- a/internal/mirror/cmd/push/validation_test.go
+++ b/internal/mirror/cmd/push/validation_test.go
@@ -453,6 +453,55 @@ func TestParseAndValidateRegistryURLArg(t *testing.T) {
 			name:        "no repository path",
 			registry:    "registry.example.com",
 			expectError: true,
+			errorMsg:    "is missing the repository path",
+		},
+		{
+			name:        "host with port but no repository path",
+			registry:    "localhost:5000",
+			expectError: true,
+			errorMsg:    `<registry> "localhost:5000" is missing the repository path (pushing to a registry root is not supported): expected format registry-host[:port]/path, e.g. "localhost:5000/deckhouse"`,
+		},
+		{
+			name:        "scheme is stripped before the missing-path check",
+			registry:    "http://localhost:5000",
+			expectError: true,
+			errorMsg:    `e.g. "localhost:5000/deckhouse"`,
+		},
+		{
+			name:        "trailing slash without repository path",
+			registry:    "localhost:5000/",
+			expectError: true,
+			errorMsg:    "is missing the repository path",
+		},
+		{
+			name:        "uppercase repository is a character error, not a missing path",
+			registry:    "localhost:5000/UPPER",
+			expectError: true,
+			errorMsg:    "can only contain",
+		},
+		{
+			name:        "no registry host",
+			registry:    "/deckhouse/ee",
+			expectError: true,
+			errorMsg:    "no registry host",
+		},
+		{
+			name:     "IP with port and path",
+			registry: "192.168.1.1:5000/repo",
+			wantHost: "192.168.1.1:5000",
+			wantPath: "/repo",
+		},
+		{
+			name:     "host without dot or colon stays accepted",
+			registry: "myregistry/repo",
+			wantHost: "myregistry",
+			wantPath: "/repo",
+		},
+		{
+			name:     "double slash before repo stays accepted",
+			registry: "localhost:5000//repo",
+			wantHost: "localhost:5000",
+			wantPath: "//repo",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Pushing to a registry root (e.g. `localhost:5000`) failed with a raw go-containerregistry error about invalid characters. Users read it as "the port is not allowed". Now the CLI says what is actually missing: the repository path.

## Problem

- `d8 mirror push distr/ localhost:5000 --insecure` fails with:
  `Validate registry address: repository can only contain the characters 'abcdefghijklmnopqrstuvwxyz0123456789_-./': localhost:5000`
- The real cause: the address must include a repository path (`localhost:5000/deckhouse`). Pushing to a registry root is not supported.
- The message points at characters, and the only suspicious character in the input is the `:` before the port.
- Root cause: without a `/` in the address, `name.NewRepository` validates the whole `host:port` string as a repository name, where `:` is illegal. The friendlier host and path checks below never run.

## Fix

- Check for a missing repository path before calling `name.NewRepository`.
- Applied to both inputs: `mirror push <registry>` and `mirror pull --source`.
- The new error names the argument, shows the expected format, and builds an example from the user's own input.
- Remaining parse errors now name the argument instead of the generic `Validate registry address:` wrapper.
- Docs: format example added to the mirror README and the `--source` flag help.
- Error-path only: every address that was valid before stays valid (pinned by tests).

## Before / After

**Before:**

<img width="2518" height="226" alt="2026-07-14 AT 13 34@2x" src="https://github.com/user-attachments/assets/f51e4a7e-ba5f-4961-ad76-b7bc00c46ffb" />


**After:**

<img width="2980" height="254" alt="2026-07-14 AT 13 34@2x" src="https://github.com/user-attachments/assets/1cc011ad-6815-4f7c-9aaf-d56394c601e1" />


## Tests

- `TestParseAndValidateRegistryURLArg` (push): new cases for `localhost:5000`, `http://` scheme stripping, trailing slash, and the full new message text.
- Same test: backward-compat pins for `192.168.1.1:5000/repo`, `myregistry/repo`, `localhost:5000//repo` - they stay accepted.
- `TestValidationValidateSourceRegistry` (pull): new cases for `localhost:5000` and trailing slash; the existing "no path" case now asserts the new message.
