### PR TITLE
[deckhouse-cli] fix sequential download when 0 major (backport)

### DIFF
--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -150,7 +150,7 @@ Examples (available platform versions: v1.63.x, v1.64.x, v1.65.x, v1.66.x, v1.67
 
 --include-platform "^1.65.0" → semver ^ constraint (>=1.65.0 <2.0.0): latest patch per minor starting at v1.65.x.
 
---include-platform "1.65.0" → implicit caret (^1.65.0): same as above; shorthand kept for parity with --include-module.
+--include-platform "1.65.0" → bare version, expands to >=1.65.0 <2.0.0 (same major line): keep latest patch per minor starting at v1.65.x. Same result as ^1.65.0 here because platform is always major >= 1; shorthand kept for parity with --include-module.
 
 --include-platform "=v1.65.3" → exact-tag pin: only v1.65.3 is pulled and propagated to all default release channels, just like --deckhouse-tag.
 
@@ -179,22 +179,31 @@ Semver constraints (caret, tilde, range) keep only the highest patch in each (ma
 Versions explicitly named with an inclusive boundary operator (>= or <=) are always preserved — that boundary is part of the user's request and must round-trip even when a newer patch exists in the same minor.
 Use the exact-tag form (=) when you need a specific older patch unconditionally.
 
+A bare version with no operator (module-name@1.3.0) means "this version or newer within the same major line" and keeps the latest patch per minor. It expands to >=X.Y.Z <(major+1).0.0, treating major 0 like any other major: module-name@0.4.0 spans the whole 0.x line (>=0.4.0 <1.0.0), NOT just the 0.4 minor as a caret (^0.4.0 = >=0.4.0 <0.5.0) would. Prefer this bare form for step-by-step upgrades — it captures every intermediate minor and needs no shell quoting.
+
+Shell note: >= and <= contain the redirection metacharacters > and <, so an unquoted module-name@>=1.3.0 is mangled by bash/zsh (it strips the operator and redirects into a file named "=1.3.0", leaving the module with an empty version). Quote the whole value when you use these operators: --include-module 'module-name@>=1.3.0'. The bare-version form above avoids this entirely.
+
 Example:
 Available versions for <module-name>: v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1
 
-module-name@1.3.0 → semver ^ constraint (^1.3.0): keep latest patch per minor — includes v1.3.3 (1.3.x) and v1.4.1 (1.4.x). Versions currently pinned by release channels are pulled in addition.
+module-name@1.3.0 → bare version, expands to >=1.3.0 <2.0.0 (same major line): keep latest patch per minor — includes v1.3.3 (1.3.x) and v1.4.1 (1.4.x). Versions currently pinned by release channels are pulled in addition.
 
 module-name@~1.3.0 → semver ~ constraint (>=1.3.0 <1.4.0): keep latest patch per minor in range — includes v1.3.3. Versions currently pinned by release channels are pulled in addition.
 
-module-name@>=1.3.0 → range constraint with explicit >= anchor: keep latest patch per minor AND the named anchor v1.3.0 — includes v1.3.0 (anchor), v1.3.3 (1.3.x latest), v1.4.1 (1.4.x latest).
+module-name@^1.3.0 → semver ^ constraint (>=1.3.0 <2.0.0): keep latest patch per minor — includes v1.3.3, v1.4.1. For a 0.x version the caret locks the minor (^0.4.0 = >=0.4.0 <0.5.0), so use the bare form instead when you want the whole 0.x line.
 
-module-name@>=1.3.0 <=1.4.0 → both anchors honoured: includes v1.3.0, v1.3.3, v1.4.0; v1.4.1 is excluded by the upper bound.
+module-name@>=1.3.0 → range constraint with explicit >= anchor (quote in shell): keep latest patch per minor AND the named anchor v1.3.0 — includes v1.3.0 (anchor), v1.3.3 (1.3.x latest), v1.4.1 (1.4.x latest).
+
+module-name@>=1.3.0 <=1.4.0 → both anchors honoured (quote in shell): includes v1.3.0, v1.3.3, v1.4.0; v1.4.1 is excluded by the upper bound.
 
 module-name@=v1.3.0 → exact tag match: include only v1.3.0 and publish it to all release channels (alpha, beta, early-access, stable, rock-solid).
 
 module-name@=bobV1 → exact tag match: include only bobV1 and publish it to all release channels (alpha, beta, early-access, stable, rock-solid).
 
-module-name@=v1.3.0+stable → exact tag match: include only v1.3.0 and and publish it to stable channel
+module-name@=v1.3.0+stable → exact tag match: include only v1.3.0 and publish it to stable channel
+
+0.x example — available versions for <module-name>: v0.4.2, v0.4.4, v0.5.3, v0.6.1, v0.7.2
+module-name@0.4.0 → bare version, expands to >=0.4.0 <1.0.0: keep latest patch per minor across the whole 0.x line — includes v0.4.4, v0.5.3, v0.6.1, v0.7.2.
 		`,
 	)
 	flagSet.StringArrayVarP(

--- a/internal/mirror/modules/constraints.go
+++ b/internal/mirror/modules/constraints.go
@@ -96,6 +96,42 @@ func NewSemanticVersionConstraint(c string) (*SemanticVersionConstraint, error) 
 	}, nil
 }
 
+// NewImplicitVersionConstraint builds the constraint for a bare, operator-less
+// version literal (e.g. `alb@0.4.0`). Historically this was implemented by
+// prepending a caret (`^0.4.0`), but Masterminds' caret special-cases the 0.x
+// major line: `^0.4.0` expands to `>=0.4.0 <0.5.0`, locking the MINOR instead
+// of the major. In a catch-up mirror that silently drops every intermediate
+// 0.x minor (0.5.*, 0.6.* …), leaving gaps that block sequential upgrades.
+//
+// We instead expand a bare version to `>=X.Y.Z <(major+1).0.0`, treating major
+// 0 like any other major. For major >= 1 this is byte-for-byte equivalent to
+// the previous caret behaviour (`^1.52.0` == `>=1.52.0 <2.0.0`); for major 0 it
+// now spans the whole 0.x line from the named version upward.
+//
+// The synthesized `>=` lower bound is deliberately NOT registered as an anchor:
+// the user wrote a bare version, not an explicit inclusive boundary, so the
+// latest-patch-per-minor filter stays free to collapse same-minor patches (see
+// the anchors field doc). This preserves the issue #220 behaviour.
+func NewImplicitVersionConstraint(version string) (*SemanticVersionConstraint, error) {
+	ver, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version %q: %w", version, err)
+	}
+
+	rangeStr := fmt.Sprintf(">= %s, < %d.0.0", ver.String(), ver.Major()+1)
+
+	constraint, err := semver.NewConstraint(rangeStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid implicit version constraint %q: %w", rangeStr, err)
+	}
+
+	return &SemanticVersionConstraint{
+		constraint: constraint,
+		anchors:    nil,
+		lowerBound: ver,
+	}, nil
+}
+
 // Anchors returns the versions explicitly named with an inclusive boundary
 // operator (>=, <=). Callers must re-check membership against the constraint
 // itself (Match) before consuming an anchor: an anchor that fails Match means

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -148,7 +148,10 @@ func (f *Filter) ModuleNames() []string {
 //   - "=v1.2.3+stable"    → exact tag pinned to the named release channel
 //   - ">=1.2.0 <=1.3.0"   → semver range with inclusive anchors
 //   - "^1.2.0", "~1.2.0"  → semver shorthand
-//   - "1.2.0"             → implicit caret (^1.2.0), kept for backward compat
+//   - "1.2.0"             → implicit ">=1.2.0 <2.0.0" (bare version, same major
+//     line); for a 0.x version like "0.4.0" this spans
+//     the whole 0.x line (">=0.4.0 <1.0.0"), NOT a single
+//     minor as caret would — see NewImplicitVersionConstraint
 //
 // An empty or whitespace-only input is rejected so callers see a clear error
 // instead of silently producing a no-op constraint.
@@ -163,19 +166,18 @@ func parseVersionConstraint(v string) (VersionConstraint, error) {
 	}
 
 	switch v[0] {
-	// has user defined constraint (nothing to do)
-	case '=', '>', '<', '~', '^':
-	default:
-		// version without contraint (add ^ for backward compatibility)
-		v = "^" + v
-	}
-
 	// exact-match: "=1.2.3" or "=1.2.3+stable"
-	if v[0] == '=' {
+	case '=':
 		return parseExact(v[1:])
+	// user-supplied semver constraint (caret, tilde, range): honoured as-is.
+	case '>', '<', '~', '^':
+		return parseSemver(v)
+	// bare "X.Y.Z" with no operator: "this version or newer within the same
+	// major line". Expanded explicitly instead of via caret so 0.x majors are
+	// not locked to a single minor — see NewImplicitVersionConstraint.
+	default:
+		return NewImplicitVersionConstraint(v)
 	}
-	// semver constraint
-	return parseSemver(v)
 }
 
 func parseExact(body string) (VersionConstraint, error) {

--- a/internal/mirror/modules/filter_test.go
+++ b/internal/mirror/modules/filter_test.go
@@ -130,6 +130,65 @@ func TestNewFilter_VersionParsing(t *testing.T) {
 	}
 }
 
+// TestFilter_BareVersionConstraint exercises the full --include-module parse
+// path (NewFilter -> parseVersionConstraint -> NewImplicitVersionConstraint)
+// for operator-less version literals. The 0.x case is the regression guard:
+// a bare `0.4.0` must span the whole 0.x line, not lock to the 0.4 minor the
+// way a caret (`^0.4.0` == `>=0.4.0 <0.5.0`) would.
+func TestFilter_BareVersionConstraint(t *testing.T) {
+	logger := log.NewSLogger(slog.LevelDebug)
+
+	tests := []struct {
+		name       string
+		expression string
+		releases   []string
+		want       []string
+	}{
+		{
+			// Regression: bare 0.x version must reach every intermediate minor
+			// up to (but not including) the next major, keeping only the latest
+			// patch per minor. Caret would have stopped at <0.5.0.
+			name:       "bare 0.x version spans the whole 0.x line",
+			expression: "module1@0.4.0",
+			releases: []string{
+				"v0.4.2", "v0.4.4",
+				"v0.5.1", "v0.5.3",
+				"v0.6.1",
+				"v0.7.2",
+			},
+			want: []string{"v0.4.4", "v0.5.3", "v0.6.1", "v0.7.2"},
+		},
+		{
+			// A bare >=1 version is unchanged from the old caret behaviour:
+			// spans the current major, latest patch per minor, no 2.x.
+			name:       "bare 1.x version keeps caret-equivalent behaviour",
+			expression: "module1@1.52.0",
+			releases: []string{
+				"v1.52.0",
+				"v1.53.1", "v1.53.2",
+				"v1.54.1",
+				"v1.55.1",
+				"v2.0.0",
+			},
+			want: []string{"v1.52.0", "v1.53.2", "v1.54.1", "v1.55.1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := NewFilter([]string{tt.expression}, FilterTypeWhitelist)
+			require.NoError(t, err)
+			filter.UseLogger(logger)
+
+			// A bare version is non-exact, so release channels must be mirrored.
+			require.True(t, filter.ShouldMirrorReleaseChannels("module1"))
+
+			mod := &Module{Name: "module1", Releases: tt.releases}
+			require.ElementsMatch(t, tt.want, filter.VersionsToMirror(mod))
+		})
+	}
+}
+
 func TestFilter_Match(t *testing.T) {
 	logger := log.NewSLogger(slog.LevelDebug)
 	type args struct {


### PR DESCRIPTION
> ⚠️ Backport from #412 

## What

`d8 mirror pull` silently skipped intermediate **minor** versions of `0.x` modules when a bare (operator-less) version was passed to `--include-module`.

For a module on the `0.x` line:

```
--include-module alb@0.4.0
```

only `0.4.4` (plus whatever the release channels currently point at, e.g. `0.7.2`) was pulled — `0.5.*` and `0.6.*` were dropped, leaving gaps that block Deckhouse's one-minor-at-a-time upgrades. Modules on `>=1.0` (`console`, `gpu`) were unaffected, which made the behaviour look random.

## Why

A bare version was expanded by prepending a caret (`0.4.0` → `^0.4.0`). `Masterminds/semver` special-cases the `0.x` major line for caret:

| Input | Caret expands to | Captures |
|-------|------------------|----------|
| `^1.52.0` | `>=1.52.0 <2.0.0` | whole `1.x` ✅ |
| `^0.4.0`  | `>=0.4.0 <0.5.0`  | only `0.4.x` ⚠️ |

So for a `0.x` module the caret locked the **minor**, not the major, and every intermediate minor fell outside the constraint. `>=1.0` modules happened to work because there the caret locks the major.

## Fix

Bare versions are now expanded to an explicit range `>=X.Y.Z <(major+1).0.0`, treating major `0` like any other major line:

| Input | Now expands to | Captures |
|-------|----------------|----------|
| `alb@0.4.0`     | `>=0.4.0 <1.0.0`   | whole `0.x` from 0.4 up ✅ |
| `console@1.52.0`| `>=1.52.0 <2.0.0`  | whole `1.x` (**byte-identical to old caret**) |

The synthesized `>=` lower bound is deliberately **not** registered as an inclusive anchor — a bare version is not an explicit boundary, so the "latest-patch-per-minor" collapse still applies (preserves the issue #220 behaviour). `--include-platform` shares the same parser; since platform versions are always `>=1.0`, its behaviour is unchanged.

## Changes

- `internal/mirror/modules/constraints.go` — new `NewImplicitVersionConstraint` that builds the caret-free range and clears anchors.
- `internal/mirror/modules/filter.go` — `parseVersionConstraint` routes bare versions through the new helper instead of prepending `^`; updated `ParseVersionConstraint` doc.
- `internal/mirror/cmd/pull/flags/flags.go` — corrected the `--include-module` / `--include-platform` help (the old text claimed "implicit caret"), added a `0.x` example and a shell-quoting note for `>=`/`<=` (the shell eats the `>`/`<` redirection metacharacters, so those operators must be quoted; the bare-version form needs no quoting).
- `internal/mirror/modules/filter_test.go` — regression test `TestFilter_BareVersionConstraint` covering the `0.x` fix and confirming the `1.x` path is unchanged.

## Behaviour change / compatibility

- **`0.x` modules:** bare version now spans the whole `0.x` line (the bug fix).
- **`>=1.0` modules:** no change — bare version resolves to the same set as before.
- Explicit `^`, `~`, `>=`, `<=`, `=` constraints are untouched. Users who still want the old "single 0.x minor" behaviour can pass `alb@~0.4.0`.

## Testing

- `go test ./internal/mirror/modules/ ./internal/mirror/cmd/pull/` — pass (new regression test + all existing caret/tilde/range/anchor cases green).
- `go build ./internal/mirror/...` and `go vet` — clean.

## Reproduction / verification

Available `alb` versions: `v0.4.2, v0.4.4, v0.5.3, v0.6.1, v0.7.2`

| Command | Before | After |
|---------|--------|-------|
| `--include-module alb@0.4.0` | `0.4.4` (+ channel snapshots) | `0.4.4, 0.5.3, 0.6.1, 0.7.2` |