### PR TITLE
[deckhouse-cli] Fix --include-module pulling extra modules

### DIFF
--- a/internal/mirror/cmd/pull/flags/flags.go
+++ b/internal/mirror/cmd/pull/flags/flags.go
@@ -175,6 +175,8 @@ Examples (available platform versions: v1.63.x, v1.64.x, v1.65.x, v1.66.x, v1.67
 		nil,
 		`Whitelist specific modules for downloading. Use one flag per each module. Disables blacklisting by --exclude-module."
 
+Without a version part (module-name), only the versions the release channels currently point at are pulled - the same set as a default pull with no filters.
+
 Semver constraints (caret, tilde, range) keep only the highest patch in each (major, minor) series, mirroring how platform releases are discovered.
 Versions explicitly named with an inclusive boundary operator (>= or <=) are always preserved — that boundary is part of the user's request and must round-trip even when a newer patch exists in the same minor.
 Use the exact-tag form (=) when you need a specific older patch unconditionally.
@@ -185,6 +187,8 @@ Shell note: >= and <= contain the redirection metacharacters > and <, so an unqu
 
 Example:
 Available versions for <module-name>: v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.3.3, v1.4.0, v1.4.1
+
+module-name → no version part: pull only the versions the release channels currently point at (same as a default pull).
 
 module-name@1.3.0 → bare version, expands to >=1.3.0 <2.0.0 (same major line): keep latest patch per minor — includes v1.3.3 (1.3.x) and v1.4.1 (1.4.x). Versions currently pinned by release channels are pulled in addition.
 

--- a/internal/mirror/cmd/pull/validation.go
+++ b/internal/mirror/cmd/pull/validation.go
@@ -217,11 +217,10 @@ func validateProxyRegistryFlag() error {
 			return errors.New("--proxy-registry requires --include-module (or --no-modules to skip module mirroring): the probe needs explicit module names and version anchors to start incrementing from")
 		}
 		// Every --include-module entry must come with an explicit
-		// version part. The implicit ">=0.0.0" fallback used by the
-		// regular pull mode is poisonous for the probe: it starts at
-		// v0.0.0 and stops on the first not-found, silently skipping
-		// any module whose lowest tag is above v0.0.0 / v0.1.0 /
-		// v1.0.0. Bail out loudly so the user picks a real anchor.
+		// version part. A bare include pins no version and pulls only
+		// what the release channels point at - the probe has no lower
+		// bound to increment from and would miss every version tag.
+		// Bail out loudly so the user picks a real anchor.
 		for _, entry := range pullflags.ModulesWhitelist {
 			if !strings.Contains(entry, "@") {
 				return fmt.Errorf("--proxy-registry requires every --include-module entry to specify an explicit version constraint (e.g. %q@^1.0.0); without it the probe would start at v0.0.0 and miss everything", strings.TrimSpace(entry))

--- a/internal/mirror/modules/constraints.go
+++ b/internal/mirror/modules/constraints.go
@@ -345,7 +345,19 @@ func (m *MultiConstraint) HasChannelAlias() bool {
 // mergeConstraints OR-combines an already-registered constraint with an
 // additional one declared for the same name, flattening nested
 // MultiConstraints so repeated declarations stay a single flat list.
+//
+// A nil operand is a bare include (name without @version): it pins no
+// version of its own, so merging it keeps the other side. Two bare includes
+// merge back to nil (still "channels only").
 func mergeConstraints(existing, additional VersionConstraint) VersionConstraint {
+	if existing == nil {
+		return additional
+	}
+
+	if additional == nil {
+		return existing
+	}
+
 	if multi, ok := existing.(*MultiConstraint); ok {
 		multi.constraints = append(multi.constraints, additional)
 		return multi

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -65,10 +65,12 @@ func NewFilter(filterExpressions []string, filterType FilterType) (*Filter, erro
 			return nil, fmt.Errorf("Malformed filter expression %q: empty name", filterExpr)
 		}
 
+		// A bare "--include-module <name>" (no @version) selects the module
+		// for mirroring but pins no version: a nil constraint means "pull
+		// only what the release channels point at", the same behaviour as a
+		// default all-modules pull. An explicit @version is parsed as usual.
 		var constraint VersionConstraint
-		if !hasVersion {
-			constraint, _ = NewSemanticVersionConstraint(">=0.0.0")
-		} else {
+		if hasVersion {
 			var err error
 
 			constraint, err = parseVersionConstraint(versionStr)
@@ -108,9 +110,17 @@ func (f *Filter) Match(mod *Module) bool {
 
 func (f *Filter) Len() int { return len(f.modules) }
 
+// GetConstraint returns the version constraint registered for the module.
+// A bare "--include-module <name>" registers the name with a nil constraint;
+// that reports as "no constraint" (found == false) so callers pull only the
+// versions the release channels point at, never the full registry tag list.
 func (f *Filter) GetConstraint(moduleName string) (VersionConstraint, bool) {
 	constraint, found := f.modules[moduleName]
-	return constraint, found
+	if !found || constraint == nil {
+		return nil, false
+	}
+
+	return constraint, true
 }
 
 // IsWhitelist reports whether the filter is operating in whitelist mode.
@@ -207,7 +217,7 @@ func parseSemver(v string) (VersionConstraint, error) {
 }
 
 func (f *Filter) ShouldMirrorReleaseChannels(moduleName string) bool {
-	constraint, hasConstraint := f.modules[moduleName]
+	constraint, hasConstraint := f.GetConstraint(moduleName)
 	if hasConstraint && constraint.IsExact() {
 		return false
 	}
@@ -239,7 +249,7 @@ func (f *Filter) ShouldMirrorReleaseChannels(moduleName string) bool {
 // channel still points at remains reachable through the channel snapshot even
 // when filterOnlyLatestPatches drops it from the constraint set.
 func (f *Filter) VersionsToMirror(mod *Module) []string {
-	constraint, hasConstraint := f.modules[mod.Name]
+	constraint, hasConstraint := f.GetConstraint(mod.Name)
 	if !hasConstraint {
 		return nil
 	}

--- a/internal/mirror/modules/filter.go
+++ b/internal/mirror/modules/filter.go
@@ -70,6 +70,7 @@ func NewFilter(filterExpressions []string, filterType FilterType) (*Filter, erro
 		// only what the release channels point at", the same behaviour as a
 		// default all-modules pull. An explicit @version is parsed as usual.
 		var constraint VersionConstraint
+
 		if hasVersion {
 			var err error
 

--- a/internal/mirror/modules/filter_test.go
+++ b/internal/mirror/modules/filter_test.go
@@ -189,6 +189,89 @@ func TestFilter_BareVersionConstraint(t *testing.T) {
 	}
 }
 
+// TestFilter_BareIncludeHasNoVersionConstraint covers "--include-module <name>"
+// with no "@version" part. Membership and version selection are separate
+// concerns: the name alone selects the module for mirroring, while the absent
+// version part means no version is pinned, so the release channels decide what
+// gets pulled and the registry tag list is never consulted.
+func TestFilter_BareIncludeHasNoVersionConstraint(t *testing.T) {
+	const moduleName = "csi-huawei"
+
+	filter, err := NewFilter([]string{moduleName}, FilterTypeWhitelist)
+	require.NoError(t, err)
+	filter.UseLogger(log.NewSLogger(slog.LevelDebug))
+
+	require.True(t, filter.Match(&Module{Name: moduleName}),
+		"the name alone must select the module for mirroring")
+
+	_, hasConstraint := filter.GetConstraint(moduleName)
+	assert.False(t, hasConstraint,
+		"a bare include pins no version, so it must report no constraint")
+
+	assert.True(t, filter.ShouldMirrorReleaseChannels(moduleName),
+		"release channels are the only version source for a bare include")
+
+	mod := &Module{
+		Name:     moduleName,
+		Releases: []string{"v0.1.1", "v0.2.9", "v0.3.11", "v0.3.13"},
+	}
+	assert.Empty(t, filter.VersionsToMirror(mod),
+		"a bare include must not add version tags from the registry tag list")
+}
+
+// TestFilter_BareIncludeMergedWithExplicitConstraint covers a name declared
+// several times with and without a version part. A bare entry pins nothing, so
+// merging it must neither drop an explicitly pinned version nor widen the
+// selection back to the whole registry tag list.
+func TestFilter_BareIncludeMergedWithExplicitConstraint(t *testing.T) {
+	releases := []string{"v0.1.1", "v0.2.9", "v1.2.3", "v1.2.4", "v1.3.0"}
+
+	tests := []struct {
+		name           string
+		expressions    []string
+		wantConstraint bool     // GetConstraint reports a pinned constraint
+		wantVersions   []string // tags VersionsToMirror resolves to
+	}{
+		{
+			name:           "bare first, pinned second",
+			expressions:    []string{"module1", "module1@=v1.2.3"},
+			wantConstraint: true,
+			wantVersions:   []string{"v1.2.3"},
+		},
+		{
+			name:           "pinned first, bare second",
+			expressions:    []string{"module1@=v1.2.3", "module1"},
+			wantConstraint: true,
+			wantVersions:   []string{"v1.2.3"},
+		},
+		{
+			name:           "two bare entries stay channels-only",
+			expressions:    []string{"module1", "module1"},
+			wantConstraint: false,
+			wantVersions:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := NewFilter(tt.expressions, FilterTypeWhitelist)
+			require.NoError(t, err)
+			filter.UseLogger(log.NewSLogger(slog.LevelDebug))
+
+			constraint, hasConstraint := filter.GetConstraint("module1")
+			require.Equal(t, tt.wantConstraint, hasConstraint)
+
+			if tt.wantConstraint {
+				assert.True(t, constraint.IsExact(),
+					"merging a bare entry must keep the pinned tag exact")
+			}
+
+			assert.ElementsMatch(t, tt.wantVersions,
+				filter.VersionsToMirror(&Module{Name: "module1", Releases: releases}))
+		})
+	}
+}
+
 func TestFilter_Match(t *testing.T) {
 	logger := log.NewSLogger(slog.LevelDebug)
 	type args struct {

--- a/internal/mirror/modules/pull_modules_test.go
+++ b/internal/mirror/modules/pull_modules_test.go
@@ -52,6 +52,14 @@ const (
 	channelVersion = "v1.45.2" // version every release channel points at
 )
 
+// baselineRootListTagsCalls is how many times PullModules lists tags at the
+// registry root regardless of the filter in use:
+//   - validateModulesAccess (reachability check)
+//   - pullModules (module-name enumeration)
+//
+// Anything above this baseline is a per-module tag listing.
+const baselineRootListTagsCalls int64 = 2
+
 // defaultRegistryVersions is a small but representative tag set for tests
 // that don't care about the exact list - a few patches and a few minors.
 var defaultRegistryVersions = []string{"v1.40.0", "v1.40.1", "v1.41.0", "v1.45.2"}
@@ -252,6 +260,51 @@ func TestPullModules_Issue220_LatestPatchPerMinor(t *testing.T) {
 	}
 }
 
+// TestPullModules_BareIncludePullsChannelsOnly pins the contract for
+// --include-module without a version part:
+//
+//	d8 mirror pull --include-module csi-huawei
+//
+// The module is selected for mirroring but no version is pinned, so the release
+// channels are the only version source - exactly like a default all-modules
+// pull. Versions that live in the registry but that no channel points at must
+// stay out of the bundle, and the per-module tag list must not be requested.
+//
+// The registry shape mirrors the reported csi-huawei case: several minors with
+// every channel pointing at the newest one. A bare include used to drag in
+// v0.1.1 and v0.2.9 (latest patch of each older minor), doubling the bundle.
+func TestPullModules_BareIncludePullsChannelsOnly(t *testing.T) {
+	const (
+		moduleName    = "csi-huawei"
+		channelTarget = "v0.3.13" // version every release channel points at
+	)
+
+	registryVersions := []string{"v0.1.1", "v0.2.9", "v0.3.11", channelTarget}
+
+	reg := singleModuleRegistry(moduleName, channelTarget, registryVersions)
+	counter := newListTagsCounter(upfake.NewClient(reg))
+	// Bare include: module name only, no "@version".
+	filter := mustNewFilter(t, FilterTypeWhitelist, moduleName)
+	svc := newService(t, pkgclient.Adapt(counter), filter)
+
+	require.NoError(t, svc.PullModules(context.Background()))
+
+	got := pulledModuleVersionRefs(t, svc, moduleName)
+
+	assert.ElementsMatch(t, taggedModuleRefs(moduleName, []string{channelTarget}), got,
+		"a bare --include-module must pull only channel-referenced versions")
+
+	// Headline regression: versions no channel points at must not be pulled.
+	for _, dropped := range []string{"v0.1.1", "v0.2.9", "v0.3.11"} {
+		assert.NotContains(t, got, taggedModuleRef(moduleName, dropped),
+			"%s is not referenced by any release channel and must not be pulled", dropped)
+	}
+
+	// No version is pinned, so the registry tag list is never needed.
+	assert.Equal(t, baselineRootListTagsCalls, counter.calls.Load(),
+		"a bare --include-module must not trigger a per-module ListTags")
+}
+
 // =============================================================================
 // Tests: per-module ListTags policy
 // =============================================================================
@@ -260,11 +313,6 @@ func TestPullModules_Issue220_LatestPatchPerMinor(t *testing.T) {
 // cost of a default pull or an exact-tag pull must not regress by adding an
 // unconditional per-module call.
 func TestPullModules_PerModuleListTagsCallCount(t *testing.T) {
-	// PullModules lists tags at the registry root twice:
-	//   - validateModulesAccess (reachability check)
-	//   - pullModules (module-name enumeration)
-	const baselineRootCalls int64 = 2
-
 	cases := []struct {
 		name        string
 		filterType  FilterType
@@ -300,7 +348,7 @@ func TestPullModules_PerModuleListTagsCallCount(t *testing.T) {
 
 			require.NoError(t, svc.PullModules(context.Background()))
 
-			assert.Equal(t, baselineRootCalls+tc.wantExtra, counter.calls.Load())
+			assert.Equal(t, baselineRootListTagsCalls+tc.wantExtra, counter.calls.Load())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`--include-module <name>` without a version pulled far more than asked. 

Now it pulls only the versions the release channels point at, same as a default pull.

## Problem

A bare `--include-module <name>` got the `>=0.0.0` constraint. 

The rest of the pull then treated it as a real range the user typed:

- it read every tag of the module
- it kept the newest patch of every minor
- old versions no channel points at ended up in the bundle

A default pull with no filters never did this. 
The same registry gave two different results.

**How you could notice it. Mirror one module without a version:**

```
d8 mirror pull csi-huawei-bundle/ --include-module csi-huawei \
  --no-platform --no-installer --no-security-db --no-packages
```

**All five release channels point at `v0.3.13`. The log pulls four versions:**

```
[1 / 4] Pulling .../modules/csi-huawei:v0.3.13
[2 / 4] Pulling .../modules/csi-huawei:v0.3.11
[3 / 4] Pulling .../modules/csi-huawei:v0.2.9
[4 / 4] Pulling .../modules/csi-huawei:v0.1.1
```

- `v0.1.1` is the newest patch of an old minor
- no channel points at it
- the bundle grew from about 900 MiB to 1.5 GiB

## Fix

- A bare include picks the module and sets no version
- Versions come only from the release channels
- The extra call that reads the module tag list is gone
- Explicit constraints (`@1.6.0`, `^`, `~`, `>=`, `=vX`) work as before
- `--include-package` uses the same filter and gets the same fix
- The `--include-module` help now says what a name without a version does

## Tests

- `TestPullModules_BareIncludePullsChannelsOnly` - same registry layout as above; only the channel version gets pulled, and the tag list is not read
- `TestFilter_BareIncludeHasNoVersionConstraint` - a bare include picks the module, sets no version, adds no tags
- `TestFilter_BareIncludeMergedWithExplicitConstraint` - a name given both bare and pinned, in either order, keeps the pinned tag

All three fail without the fix.

## Notes

A module can have version tags but no release channels. For such a module:

- a bare include now pulls nothing
- a default pull already worked this way
- to pull its tags, name a version: `--include-module <name>@<version>`

