### PR TITLE
[deckhouse-cli] Add -o output format flag to module values

### DIFF
--- a/internal/system/cmd/module/cmd/list/list.go
+++ b/internal/system/cmd/module/cmd/list/list.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/edit/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/system/cmd/module/deckhouse"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 )
@@ -31,6 +30,8 @@ var listLong = templates.LongDesc(`
 List enabled Deckhouse Kubernetes Platform modules.
 
 © Flant JSC 2025`)
+
+var outputFormats = []string{"yaml", "json", "text"}
 
 func NewCommand() *cobra.Command {
 	listCmd := &cobra.Command{
@@ -41,12 +42,17 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          listModule,
 	}
-	flags.AddFlags(listCmd.Flags())
+	utilk8s.AddOutputFlag(listCmd, "yaml", outputFormats...)
 
 	return listCmd
 }
 
 func listModule(cmd *cobra.Command, _ []string) error {
+	format, err := utilk8s.GetOutputFormat(cmd, outputFormats...)
+	if err != nil {
+		return err
+	}
+
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
@@ -62,7 +68,7 @@ func listModule(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	err = deckhouse.QueryAPI(config, kubeCl, "list.yaml")
+	err = deckhouse.QueryAPI(config, kubeCl, "list."+format)
 	if err != nil {
 		return fmt.Errorf("Error list modules: %w", err)
 	}

--- a/internal/system/cmd/module/cmd/list/list.go
+++ b/internal/system/cmd/module/cmd/list/list.go
@@ -31,7 +31,9 @@ List enabled Deckhouse Kubernetes Platform modules.
 
 © Flant JSC 2025`)
 
-var outputFormats = []string{"yaml", "json", "text"}
+// The /module/list debug endpoint also matches ".text" in its route,
+// but renders structured payloads as JSON anyway, so text is not offered.
+var outputFormats = []string{"yaml", "json"}
 
 func NewCommand() *cobra.Command {
 	listCmd := &cobra.Command{

--- a/internal/system/cmd/module/cmd/snapshots/snapshots.go
+++ b/internal/system/cmd/module/cmd/snapshots/snapshots.go
@@ -31,6 +31,8 @@ Dump module hooks snapshots.
 
 © Flant JSC 2025`)
 
+var outputFormats = []string{"yaml", "json"}
+
 func NewCommand() *cobra.Command {
 	snapshotsCmd := &cobra.Command{
 		Use:           "snapshots",
@@ -41,12 +43,22 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          snapshotsModule,
 	}
+	utilk8s.AddOutputFlag(snapshotsCmd, "yaml", outputFormats...)
 
 	return snapshotsCmd
 }
 
 func snapshotsModule(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("this command requires exactly 1 argument: module name")
+	}
+
 	moduleName := args[0]
+
+	format, err := utilk8s.GetOutputFormat(cmd, outputFormats...)
+	if err != nil {
+		return err
+	}
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
@@ -63,7 +75,7 @@ func snapshotsModule(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	pathFromOption := fmt.Sprintf("%s/snapshots.yaml", moduleName)
+	pathFromOption := fmt.Sprintf("%s/snapshots.%s", moduleName, format)
 
 	err = deckhouse.QueryAPI(config, kubeCl, pathFromOption)
 	if err != nil {

--- a/internal/system/cmd/module/cmd/values/values.go
+++ b/internal/system/cmd/module/cmd/values/values.go
@@ -31,6 +31,8 @@ Dump module hooks values.
 
 © Flant JSC 2025`)
 
+var outputFormats = []string{"yaml", "json"}
+
 func NewCommand() *cobra.Command {
 	valuesCmd := &cobra.Command{
 		Use:           "values",
@@ -41,6 +43,7 @@ func NewCommand() *cobra.Command {
 		SilenceUsage:  true,
 		RunE:          valuesModule,
 	}
+	utilk8s.AddOutputFlag(valuesCmd, "yaml", outputFormats...)
 
 	return valuesCmd
 }
@@ -51,6 +54,11 @@ func valuesModule(cmd *cobra.Command, args []string) error {
 	}
 
 	moduleName := args[0]
+
+	format, err := utilk8s.GetOutputFormat(cmd, outputFormats...)
+	if err != nil {
+		return err
+	}
 
 	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
 	if err != nil {
@@ -67,7 +75,7 @@ func valuesModule(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to setup Kubernetes client: %w", err)
 	}
 
-	pathFromOption := fmt.Sprintf("%s/values.yaml", moduleName)
+	pathFromOption := fmt.Sprintf("%s/values.%s", moduleName, format)
 
 	err = deckhouse.QueryAPI(config, kubeCl, pathFromOption)
 	if err != nil {

--- a/internal/utilk8s/output.go
+++ b/internal/utilk8s/output.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,21 @@ import (
 func AddOutputFlag(cmd *cobra.Command, defaultFmt string, formats ...string) {
 	cmd.Flags().StringP("output", "o", defaultFmt, "Output format: "+strings.Join(formats, "|"))
 	_ = cmd.RegisterFlagCompletionFunc("output", CompleteOutputFormats(formats...))
+}
+
+// GetOutputFormat reads the "-o/--output" flag declared by AddOutputFlag
+// and validates it against the accepted formats.
+func GetOutputFormat(cmd *cobra.Command, formats ...string) (string, error) {
+	format, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return "", fmt.Errorf("reading output flag: %w", err)
+	}
+
+	if !slices.Contains(formats, format) {
+		return "", fmt.Errorf("unsupported output format %q; use %s", format, strings.Join(formats, "|"))
+	}
+
+	return format, nil
 }
 
 // PrintObject writes an unstructured Kubernetes object to w in the given format.

--- a/internal/utilk8s/output_test.go
+++ b/internal/utilk8s/output_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utilk8s
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOutputFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		formats  []string
+		args     []string
+		expected string
+		wantErr  string
+	}{
+		{
+			name:     "default format when flag is not set",
+			formats:  []string{"yaml", "json"},
+			args:     []string{},
+			expected: "yaml",
+		},
+		{
+			name:     "explicit allowed format",
+			formats:  []string{"yaml", "json"},
+			args:     []string{"-o", "json"},
+			expected: "json",
+		},
+		{
+			name:    "unsupported format",
+			formats: []string{"yaml", "json"},
+			args:    []string{"-o", "xml"},
+			wantErr: `unsupported output format "xml"; use yaml|json`,
+		},
+		{
+			name:    "flag not registered",
+			formats: nil,
+			args:    []string{},
+			wantErr: "reading output flag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			if tt.formats != nil {
+				AddOutputFlag(cmd, tt.formats[0], tt.formats...)
+			}
+			assert.NoError(t, cmd.Flags().Parse(tt.args))
+
+			format, err := GetOutputFormat(cmd, tt.formats...)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, format)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `d8 s module values/list/snapshots` always printed YAML, with no way to ask for JSON.
- This adds `-o/--output` (yaml|json) to all three, closing [#154](https://github.com/deckhouse/deckhouse-cli/issues/154).
- The docs can now suggest `d8 s module values XXX -o json` instead of the long `d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module values XXX -o json`.

## How it works
- These commands run `curl` against the addon-operator debug API inside the deckhouse pod.
- That API picks the response format from the path extension (`values.yaml` vs `values.json`).
- So the flag value maps straight into the request path, no local re-serialization.
- New helper `utilk8s.GetOutputFormat` reads `--output` and validates it against the accepted formats. It pairs with the existing `utilk8s.AddOutputFlag`.

## Before / After
**Before:** `d8 s module values user-authn` only prints YAML.
**After:** `d8 s module values user-authn -o json` prints JSON; no flag keeps the old YAML default.

<img width="1788" height="352" alt="2026-07-15 AT 11 37@2x" src="https://github.com/user-attachments/assets/29f79c98-08b9-462e-8a60-6b7feb82ffec" />

<img width="2130" height="542" alt="2026-07-15 AT 11 36@2x" src="https://github.com/user-attachments/assets/340eb4ce-871a-4a8e-b15d-3334b86417ee" />

## Notes
- `text` is not offered for `module list`. The debug route matches `.text`, but the handler returns a map that the server renders as JSON anyway, so text would promise one format and deliver another.
- Two small fixes came along in the touched files:
  - `module list` no longer registers the stray `--editor` flag it never used.
  - `module snapshots` now requires the module name argument instead of panicking when called without it.

## Tests
- `TestGetOutputFormat` covers the default value, an explicit allowed format, an unsupported format, and a command with no output flag registered.
- Manual run against a live cluster: `values`, `list` and `snapshots` with `-o json` return JSON; without the flag they return the previous YAML; `-o xml` is rejected before any cluster call.

