### PR TITLE
[deckhouse-cli] Update the description of mirror pull flags

### DIFF
--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -351,6 +352,67 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 	}
 
 	return nil
+}
+
+const categoryShellRedirect = "Invalid version constraint (possible shell redirection)"
+
+// DiagnoseConstraintParseError checks whether an "empty constraint" error from
+// modules.ParseVersionConstraint or modules.NewFilter was most likely caused by
+// the shell eating part of the flag value because the user forgot to quote it.
+//
+// When a user types:
+//
+//	d8 mirror pull ... --include-module console@>=1.43.2 ./bundle
+//
+// the shell interprets '>' as output redirection and '=1.43.2' as the target
+// file name, so cobra receives the flag value "console@" — a name with an
+// empty constraint. The resulting "empty constraint" error gives no hint as to what went wrong.
+//
+// This function recognises that pattern by combining two signals:
+//  1. The error message contains "empty constraint".
+//  2. At least one raw flag value ends with '@' (the version separator), which
+//     means the constraint part was empty before parsing even began.
+//
+// flagName is the CLI flag name used in the suggestion text (e.g. "include-module").
+// rawValues are the exact strings cobra stored for that flag.
+//
+// Returns nil when neither signal is present, so callers can fall through to
+// their normal error path without double-wrapping.
+func DiagnoseConstraintParseError(err error, flagName string, rawValues ...string) *diagnostic.HelpfulError {
+	if err == nil {
+		return nil
+	}
+
+	if !strings.Contains(err.Error(), "empty constraint") {
+		return nil
+	}
+
+	looksLikeRedirect := false
+	for _, v := range rawValues {
+		if strings.HasSuffix(strings.TrimSpace(v), "@") {
+			looksLikeRedirect = true
+			break
+		}
+	}
+
+	if !looksLikeRedirect {
+		return nil
+	}
+
+	return &diagnostic.HelpfulError{
+		Category:    categoryShellRedirect,
+		OriginalErr: err,
+		Suggestions: []diagnostic.Suggestion{
+			{
+				Cause: "The shell interpreted '>' as output redirection instead of passing it to d8.\n" +
+					"The constraint part after '@' was never received — perhaps you forgot to quote the flag value?",
+				Solutions: []string{
+					`Wrap the constraint in double quotes: --` + flagName + ` "module-name@>=1.43.2"`,
+					`Example: d8 mirror pull --license='****' --include-module "console@>=1.43.2" ./console`,
+				},
+			},
+		},
+	}
 }
 
 // --- detection functions ---

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -408,7 +408,7 @@ func DiagnoseConstraintParseError(err error, flagName string, rawValues ...strin
 					"The constraint part after '@' was never received — perhaps you forgot to quote the flag value?",
 				Solutions: []string{
 					`Wrap the constraint in double quotes: --` + flagName + ` "module-name@>=1.43.2"`,
-					`Example: d8 mirror pull --license='****' --include-module "console@>=1.43.2" ./console`,
+					`Example: d8 mirror pull --license='****' --include-module console@">=1.43.2" ./console`,
 				},
 			},
 		},

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/errmatch"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
 	"github.com/deckhouse/deckhouse-cli/pkg/diagnostic"
 )
 
@@ -369,7 +370,7 @@ const categoryShellRedirect = "Invalid version constraint (possible shell redire
 // empty constraint. The resulting "empty constraint" error gives no hint as to what went wrong.
 //
 // This function recognises that pattern by combining two signals:
-//  1. The error message contains "empty constraint".
+//  1. The parser rejected the expression with modules.ErrEmptyConstraint.
 //  2. At least one raw flag value ends with '@' (the version separator), which
 //     means the constraint part was empty before parsing even began.
 //
@@ -379,18 +380,16 @@ const categoryShellRedirect = "Invalid version constraint (possible shell redire
 // Returns nil when neither signal is present, so callers can fall through to
 // their normal error path without double-wrapping.
 func DiagnoseConstraintParseError(err error, flagName string, rawValues ...string) *diagnostic.HelpfulError {
-	if err == nil {
-		return nil
-	}
-
-	if !strings.Contains(err.Error(), "empty constraint") {
+	if !errors.Is(err, modules.ErrEmptyConstraint) {
 		return nil
 	}
 
 	looksLikeRedirect := false
+
 	for _, v := range rawValues {
 		if strings.HasSuffix(strings.TrimSpace(v), "@") {
 			looksLikeRedirect = true
+
 			break
 		}
 	}

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -38,20 +38,21 @@ import (
 )
 
 const (
-	categoryEOF           = "Connection terminated unexpectedly (EOF)"
-	categoryTLS           = "TLS/certificate verification failed"
-	categoryAuth          = "Authentication failed"
-	categoryAuth401       = "Authentication failed (HTTP 401 Unauthorized)"
-	categoryAuth403       = "Access denied (HTTP 403 Forbidden)"
-	categoryRateLimit     = "Rate limited by registry (HTTP 429 Too Many Requests)"
-	categoryServerError   = "Registry server error"
-	categoryDNS           = "DNS resolution failed"
-	categoryTimeout       = "Operation timed out"
-	categoryNetwork       = "Network connection failed"
-	categoryDiskFull      = "Disk space exhausted"
-	categoryPermission    = "Permission denied"
-	categoryImageNotFound = "Image not found in registry"
-	categoryRepoNotFound  = "Repository not found in registry"
+	categoryEOF             = "Connection terminated unexpectedly (EOF)"
+	categoryTLS             = "TLS/certificate verification failed"
+	categoryAuth            = "Authentication failed"
+	categoryAuth401         = "Authentication failed (HTTP 401 Unauthorized)"
+	categoryAuth403         = "Access denied (HTTP 403 Forbidden)"
+	categoryRateLimit       = "Rate limited by registry (HTTP 429 Too Many Requests)"
+	categoryServerError     = "Registry server error"
+	categoryDNS             = "DNS resolution failed"
+	categoryTimeout         = "Operation timed out"
+	categoryNetwork         = "Network connection failed"
+	categoryDiskFull        = "Disk space exhausted"
+	categoryPermission      = "Permission denied"
+	categoryImageNotFound   = "Image not found in registry"
+	categoryRepoNotFound    = "Repository not found in registry"
+	categoryEmptyConstraint = "Version constraint is missing after '@'"
 )
 
 // Diagnose analyzes an error and returns a *diagnostic.HelpfulError
@@ -355,60 +356,57 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 	return nil
 }
 
-const categoryShellRedirect = "Invalid version constraint (possible shell redirection)"
-
-// DiagnoseConstraintParseError checks whether an "empty constraint" error from
-// modules.ParseVersionConstraint or modules.NewFilter was most likely caused by
-// the shell eating part of the flag value because the user forgot to quote it.
+// DiagnoseConstraintParseError explains a filter expression that carries the
+// '@' separator with nothing after it, e.g. "console@".
 //
-// When a user types:
+// The usual cause is quoting. An unquoted value is split by the shell before
+// d8 ever sees it:
 //
-//	d8 mirror pull ... --include-module console@>=1.43.2 ./bundle
+//	--include-module console@>=1.43.2
 //
-// the shell interprets '>' as output redirection and '=1.43.2' as the target
-// file name, so cobra receives the flag value "console@" — a name with an
-// empty constraint. The resulting "empty constraint" error gives no hint as to what went wrong.
+// bash keeps the word "console@" and turns ">=1.43.2" into an output
+// redirection into a file named "=1.43.2". A script interpolating a version
+// variable that expanded to nothing lands on the same value, so both causes
+// are offered.
 //
-// This function recognises that pattern by combining two signals:
-//  1. The parser rejected the expression with modules.ErrEmptyConstraint.
-//  2. At least one raw flag value ends with '@' (the version separator), which
-//     means the constraint part was empty before parsing even began.
-//
-// flagName is the CLI flag name used in the suggestion text (e.g. "include-module").
-// rawValues are the exact strings cobra stored for that flag.
-//
-// Returns nil when neither signal is present, so callers can fall through to
-// their normal error path without double-wrapping.
+// flagName names the flag in the suggestion text (e.g. "include-module").
+// rawValues are the exact strings cobra stored for that flag. The first one
+// ending with '@' is the entry the parser rejected; it is reported to the user
+// and its absence keeps the hint away from flags whose values have no
+// "name@constraint" shape.
 func DiagnoseConstraintParseError(err error, flagName string, rawValues ...string) *diagnostic.HelpfulError {
 	if !errors.Is(err, modules.ErrEmptyConstraint) {
 		return nil
 	}
 
-	looksLikeRedirect := false
+	offender := ""
 
 	for _, v := range rawValues {
-		if strings.HasSuffix(strings.TrimSpace(v), "@") {
-			looksLikeRedirect = true
+		if v = strings.TrimSpace(v); strings.HasSuffix(v, "@") {
+			offender = v
 
 			break
 		}
 	}
 
-	if !looksLikeRedirect {
+	if offender == "" {
 		return nil
 	}
 
 	return &diagnostic.HelpfulError{
-		Category:    categoryShellRedirect,
+		Category:    categoryEmptyConstraint,
 		OriginalErr: err,
 		Suggestions: []diagnostic.Suggestion{
 			{
-				Cause: "The shell interpreted '>' as output redirection instead of passing it to d8.\n" +
-					"The constraint part after '@' was never received — perhaps you forgot to quote the flag value?",
+				Cause: fmt.Sprintf("An unquoted >= or <= was eaten by the shell, so --%s only got %q", flagName, offender),
 				Solutions: []string{
-					`Wrap the constraint in double quotes: --` + flagName + ` "module-name@>=1.43.2"`,
-					`Example: d8 mirror pull --license='****' --include-module console@">=1.43.2" ./console`,
+					fmt.Sprintf(`Quote the whole value: --%s "%s>=1.43.2"`, flagName, offender),
+					fmt.Sprintf(`Example: d8 mirror pull --license='****' --%s "console@>=1.43.2" ./console`, flagName),
 				},
+			},
+			{
+				Cause:     "The version came from a variable that expanded to nothing",
+				Solutions: []string{fmt.Sprintf("Check what the calling script puts after '@' in --%s", flagName)},
 			},
 		},
 	}

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -399,11 +399,8 @@ func DiagnoseConstraintParseError(err error, flagName string, rawValues ...strin
 		OriginalErr: err,
 		Suggestions: []diagnostic.Suggestion{
 			{
-				Cause: fmt.Sprintf("An unquoted >= or <= was eaten by the shell, so --%s only got %q", flagName, offender),
-				Solutions: []string{
-					fmt.Sprintf(`Quote the whole value: --%s "%s>=1.43.2"`, flagName, offender),
-					fmt.Sprintf(`Example: d8 mirror pull --license='****' --%s "console@>=1.43.2" ./console`, flagName),
-				},
+				Cause:     fmt.Sprintf("An unquoted >= or <= was eaten by the shell, so --%s only got %q", flagName, offender),
+				Solutions: []string{fmt.Sprintf(`Quote the whole value: --%s "%s>=1.43.2"`, flagName, offender)},
 			},
 			{
 				Cause:     "The version came from a variable that expanded to nothing",
@@ -448,26 +445,23 @@ func DiagnosePlatformConstraintParseError(err error, rawValue string) *diagnosti
 
 // --- detection functions ---
 
-// looksLikePath reports whether a value is shaped like a filesystem path rather
-// than a version constraint. A tilde constraint (~1.65.0) is not a home-relative
-// path, so only "~/" counts.
+// looksLikePath reports whether a value is a filesystem path rather than a
+// version constraint. A separator settles it: no constraint contains one.
+// A bare name like "bundle" is only taken as a path when it names an existing
+// directory, which the bundle argument always does.
 func looksLikePath(v string) bool {
 	v = strings.TrimSpace(v)
 	if v == "" {
 		return false
 	}
 
-	if filepath.IsAbs(v) {
+	if filepath.IsAbs(v) || strings.ContainsAny(v, `/\`) {
 		return true
 	}
 
-	for _, prefix := range []string{"./", "../", `.\`, `..\`, "~/"} {
-		if strings.HasPrefix(v, prefix) {
-			return true
-		}
-	}
+	info, err := os.Stat(v)
 
-	return false
+	return err == nil && info.IsDir()
 }
 
 func isEOF(err error) bool {

--- a/internal/mirror/cmd/pull/errdetect/diagnose.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -53,6 +54,7 @@ const (
 	categoryImageNotFound   = "Image not found in registry"
 	categoryRepoNotFound    = "Repository not found in registry"
 	categoryEmptyConstraint = "Version constraint is missing after '@'"
+	categoryPathConstraint  = "Version constraint is a path, not a version"
 )
 
 // Diagnose analyzes an error and returns a *diagnostic.HelpfulError
@@ -371,9 +373,8 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 //
 // flagName names the flag in the suggestion text (e.g. "include-module").
 // rawValues are the exact strings cobra stored for that flag. The first one
-// ending with '@' is the entry the parser rejected; it is reported to the user
-// and its absence keeps the hint away from flags whose values have no
-// "name@constraint" shape.
+// ending with '@' is the entry the parser rejected and is quoted back to the
+// user; without it the caller falls through to its own error.
 func DiagnoseConstraintParseError(err error, flagName string, rawValues ...string) *diagnostic.HelpfulError {
 	if !errors.Is(err, modules.ErrEmptyConstraint) {
 		return nil
@@ -412,7 +413,62 @@ func DiagnoseConstraintParseError(err error, flagName string, rawValues ...strin
 	}
 }
 
+// DiagnosePlatformConstraintParseError explains a --include-platform value that
+// turned out to be a filesystem path.
+//
+// The flag takes a bare constraint with no "name@" prefix, so an unquoted value
+// leaves nothing behind:
+//
+//	--include-platform >=1.64 ./bundle
+//
+// bash redirects ">=1.64" into a file named "=1.64" and the flag swallows the
+// bundle path that followed it, so the constraint parser is handed a directory.
+//
+// Returns nil for a value that is not path-shaped, so a plain typo in the
+// constraint keeps the parser's own message.
+func DiagnosePlatformConstraintParseError(err error, rawValue string) *diagnostic.HelpfulError {
+	if err == nil || !looksLikePath(rawValue) {
+		return nil
+	}
+
+	return &diagnostic.HelpfulError{
+		Category:    categoryPathConstraint,
+		OriginalErr: err,
+		Suggestions: []diagnostic.Suggestion{
+			{
+				Cause: fmt.Sprintf("An unquoted >= or <= was eaten by the shell, so --include-platform swallowed the bundle path %q", strings.TrimSpace(rawValue)),
+				Solutions: []string{
+					`Quote the constraint: --include-platform ">=1.64"`,
+					`Example: d8 mirror pull --license='****' --include-platform ">=1.64 <=1.68" ./bundle`,
+				},
+			},
+		},
+	}
+}
+
 // --- detection functions ---
+
+// looksLikePath reports whether a value is shaped like a filesystem path rather
+// than a version constraint. A tilde constraint (~1.65.0) is not a home-relative
+// path, so only "~/" counts.
+func looksLikePath(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+
+	if filepath.IsAbs(v) {
+		return true
+	}
+
+	for _, prefix := range []string{"./", "../", `.\`, `..\`, "~/"} {
+		if strings.HasPrefix(v, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
 
 func isEOF(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)

--- a/internal/mirror/cmd/pull/errdetect/diagnose_test.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose_test.go
@@ -120,3 +120,66 @@ func TestDiagnose_Unwrap(t *testing.T) {
 	require.True(t, errors.As(diag, &helpErr))
 	assert.True(t, errors.Is(diag, io.EOF))
 }
+
+// --- DiagnoseConstraintParseError tests ---
+
+func TestDiagnoseConstraintParseError_NilError(t *testing.T) {
+	assert.Nil(t, DiagnoseConstraintParseError(nil, "include-module", "console@"))
+}
+
+func TestDiagnoseConstraintParseError_NoEmptyConstraintInMessage(t *testing.T) {
+	// Error message unrelated to constraints — should not be diagnosed.
+	err := errors.New("something completely different")
+	assert.Nil(t, DiagnoseConstraintParseError(err, "include-module", "console@"))
+}
+
+func TestDiagnoseConstraintParseError_EmptyConstraintButNoAtSuffix(t *testing.T) {
+	// "empty constraint" in message but none of the raw values ends with '@'.
+	// Could be a genuine parse error from a quoted but empty value "console@",
+	// not a shell redirect. Return nil so the caller uses its own message.
+	err := errors.New("parse constraint: empty constraint")
+	assert.Nil(t, DiagnoseConstraintParseError(err, "include-module", "console"))
+}
+
+func TestDiagnoseConstraintParseError_ShellRedirectDetected(t *testing.T) {
+	// shell-redirect scenario:
+	//   --include-module console@>=1.43.2  (no quotes)
+	// Shell hands cobra "console@" and redirects "=1.43.2" to a file.
+	err := errors.New("parse constraint for 'console': empty constraint")
+	diag := DiagnoseConstraintParseError(err, "include-module", "console@")
+	require.NotNil(t, diag, "should produce a diagnostic when value ends with '@' and error contains 'empty constraint'")
+	assert.Equal(t, categoryShellRedirect, diag.Category)
+	assert.True(t, errors.Is(diag, err), "original error must be accessible via errors.Is")
+	require.NotEmpty(t, diag.Suggestions)
+	solutions := allSolutions(diag)
+	assert.Contains(t, solutions, "include-module", "solution should name the affected flag")
+	assert.Contains(t, solutions, `"module-name@>=1.43.2"`, "solution should show a quoted example")
+}
+
+func TestDiagnoseConstraintParseError_MultipleValuesOneTriggersDetect(t *testing.T) {
+	// Several --include-module entries; only one ends with '@'.
+	err := errors.New("parse constraint: empty constraint")
+	diag := DiagnoseConstraintParseError(err, "include-module", "cert-manager@^1.0.0", "console@", "ingress-nginx@~2.0.0")
+	require.NotNil(t, diag)
+	assert.Equal(t, categoryShellRedirect, diag.Category)
+}
+
+func TestDiagnoseConstraintParseError_WhitespaceTrimmedAtSuffix(t *testing.T) {
+	// Value with trailing space after '@' should still be detected.
+	err := errors.New("empty constraint")
+	diag := DiagnoseConstraintParseError(err, "include-platform", ">=1.64 ")
+	assert.Nil(t, diag, "a plain value without '@' should not trigger the shell-redirect hint")
+
+	diag = DiagnoseConstraintParseError(err, "include-module", "console@ ")
+	require.NotNil(t, diag, "trailing whitespace after '@' should still be detected after TrimSpace")
+}
+
+func TestDiagnoseConstraintParseError_FlagNameAppearsInSolution(t *testing.T) {
+	err := errors.New("empty constraint")
+	for _, flagName := range []string{"include-module", "include-package", "include-platform"} {
+		diag := DiagnoseConstraintParseError(err, flagName, "foo@")
+		require.NotNil(t, diag)
+		solutions := allSolutions(diag)
+		assert.Contains(t, solutions, flagName, "solution text should reference the flag that was passed")
+	}
+}

--- a/internal/mirror/cmd/pull/errdetect/diagnose_test.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose_test.go
@@ -195,3 +195,47 @@ func TestDiagnoseConstraintParseError_FlagNameAppearsInSolution(t *testing.T) {
 		assert.NotContains(t, solutions, "--include-module", "no solution may hardcode a different flag")
 	}
 }
+
+// --- DiagnosePlatformConstraintParseError tests ---
+
+func TestDiagnosePlatformConstraintParseError_NilError(t *testing.T) {
+	assert.Nil(t, DiagnosePlatformConstraintParseError(nil, "./bundle"))
+}
+
+func TestDiagnosePlatformConstraintParseError_ConstraintTypoIsNotDiagnosed(t *testing.T) {
+	// A malformed but path-less value is the user's own typo.
+	for _, value := range []string{"1.64.", "^^1.0", ">=1.64 <=x"} {
+		_, err := modules.ParseVersionConstraint(value)
+		require.Error(t, err, "value %q should not parse", value)
+		assert.Nil(t, DiagnosePlatformConstraintParseError(err, value), "value %q is not a path", value)
+	}
+}
+
+func TestLooksLikePath(t *testing.T) {
+	for _, v := range []string{"./bundle", "../bundle", "/tmp/bundle", "~/bundle", `.\bundle`, `..\bundle`, " ./bundle "} {
+		assert.True(t, looksLikePath(v), "%q is a path", v)
+	}
+
+	// Constraint operators only. The tilde constraint is the trap: ~1.65.0 is
+	// semver shorthand, not a home-relative path.
+	for _, v := range []string{"~1.65.0", "^1.65.0", ">=1.64 <=1.68", "=v1.65.3", "1.65.0", "", "  "} {
+		assert.False(t, looksLikePath(v), "%q is a constraint", v)
+	}
+}
+
+func TestDiagnosePlatformConstraintParseError_BundlePathSwallowed(t *testing.T) {
+	// shell-redirect scenario:
+	//   --include-platform >=1.64 ./bundle  (no quotes)
+	// Shell redirects ">=1.64" into a file, so the flag takes the bundle path.
+	for _, path := range []string{"./bundle", "../bundle", "/tmp/bundle", "~/bundle"} {
+		_, err := modules.ParseVersionConstraint(path)
+		require.Error(t, err)
+
+		diag := DiagnosePlatformConstraintParseError(err, path)
+		require.NotNil(t, diag, "path-shaped value %q should be diagnosed", path)
+		assert.Equal(t, categoryPathConstraint, diag.Category)
+		assert.True(t, errors.Is(diag, err), "original error must be accessible via errors.Is")
+		assert.Contains(t, diag.Suggestions[0].Cause, path, "cause should quote the value that landed in the flag")
+		assert.Contains(t, allSolutions(diag), "--include-platform")
+	}
+}

--- a/internal/mirror/cmd/pull/errdetect/diagnose_test.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
 	"github.com/deckhouse/deckhouse-cli/pkg/diagnostic"
 )
 
@@ -127,30 +128,39 @@ func TestDiagnoseConstraintParseError_NilError(t *testing.T) {
 	assert.Nil(t, DiagnoseConstraintParseError(nil, "include-module", "console@"))
 }
 
-func TestDiagnoseConstraintParseError_NoEmptyConstraintInMessage(t *testing.T) {
-	// Error message unrelated to constraints — should not be diagnosed.
+func TestDiagnoseConstraintParseError_UnrelatedError(t *testing.T) {
 	err := errors.New("something completely different")
 	assert.Nil(t, DiagnoseConstraintParseError(err, "include-module", "console@"))
 }
 
-func TestDiagnoseConstraintParseError_EmptyConstraintButNoAtSuffix(t *testing.T) {
-	// "empty constraint" in message but none of the raw values ends with '@'.
-	// Could be a genuine parse error from a quoted but empty value "console@",
-	// not a shell redirect. Return nil so the caller uses its own message.
-	err := errors.New("parse constraint: empty constraint")
-	assert.Nil(t, DiagnoseConstraintParseError(err, "include-module", "console"))
+func TestDiagnoseConstraintParseError_MalformedConstraintIsNotDiagnosed(t *testing.T) {
+	// A constraint that is present but invalid is the user's own typo.
+	_, err := modules.NewFilter([]string{"console@^^1.0"}, modules.FilterTypeWhitelist)
+	require.Error(t, err)
+	assert.Nil(t, DiagnoseConstraintParseError(err, "include-module", "console@^^1.0"))
 }
 
-func TestDiagnoseConstraintParseError_ShellRedirectDetected(t *testing.T) {
+func TestDiagnoseConstraintParseError_EmptyConstraintButNoAtSuffix(t *testing.T) {
+	// No raw value ends with '@', so the constraint was not cut off by the
+	// shell. Return nil and let the caller use its own message.
+	assert.Nil(t, DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "console"))
+}
+
+func TestDiagnoseConstraintParseError_RealFilterError(t *testing.T) {
 	// shell-redirect scenario:
 	//   --include-module console@>=1.43.2  (no quotes)
 	// Shell hands cobra "console@" and redirects "=1.43.2" to a file.
-	err := errors.New("parse constraint for 'console': empty constraint")
+	// The error must be recognised as produced by modules.NewFilter, not as a
+	// string this package spells out for itself.
+	_, err := modules.NewFilter([]string{"console@"}, modules.FilterTypeWhitelist)
+	require.Error(t, err)
+
 	diag := DiagnoseConstraintParseError(err, "include-module", "console@")
-	require.NotNil(t, diag, "should produce a diagnostic when value ends with '@' and error contains 'empty constraint'")
+	require.NotNil(t, diag)
 	assert.Equal(t, categoryShellRedirect, diag.Category)
-	assert.True(t, errors.Is(diag, err), "original error must be accessible via errors.Is")
+	assert.True(t, errors.Is(diag, modules.ErrEmptyConstraint), "original error must stay reachable via errors.Is")
 	require.NotEmpty(t, diag.Suggestions)
+
 	solutions := allSolutions(diag)
 	assert.Contains(t, solutions, "include-module", "solution should name the affected flag")
 	assert.Contains(t, solutions, `"module-name@>=1.43.2"`, "solution should show a quoted example")
@@ -158,27 +168,21 @@ func TestDiagnoseConstraintParseError_ShellRedirectDetected(t *testing.T) {
 
 func TestDiagnoseConstraintParseError_MultipleValuesOneTriggersDetect(t *testing.T) {
 	// Several --include-module entries; only one ends with '@'.
-	err := errors.New("parse constraint: empty constraint")
-	diag := DiagnoseConstraintParseError(err, "include-module", "cert-manager@^1.0.0", "console@", "ingress-nginx@~2.0.0")
+	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "cert-manager@^1.0.0", "console@", "ingress-nginx@~2.0.0")
 	require.NotNil(t, diag)
 	assert.Equal(t, categoryShellRedirect, diag.Category)
 }
 
 func TestDiagnoseConstraintParseError_WhitespaceTrimmedAtSuffix(t *testing.T) {
-	// Value with trailing space after '@' should still be detected.
-	err := errors.New("empty constraint")
-	diag := DiagnoseConstraintParseError(err, "include-platform", ">=1.64 ")
-	assert.Nil(t, diag, "a plain value without '@' should not trigger the shell-redirect hint")
-
-	diag = DiagnoseConstraintParseError(err, "include-module", "console@ ")
+	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "console@ ")
 	require.NotNil(t, diag, "trailing whitespace after '@' should still be detected after TrimSpace")
 }
 
 func TestDiagnoseConstraintParseError_FlagNameAppearsInSolution(t *testing.T) {
-	err := errors.New("empty constraint")
 	for _, flagName := range []string{"include-module", "include-package", "include-platform"} {
-		diag := DiagnoseConstraintParseError(err, flagName, "foo@")
+		diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, flagName, "foo@")
 		require.NotNil(t, diag)
+
 		solutions := allSolutions(diag)
 		assert.Contains(t, solutions, flagName, "solution text should reference the flag that was passed")
 	}

--- a/internal/mirror/cmd/pull/errdetect/diagnose_test.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose_test.go
@@ -178,6 +178,7 @@ func TestDiagnoseConstraintParseError_NamesTheBrokenEntry(t *testing.T) {
 func TestDiagnoseConstraintParseError_CausesAreSingleLine(t *testing.T) {
 	// Format() indents only the first line of a cause.
 	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "console@")
+	require.NotNil(t, diag)
 	require.Len(t, diag.Suggestions, 2, "both the shell and the empty-variable cause are offered")
 
 	for _, s := range diag.Suggestions {
@@ -212,15 +213,21 @@ func TestDiagnosePlatformConstraintParseError_ConstraintTypoIsNotDiagnosed(t *te
 }
 
 func TestLooksLikePath(t *testing.T) {
-	for _, v := range []string{"./bundle", "../bundle", "/tmp/bundle", "~/bundle", `.\bundle`, `..\bundle`, " ./bundle "} {
+	for _, v := range []string{"./bundle", "../bundle", "/tmp/bundle", "~/bundle", `.\bundle`, "bundles/d8", "out/", " ./bundle "} {
 		assert.True(t, looksLikePath(v), "%q is a path", v)
 	}
 
 	// Constraint operators only. The tilde constraint is the trap: ~1.65.0 is
 	// semver shorthand, not a home-relative path.
-	for _, v := range []string{"~1.65.0", "^1.65.0", ">=1.64 <=1.68", "=v1.65.3", "1.65.0", "", "  "} {
+	for _, v := range []string{"~1.65.0", "^1.65.0", ">=1.64 <=1.68", "=v1.65.3", "1.65.0", "", "  ", "d8-bundle"} {
 		assert.False(t, looksLikePath(v), "%q is a constraint", v)
 	}
+
+	// A separator-free name is a path only when it exists as a directory,
+	// which the swallowed bundle argument always does.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.Mkdir("d8-bundle", 0o755))
+	assert.True(t, looksLikePath("d8-bundle"), "an existing directory is a path")
 }
 
 func TestDiagnosePlatformConstraintParseError_BundlePathSwallowed(t *testing.T) {

--- a/internal/mirror/cmd/pull/errdetect/diagnose_test.go
+++ b/internal/mirror/cmd/pull/errdetect/diagnose_test.go
@@ -157,33 +157,41 @@ func TestDiagnoseConstraintParseError_RealFilterError(t *testing.T) {
 
 	diag := DiagnoseConstraintParseError(err, "include-module", "console@")
 	require.NotNil(t, diag)
-	assert.Equal(t, categoryShellRedirect, diag.Category)
+	assert.Equal(t, categoryEmptyConstraint, diag.Category)
 	assert.True(t, errors.Is(diag, modules.ErrEmptyConstraint), "original error must stay reachable via errors.Is")
 	require.NotEmpty(t, diag.Suggestions)
+	assert.Contains(t, diag.Suggestions[0].Cause, `"console@"`, "cause should quote the value the parser rejected")
 
 	solutions := allSolutions(diag)
-	assert.Contains(t, solutions, "include-module", "solution should name the affected flag")
-	assert.Contains(t, solutions, `"module-name@>=1.43.2"`, "solution should show a quoted example")
+	assert.Contains(t, solutions, "--include-module", "solution should name the affected flag")
+	assert.Contains(t, solutions, `"console@>=1.43.2"`, "quotes go around the whole value, not just the constraint")
 }
 
-func TestDiagnoseConstraintParseError_MultipleValuesOneTriggersDetect(t *testing.T) {
+func TestDiagnoseConstraintParseError_NamesTheBrokenEntry(t *testing.T) {
 	// Several --include-module entries; only one ends with '@'.
-	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "cert-manager@^1.0.0", "console@", "ingress-nginx@~2.0.0")
+	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "cert-manager@^1.0.0", "console@ ", "ingress-nginx@~2.0.0")
 	require.NotNil(t, diag)
-	assert.Equal(t, categoryShellRedirect, diag.Category)
+	assert.Equal(t, categoryEmptyConstraint, diag.Category)
+	assert.Contains(t, diag.Suggestions[0].Cause, `"console@"`, "cause should name the broken entry, trimmed, not the intact ones")
 }
 
-func TestDiagnoseConstraintParseError_WhitespaceTrimmedAtSuffix(t *testing.T) {
-	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "console@ ")
-	require.NotNil(t, diag, "trailing whitespace after '@' should still be detected after TrimSpace")
+func TestDiagnoseConstraintParseError_CausesAreSingleLine(t *testing.T) {
+	// Format() indents only the first line of a cause.
+	diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, "include-module", "console@")
+	require.Len(t, diag.Suggestions, 2, "both the shell and the empty-variable cause are offered")
+
+	for _, s := range diag.Suggestions {
+		assert.NotContains(t, s.Cause, "\n", "cause must stay on one line")
+	}
 }
 
 func TestDiagnoseConstraintParseError_FlagNameAppearsInSolution(t *testing.T) {
-	for _, flagName := range []string{"include-module", "include-package", "include-platform"} {
+	for _, flagName := range []string{"exclude-module", "include-package", "exclude-package"} {
 		diag := DiagnoseConstraintParseError(modules.ErrEmptyConstraint, flagName, "foo@")
 		require.NotNil(t, diag)
 
 		solutions := allSolutions(diag)
-		assert.Contains(t, solutions, flagName, "solution text should reference the flag that was passed")
+		assert.Contains(t, solutions, "--"+flagName, "solution text should reference the flag that was passed")
+		assert.NotContains(t, solutions, "--include-module", "no solution may hardcode a different flag")
 	}
 }

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -148,7 +148,7 @@ Given platform releases v1.63.x .. v1.71.x:
   "^1.65.0"         latest patch per minor from v1.65.x up
   "1.65.0"          same as ^1.65.0 here: platform majors are always >= 1
   "=v1.65.3"        only v1.65.3, published to every release channel
-  "=v1.65.3+stable" only v1.65.3, published to stable`,
+  "=v1.65.3+stable" only v1.65.3; the +channel suffix is accepted but changes nothing here`,
 	)
 	flagSet.StringVar(
 		&DeckhouseTag,
@@ -182,7 +182,7 @@ Given v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1:
   "module-name@>=1.3.0 <=1.4.0"   v1.3.0, v1.3.3, v1.4.0
   module-name@=v1.3.0             only v1.3.0, published to every release channel
   module-name@=v1.3.0+stable      only v1.3.0, published to stable
-  module-name@=bobV1              only the bobV1 tag
+  module-name@=bobV1              only the bobV1 tag, published to every release channel
 
 For a 0.x module the bare form spans the whole 0.x line (0.4.0 means >=0.4.0 <1.0.0) while the caret locks the minor (^0.4.0 means >=0.4.0 <0.5.0).`,
 	)

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -183,7 +183,7 @@ Use the exact-tag form (=) when you need a specific older patch unconditionally.
 
 A bare version with no operator (module-name@1.3.0) means "this version or newer within the same major line" and keeps the latest patch per minor. It expands to >=X.Y.Z <(major+1).0.0, treating major 0 like any other major: module-name@0.4.0 spans the whole 0.x line (>=0.4.0 <1.0.0), NOT just the 0.4 minor as a caret (^0.4.0 = >=0.4.0 <0.5.0) would. Prefer this bare form for step-by-step upgrades — it captures every intermediate minor and needs no shell quoting.
 
-Shell note: >= and <= contain the redirection metacharacters > and <, so an unquoted module-name@>=1.3.0 is mangled by bash/zsh (it strips the operator and redirects into a file named "=1.3.0", leaving the module with an empty version). Quote the whole value when you use these operators: --include-module 'module-name@>=1.3.0'. The bare-version form above avoids this entirely.
+Shell note: >= and <= contain the redirection metacharacters > and <, so an unquoted module-name@>=1.3.0 is mangled by bash/zsh (it strips the operator and redirects into a file named "=1.3.0", leaving the module with an empty version). Quote the whole value when you use these operators: --include-module module-name@">=1.3.0". The bare-version form above avoids this entirely.
 
 Example:
 Available versions for <module-name>: v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1
@@ -196,9 +196,9 @@ module-name@~1.3.0 → semver ~ constraint (>=1.3.0 <1.4.0): keep latest patch p
 
 module-name@^1.3.0 → semver ^ constraint (>=1.3.0 <2.0.0): keep latest patch per minor — includes v1.3.3, v1.4.1. For a 0.x version the caret locks the minor (^0.4.0 = >=0.4.0 <0.5.0), so use the bare form instead when you want the whole 0.x line.
 
-module-name@>=1.3.0 → range constraint with explicit >= anchor (quote in shell): keep latest patch per minor AND the named anchor v1.3.0 — includes v1.3.0 (anchor), v1.3.3 (1.3.x latest), v1.4.1 (1.4.x latest).
+module-name@">=1.3.0" → range constraint with explicit >= anchor (quote in shell): keep latest patch per minor AND the named anchor v1.3.0 — includes v1.3.0 (anchor), v1.3.3 (1.3.x latest), v1.4.1 (1.4.x latest).
 
-module-name@>=1.3.0 <=1.4.0 → both anchors honoured (quote in shell): includes v1.3.0, v1.3.3, v1.4.0; v1.4.1 is excluded by the upper bound.
+module-name@">=1.3.0 <=1.4.0" → both anchors honoured (quote in shell): includes v1.3.0, v1.3.3, v1.4.0; v1.4.1 is excluded by the upper bound.
 
 module-name@=v1.3.0 → exact tag match: include only v1.3.0 and publish it to all release channels (alpha, beta, early-access, stable, rock-solid).
 
@@ -229,7 +229,7 @@ module-name@0.4.0 → bare version, expands to >=0.4.0 <1.0.0: keep latest patch
 		nil,
 		`Whitelist specific packages for downloading. Use one flag per each package. Disables blacklisting by --exclude-package.
 
-Packages are mirrored exactly like modules (same name@version constraint dialect), but live under the packages/ registry segment with their release metadata under packages/<name>/version.`,
+Packages are mirrored exactly like modules (same name@version constraint dialect), but live under the packages/ registry segment with their release metadata under packages/<name>/version. Note that most version ranges must be put in quotes so that your shell will treat them as a single argument.`,
 	)
 	flagSet.StringArrayVar(
 		&PackagesBlacklist,

--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -135,26 +135,20 @@ func AddFlags(flagSet *pflag.FlagSet) {
 		&PlatformConstraintString,
 		"include-platform",
 		"",
-		`Select platform releases to download by a semver constraint expression, using the same dialect as --include-module's version part.
+		`Select platform releases to download by a semver constraint. Same dialect as the version part of --include-module.
 Conflicts with --since-version and --deckhouse-tag.
 
-Semver constraints (caret, tilde, range) keep only the highest patch in each (major, minor) series, mirroring the release-discovery rules used for full pulls.
-Versions explicitly named with an inclusive boundary operator (>= or <=) are always preserved — that boundary is part of the user's request and must round-trip even when a newer patch exists in the same minor.
-Use the exact-tag form (=) when you need to pin a specific tag, optionally propagating it to a release channel via the +channel suffix.
+Always quote the value: > and < are shell redirections.
 
-Examples (available platform versions: v1.63.x, v1.64.x, v1.65.x, v1.66.x, v1.67.x, v1.68.x, v1.69.x, v1.70.x, v1.71.x):
+A constraint keeps the latest patch in each minor it covers. Versions named with >= or <= are kept as well. An exact tag (=) pins one release and propagates it to the release channels, just like --deckhouse-tag.
 
---include-platform ">=1.64 <=1.68" → bounded range: latest patch per minor in v1.64..v1.68, anchors v1.64.0 and v1.68.0 always preserved if present in the registry.
-
---include-platform "~1.65.0" → semver ~ constraint (>=1.65.0 <1.66.0): latest v1.65.x patch only.
-
---include-platform "^1.65.0" → semver ^ constraint (>=1.65.0 <2.0.0): latest patch per minor starting at v1.65.x.
-
---include-platform "1.65.0" → bare version, expands to >=1.65.0 <2.0.0 (same major line): keep latest patch per minor starting at v1.65.x. Same result as ^1.65.0 here because platform is always major >= 1; shorthand kept for parity with --include-module.
-
---include-platform "=v1.65.3" → exact-tag pin: only v1.65.3 is pulled and propagated to all default release channels, just like --deckhouse-tag.
-
---include-platform "=v1.65.3+stable" → exact-tag pin with channel suffix: only v1.65.3 is pulled (channel propagation matches --deckhouse-tag).`,
+Given platform releases v1.63.x .. v1.71.x:
+  ">=1.64 <=1.68"   latest patch per minor in v1.64..v1.68, plus v1.64.0 and v1.68.0
+  "~1.65.0"         latest v1.65.x patch
+  "^1.65.0"         latest patch per minor from v1.65.x up
+  "1.65.0"          same as ^1.65.0 here: platform majors are always >= 1
+  "=v1.65.3"        only v1.65.3, published to every release channel
+  "=v1.65.3+stable" only v1.65.3, published to stable`,
 	)
 	flagSet.StringVar(
 		&DeckhouseTag,
@@ -173,49 +167,31 @@ Examples (available platform versions: v1.63.x, v1.64.x, v1.65.x, v1.66.x, v1.67
 		"include-module",
 		"i",
 		nil,
-		`Whitelist specific modules for downloading. Use one flag per each module. Disables blacklisting by --exclude-module."
+		`Whitelist specific modules for downloading. Format is "module-name[@constraint]". Use one flag per each module. Disables blacklisting by --exclude-module.
 
-Without a version part (module-name), only the versions the release channels currently point at are pulled - the same set as a default pull with no filters.
+Quote the whole value when the constraint uses >= or <=: --include-module "module-name@>=1.3.0". Unquoted, the shell takes > as a redirection and d8 receives a module with no version.
 
-Semver constraints (caret, tilde, range) keep only the highest patch in each (major, minor) series, mirroring how platform releases are discovered.
-Versions explicitly named with an inclusive boundary operator (>= or <=) are always preserved — that boundary is part of the user's request and must round-trip even when a newer patch exists in the same minor.
-Use the exact-tag form (=) when you need a specific older patch unconditionally.
+A constraint keeps the latest patch in each minor it covers, plus whatever the release channels point at. Versions named with >= or <= are kept as well. An exact tag (=) pins one tag and publishes it to the release channels.
 
-A bare version with no operator (module-name@1.3.0) means "this version or newer within the same major line" and keeps the latest patch per minor. It expands to >=X.Y.Z <(major+1).0.0, treating major 0 like any other major: module-name@0.4.0 spans the whole 0.x line (>=0.4.0 <1.0.0), NOT just the 0.4 minor as a caret (^0.4.0 = >=0.4.0 <0.5.0) would. Prefer this bare form for step-by-step upgrades — it captures every intermediate minor and needs no shell quoting.
+Given v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1:
+  module-name                     only what the release channels point at, like a pull with no filters
+  module-name@1.3.0               >=1.3.0 <2.0.0, same major line: v1.3.3, v1.4.1
+  module-name@~1.3.0              >=1.3.0 <1.4.0: v1.3.3
+  module-name@^1.3.0              >=1.3.0 <2.0.0: v1.3.3, v1.4.1
+  "module-name@>=1.3.0"           the same, plus the named v1.3.0
+  "module-name@>=1.3.0 <=1.4.0"   v1.3.0, v1.3.3, v1.4.0
+  module-name@=v1.3.0             only v1.3.0, published to every release channel
+  module-name@=v1.3.0+stable      only v1.3.0, published to stable
+  module-name@=bobV1              only the bobV1 tag
 
-Shell note: >= and <= contain the redirection metacharacters > and <, so an unquoted module-name@>=1.3.0 is mangled by bash/zsh (it strips the operator and redirects into a file named "=1.3.0", leaving the module with an empty version). Quote the whole value when you use these operators: --include-module module-name@">=1.3.0". The bare-version form above avoids this entirely.
-
-Example:
-Available versions for <module-name>: v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1
-
-module-name → no version part: pull only the versions the release channels currently point at (same as a default pull).
-
-module-name@1.3.0 → bare version, expands to >=1.3.0 <2.0.0 (same major line): keep latest patch per minor — includes v1.3.3 (1.3.x) and v1.4.1 (1.4.x). Versions currently pinned by release channels are pulled in addition.
-
-module-name@~1.3.0 → semver ~ constraint (>=1.3.0 <1.4.0): keep latest patch per minor in range — includes v1.3.3. Versions currently pinned by release channels are pulled in addition.
-
-module-name@^1.3.0 → semver ^ constraint (>=1.3.0 <2.0.0): keep latest patch per minor — includes v1.3.3, v1.4.1. For a 0.x version the caret locks the minor (^0.4.0 = >=0.4.0 <0.5.0), so use the bare form instead when you want the whole 0.x line.
-
-module-name@">=1.3.0" → range constraint with explicit >= anchor (quote in shell): keep latest patch per minor AND the named anchor v1.3.0 — includes v1.3.0 (anchor), v1.3.3 (1.3.x latest), v1.4.1 (1.4.x latest).
-
-module-name@">=1.3.0 <=1.4.0" → both anchors honoured (quote in shell): includes v1.3.0, v1.3.3, v1.4.0; v1.4.1 is excluded by the upper bound.
-
-module-name@=v1.3.0 → exact tag match: include only v1.3.0 and publish it to all release channels (alpha, beta, early-access, stable, rock-solid).
-
-module-name@=bobV1 → exact tag match: include only bobV1 and publish it to all release channels (alpha, beta, early-access, stable, rock-solid).
-
-module-name@=v1.3.0+stable → exact tag match: include only v1.3.0 and publish it to stable channel
-
-0.x example — available versions for <module-name>: v0.4.2, v0.4.4, v0.5.3, v0.6.1, v0.7.2
-module-name@0.4.0 → bare version, expands to >=0.4.0 <1.0.0: keep latest patch per minor across the whole 0.x line — includes v0.4.4, v0.5.3, v0.6.1, v0.7.2.
-		`,
+For a 0.x module the bare form spans the whole 0.x line (0.4.0 means >=0.4.0 <1.0.0) while the caret locks the minor (^0.4.0 means >=0.4.0 <0.5.0).`,
 	)
 	flagSet.StringArrayVarP(
 		&ModulesBlacklist,
 		"exclude-module",
 		"e",
 		nil,
-		`Blacklist specific modules from downloading. Format is "module-name[@version]". Use one flag per each module. Overridden by use of --include-module."`,
+		`Blacklist specific modules from downloading. Format is "module-name[@constraint]", the same dialect as --include-module, quoting included. Use one flag per each module. Overridden by use of --include-module.`,
 	)
 	flagSet.StringVar(
 		&ModulesPathSuffix,
@@ -227,15 +203,15 @@ module-name@0.4.0 → bare version, expands to >=0.4.0 <1.0.0: keep latest patch
 		&PackagesWhitelist,
 		"include-package",
 		nil,
-		`Whitelist specific packages for downloading. Use one flag per each package. Disables blacklisting by --exclude-package.
+		`Whitelist specific packages for downloading. Format is "package-name[@constraint]", the same dialect as --include-module, quoting included. Use one flag per each package. Disables blacklisting by --exclude-package.
 
-Packages are mirrored exactly like modules (same name@version constraint dialect), but live under the packages/ registry segment with their release metadata under packages/<name>/version. Note that most version ranges must be put in quotes so that your shell will treat them as a single argument.`,
+Packages live under the packages/ registry segment, with release metadata under packages/<name>/version.`,
 	)
 	flagSet.StringArrayVar(
 		&PackagesBlacklist,
 		"exclude-package",
 		nil,
-		`Blacklist specific packages from downloading. Format is "package-name[@version]". Use one flag per each package. Overridden by use of --include-package.`,
+		`Blacklist specific packages from downloading. Format is "package-name[@constraint]", the same dialect as --include-module, quoting included. Use one flag per each package. Overridden by use of --include-package.`,
 	)
 	flagSet.Int64VarP(
 		&ImagesBundleChunkSizeGB,

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -478,6 +478,9 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 	if pullflags.ModulesWhitelist != nil {
 		filter, err := modules.NewFilter(pullflags.ModulesWhitelist, modules.FilterTypeWhitelist)
 		if err != nil {
+			if diag := errdetect.DiagnoseConstraintParseError(err, "include-module", pullflags.ModulesWhitelist...); diag != nil {
+				return nil, diag
+			}
 			return nil, fmt.Errorf("Prepare module filter: %w", err)
 		}
 
@@ -499,6 +502,9 @@ func (p *Puller) createPackageFilter() (*modules.Filter, error) {
 	if pullflags.PackagesWhitelist != nil {
 		filter, err := modules.NewFilter(pullflags.PackagesWhitelist, modules.FilterTypeWhitelist)
 		if err != nil {
+			if diag := errdetect.DiagnoseConstraintParseError(err, "include-package", pullflags.PackagesWhitelist...); diag != nil {
+				return nil, diag
+			}
 			return nil, fmt.Errorf("Prepare package filter: %w", err)
 		}
 

--- a/internal/mirror/cmd/pull/pull.go
+++ b/internal/mirror/cmd/pull/pull.go
@@ -481,6 +481,7 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 			if diag := errdetect.DiagnoseConstraintParseError(err, "include-module", pullflags.ModulesWhitelist...); diag != nil {
 				return nil, diag
 			}
+
 			return nil, fmt.Errorf("Prepare module filter: %w", err)
 		}
 
@@ -489,6 +490,10 @@ func (p *Puller) createModuleFilter() (*modules.Filter, error) {
 
 	filter, err := modules.NewFilter(pullflags.ModulesBlacklist, modules.FilterTypeBlacklist)
 	if err != nil {
+		if diag := errdetect.DiagnoseConstraintParseError(err, "exclude-module", pullflags.ModulesBlacklist...); diag != nil {
+			return nil, diag
+		}
+
 		return nil, fmt.Errorf("Prepare module filter: %w", err)
 	}
 
@@ -505,6 +510,7 @@ func (p *Puller) createPackageFilter() (*modules.Filter, error) {
 			if diag := errdetect.DiagnoseConstraintParseError(err, "include-package", pullflags.PackagesWhitelist...); diag != nil {
 				return nil, diag
 			}
+
 			return nil, fmt.Errorf("Prepare package filter: %w", err)
 		}
 
@@ -513,6 +519,10 @@ func (p *Puller) createPackageFilter() (*modules.Filter, error) {
 
 	filter, err := modules.NewFilter(pullflags.PackagesBlacklist, modules.FilterTypeBlacklist)
 	if err != nil {
+		if diag := errdetect.DiagnoseConstraintParseError(err, "exclude-package", pullflags.PackagesBlacklist...); diag != nil {
+			return nil, diag
+		}
+
 		return nil, fmt.Errorf("Prepare package filter: %w", err)
 	}
 

--- a/internal/mirror/cmd/pull/pull_test.go
+++ b/internal/mirror/cmd/pull/pull_test.go
@@ -37,7 +37,9 @@ import (
 
 	"github.com/deckhouse/deckhouse-cli/internal/mirror"
 	pullflags "github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/pull/flags"
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/validation"
+	"github.com/deckhouse/deckhouse-cli/pkg/diagnostic"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/operations/params"
 	"github.com/deckhouse/deckhouse-cli/pkg/libmirror/util/log"
 )
@@ -1143,6 +1145,116 @@ func TestPullerCreateModuleFilter(t *testing.T) {
 	filter, err = puller.createModuleFilter()
 	assert.NoError(t, err)
 	assert.NotNil(t, filter)
+}
+
+// TestPullerFilterQuotingDiagnostic covers the user-visible half of the quoting
+// hint: an entry the shell cut down to a bare "name@" must reach the top level
+// as a *diagnostic.HelpfulError naming the flag that was typed, not as the raw
+// "Prepare module filter" error.
+func TestPullerFilterQuotingDiagnostic(t *testing.T) {
+	originalModulesWhitelist := pullflags.ModulesWhitelist
+	originalModulesBlacklist := pullflags.ModulesBlacklist
+	originalPackagesWhitelist := pullflags.PackagesWhitelist
+	originalPackagesBlacklist := pullflags.PackagesBlacklist
+
+	defer func() {
+		pullflags.ModulesWhitelist = originalModulesWhitelist
+		pullflags.ModulesBlacklist = originalModulesBlacklist
+		pullflags.PackagesWhitelist = originalPackagesWhitelist
+		pullflags.PackagesBlacklist = originalPackagesBlacklist
+	}()
+
+	puller := &Puller{}
+
+	for _, tt := range []struct {
+		name     string
+		setup    func()
+		call     func() (*modules.Filter, error)
+		wantFlag string
+	}{
+		{
+			name:     "include-module",
+			setup:    func() { pullflags.ModulesWhitelist = []string{"console@"} },
+			call:     puller.createModuleFilter,
+			wantFlag: "--include-module",
+		},
+		{
+			name:     "exclude-module",
+			setup:    func() { pullflags.ModulesBlacklist = []string{"console@"} },
+			call:     puller.createModuleFilter,
+			wantFlag: "--exclude-module",
+		},
+		{
+			name:     "include-package",
+			setup:    func() { pullflags.PackagesWhitelist = []string{"console@"} },
+			call:     puller.createPackageFilter,
+			wantFlag: "--include-package",
+		},
+		{
+			name:     "exclude-package",
+			setup:    func() { pullflags.PackagesBlacklist = []string{"console@"} },
+			call:     puller.createPackageFilter,
+			wantFlag: "--exclude-package",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pullflags.ModulesWhitelist, pullflags.ModulesBlacklist = nil, nil
+			pullflags.PackagesWhitelist, pullflags.PackagesBlacklist = nil, nil
+
+			tt.setup()
+
+			_, err := tt.call()
+			require.Error(t, err)
+
+			var helpErr *diagnostic.HelpfulError
+			require.ErrorAs(t, err, &helpErr, "the hint must survive to the top level")
+			assert.Contains(t, helpErr.Format(), tt.wantFlag, "the hint must name the flag that was typed")
+			assert.Contains(t, helpErr.Format(), `"console@"`, "the hint must name the entry that was rejected")
+		})
+	}
+}
+
+// TestPullerFilterKeepsPlainParseErrors guards the other direction: a constraint
+// the user mistyped is not a quoting problem and keeps the parser's own message.
+func TestPullerFilterKeepsPlainParseErrors(t *testing.T) {
+	original := pullflags.ModulesWhitelist
+	defer func() { pullflags.ModulesWhitelist = original }()
+
+	pullflags.ModulesWhitelist = []string{"console@^^1.0"}
+
+	puller := &Puller{}
+
+	_, err := puller.createModuleFilter()
+	require.Error(t, err)
+
+	var helpErr *diagnostic.HelpfulError
+	assert.False(t, errors.As(err, &helpErr), "a malformed constraint is not a quoting hint")
+	assert.Contains(t, err.Error(), "Prepare module filter")
+}
+
+// TestParseAndValidateVersionFlagsPlatformQuoting covers the --include-platform
+// shape of the same mistake: the shell eats the constraint and the flag is left
+// holding the bundle path that followed it.
+func TestParseAndValidateVersionFlagsPlatformQuoting(t *testing.T) {
+	original := pullflags.PlatformConstraintString
+	defer func() { pullflags.PlatformConstraintString = original }()
+
+	pullflags.PlatformConstraintString = "./bundle"
+
+	err := parseAndValidateVersionFlags()
+	require.Error(t, err)
+
+	var helpErr *diagnostic.HelpfulError
+	require.ErrorAs(t, err, &helpErr)
+	assert.Contains(t, helpErr.Format(), "--include-platform")
+	assert.Contains(t, helpErr.Format(), "./bundle")
+
+	// A mistyped constraint stays a plain parse error.
+	pullflags.PlatformConstraintString = "1.64."
+
+	err = parseAndValidateVersionFlags()
+	require.Error(t, err)
+	assert.False(t, errors.As(err, &helpErr), "a malformed constraint is not a quoting hint")
 }
 
 func TestPullerComputeGOSTDigests(t *testing.T) {

--- a/internal/mirror/cmd/pull/pull_test.go
+++ b/internal/mirror/cmd/pull/pull_test.go
@@ -1147,10 +1147,11 @@ func TestPullerCreateModuleFilter(t *testing.T) {
 	assert.NotNil(t, filter)
 }
 
-// TestPullerFilterQuotingDiagnostic covers the user-visible half of the quoting
-// hint: an entry the shell cut down to a bare "name@" must reach the top level
+// TestPullerFilterQuotingDiagnostic covers the wiring of the quoting hint: an
+// entry the shell cut down to a bare "name@" must leave the filter constructor
 // as a *diagnostic.HelpfulError naming the flag that was typed, not as the raw
-// "Prepare module filter" error.
+// "Prepare module filter" error. Everything above wraps with %w, so root.go
+// finds it with errors.As.
 func TestPullerFilterQuotingDiagnostic(t *testing.T) {
 	originalModulesWhitelist := pullflags.ModulesWhitelist
 	originalModulesBlacklist := pullflags.ModulesBlacklist
@@ -1207,7 +1208,7 @@ func TestPullerFilterQuotingDiagnostic(t *testing.T) {
 			require.Error(t, err)
 
 			var helpErr *diagnostic.HelpfulError
-			require.ErrorAs(t, err, &helpErr, "the hint must survive to the top level")
+			require.ErrorAs(t, err, &helpErr, "the hint must survive as a HelpfulError")
 			assert.Contains(t, helpErr.Format(), tt.wantFlag, "the hint must name the flag that was typed")
 			assert.Contains(t, helpErr.Format(), `"console@"`, "the hint must name the entry that was rejected")
 		})

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 
+	"github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/pull/errdetect"
 	pullflags "github.com/deckhouse/deckhouse-cli/internal/mirror/cmd/pull/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/mirror/modules"
 )
@@ -164,6 +165,9 @@ func parseAndValidateVersionFlags() error {
 	if pullflags.PlatformConstraintString != "" {
 		pullflags.PlatformConstraint, err = modules.ParseVersionConstraint(pullflags.PlatformConstraintString)
 		if err != nil {
+			if diag := errdetect.DiagnoseConstraintParseError(err, "include-platform", pullflags.PlatformConstraintString); diag != nil {
+				return diag
+			}
 			return fmt.Errorf("Parse --include-platform constraint: %w", err)
 		}
 	}

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -241,7 +241,7 @@ func validateProxyRegistryFlag() error {
 		// Bail out loudly so the user picks a real anchor.
 		for _, entry := range pullflags.ModulesWhitelist {
 			if !strings.Contains(entry, "@") {
-				return fmt.Errorf("--proxy-registry requires every --include-module entry to specify an explicit version constraint (e.g. %q@^1.0.0); without it the probe would start at v0.0.0 and miss everything", strings.TrimSpace(entry))
+				return fmt.Errorf("--proxy-registry requires every --include-module entry to specify an explicit version constraint (e.g. %q); without it the probe would start at v0.0.0 and miss everything", strings.TrimSpace(entry)+"@^1.0.0")
 			}
 		}
 	}

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -168,6 +168,7 @@ func parseAndValidateVersionFlags() error {
 			if diag := errdetect.DiagnoseConstraintParseError(err, "include-platform", pullflags.PlatformConstraintString); diag != nil {
 				return diag
 			}
+
 			return fmt.Errorf("Parse --include-platform constraint: %w", err)
 		}
 	}

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -165,7 +165,7 @@ func parseAndValidateVersionFlags() error {
 	if pullflags.PlatformConstraintString != "" {
 		pullflags.PlatformConstraint, err = modules.ParseVersionConstraint(pullflags.PlatformConstraintString)
 		if err != nil {
-			if diag := errdetect.DiagnoseConstraintParseError(err, "include-platform", pullflags.PlatformConstraintString); diag != nil {
+			if diag := errdetect.DiagnosePlatformConstraintParseError(err, pullflags.PlatformConstraintString); diag != nil {
 				return diag
 			}
 

--- a/internal/mirror/cmd/pull/validation_test.go
+++ b/internal/mirror/cmd/pull/validation_test.go
@@ -591,6 +591,16 @@ func TestValidationValidateProxyRegistryFlag(t *testing.T) {
 			expectError:              true,
 			errorMsg:                 "since-version",
 		},
+		{
+			// The example must be copy-pasteable: quotes go around the whole
+			// value, the same form the flag help teaches.
+			name:                     "bare --include-module: example quotes the whole value",
+			proxyRegistry:            true,
+			platformConstraintString: "^1.64.0",
+			modulesWhitelist:         []string{"console"},
+			expectError:              true,
+			errorMsg:                 `(e.g. "console@^1.0.0")`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package modules
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -170,10 +171,14 @@ func ParseVersionConstraint(v string) (VersionConstraint, error) {
 	return parseVersionConstraint(v)
 }
 
+// ErrEmptyConstraint is returned for an expression that carries the '@'
+// separator with nothing after it, e.g. "console@".
+var ErrEmptyConstraint = errors.New("empty constraint")
+
 func parseVersionConstraint(v string) (VersionConstraint, error) {
 	v = strings.TrimSpace(v)
 	if v == "" {
-		return nil, fmt.Errorf("empty constraint")
+		return nil, ErrEmptyConstraint
 	}
 
 	switch v[0] {


### PR DESCRIPTION
Currently, running the `d8 mirror pull` command with the `--include-module` flag may result in an error due to redirection with the ">" symbol.
```
d8 mirror pull --license='<LICENSE_KEY>' --source=registry.deckhouse.ru/deckhouse/ee  --no-platform  --no-installer -i console@>=1.43.2 ./console
Error executing command: pull failed: Prepare module filter: empty constraint
```

To avoid this issue, I've highlighted in the flag descriptions that the module version and its restrictions should be written in quotation marks.

```
d8 mirror pull \
--license='<LICENSE_KEY>' \
--no-platform --no-security-db \
--include-module console@">=1.43.2" \
./console
```

Added the [DiagnoseConstraintParseError](https://github.com/deckhouse/deckhouse-cli/pull/411/changes#diff-7650ceba025a1ee959b791d80530ac122d90007855fd60edafbe969b7cee9eb3R381) function to report an error when output is redirected instead of being passed to d8.
This function is triggered when both signals are present:
1. The error message contains an "empty constraint" (the exact text that `modules.NewFilter` / `modules.ParseVersionConstraint` produces when there is no constraint).
2. At least one raw flag value ends in `@` after whitespace removal—a clear sign that the shell ate the `>=…` part as a redirection target.

```
d8 mirror pull --license='<LICENSE_KEY>' --source=registry.deckhouse.ru/deckhouse/ee  --no-platform  --no-installer -i console@>=1.43.2 ./console'

error: Invalid version constraint (possible shell redirection)
  ╰─▶ empty constraint

  * The shell interpreted '>' as output redirection instead of passing it to d8.
The constraint part after '@' was never received — perhaps you forgot to quote the flag value?
    -> Wrap the constraint in double quotes: --include-module "module-name@>=1.43.2"
    -> Example: d8 mirror pull --license='****' --include-module console@">=1.43.2" ./console
```

The [parseAndValidateVersionFlags](https://github.com/deckhouse/deckhouse-cli/pull/411/changes#diff-519677928724030662f89a4e34290ec654560b245652bdc96de07847dfd42eecR168), [createModuleFilter](https://github.com/deckhouse/deckhouse-cli/pull/411/changes#diff-51912321bad98ee9015fe92f8a0b3bc0d173b7d9a895732fabc789b594123b62R474), and [createPackageFilter](https://github.com/deckhouse/deckhouse-cli/pull/411/changes#diff-51912321bad98ee9015fe92f8a0b3bc0d173b7d9a895732fabc789b594123b62R505) functions have been updated to call this check, and [tests](https://github.com/deckhouse/deckhouse-cli/pull/411/changes#diff-08c1ae3aa54758744386ffa87dbeefe5ffde04632e1ed0cfb0fdc1665dddf58eR126) have been added.