### PR TITLE
[deckhouse-cli] require d8a- prefix for application resource names

### DIFF
--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
@@ -8,14 +8,17 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
 )
 
-// Rule purpose: require every rendered object's name to start with the application instance prefix so cluster resources are scoped to the instance.
+// Rule purpose: require every rendered object's name to start with the d8a- application
+// marker followed by the instance name, so cluster resources are recognizable as
+// Deckhouse-application-owned and scoped to the instance.
 
 // InstancePrefixRuleID is the stable identifier used to reference this rule in configuration.
 const InstancePrefixRuleID = "instance-prefix"
 
-// instancePrefix is the prefix every rendered object's name must start with.
-// It tracks the hardcoded verify-time instance name from internal/packages.Render.
-const instancePrefix = "test-"
+// instancePrefix is the prefix every rendered object's name must start with: the fixed
+// d8a- application marker plus the hardcoded verify-time instance name from
+// internal/packages.Render.
+const instancePrefix = "d8a-test-"
 
 // InstancePrefixRule asserts every rendered object's name starts with the instance prefix.
 type InstancePrefixRule struct {
@@ -42,6 +45,6 @@ func (r *InstancePrefixRule) Check(_ context.Context) {
 		r.collector.With(
 			diag.ObjectID(obj.ObjectID()),
 			diag.Path(obj.FilePath),
-		).Error("object name does not start with the instance prefix")
+		).Error("object name does not start with the required d8a- instance prefix")
 	}
 }

--- a/internal/packagecmd/templates/application/templates/deployment.yaml
+++ b/internal/packagecmd/templates/application/templates/deployment.yaml
@@ -6,7 +6,7 @@ memory: 70Mi
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   revisionHistoryLimit: 2
   replicas: {{ .Application.Settings.replicas | default 1 }}
@@ -26,7 +26,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       imagePullSecrets:
-        - name: {{ .Application.Instance.Name }}-registrysecret
+        - name: d8a-{{ .Application.Instance.Name }}-registrysecret
       containers:
         - name: server
           image: {{ index .Application.Package.Images "echo" }}

--- a/internal/packagecmd/templates/application/templates/pdb.yaml
+++ b/internal/packagecmd/templates/application/templates/pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   minAvailable: 1
   selector:

--- a/internal/packagecmd/templates/application/templates/registry-secret.yaml
+++ b/internal/packagecmd/templates/application/templates/registry-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Application.Instance.Name }}-registrysecret
+  name: d8a-{{ .Application.Instance.Name }}-registrysecret
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Application.Package.Registry.dockercfg }}

--- a/internal/packagecmd/templates/application/templates/service.yaml
+++ b/internal/packagecmd/templates/application/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   type: ClusterIP
   selector:

--- a/internal/packagecmd/templates/application/templates/vpa.yaml
+++ b/internal/packagecmd/templates/application/templates/vpa.yaml
@@ -2,12 +2,12 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Application.Instance.Name }}-server
+    name: d8a-{{ .Application.Instance.Name }}-server
   updatePolicy:
     updateMode: Initial
   resourcePolicy:


### PR DESCRIPTION
## What

Port the `d8a-` resource-name reservation into `internal/packagecmd` — the copy of the `package` command compiled built-in into `d8`.

- `verify`'s `instance-prefix` rule now requires every rendered application object's name to start with `d8a-` (the reserved application marker) followed by the instance name, instead of the bare instance prefix.
- `bootstrap application` scaffold templates now emit `d8a-<instance>-...` resource names.

## Why

Objects created by Deckhouse applications must carry the reserved `d8a-` prefix so they are recognizable as platform-owned and do not collide with user resources. The same change already landed in the standalone `d8-package-plugin`. Because modern `d8` runs `d8 package` from this built-in `internal/packagecmd` copy (which shadows any installed `package` plugin), the reservation has to live here too — otherwise `d8 package verify` keeps rejecting `d8a-` names with the old message even after the plugin is updated.

Faithful mirror of the plugin change: `instance-prefix` const `test-` → `d8a-test-` (plus its diagnostic message) and the five scaffold templates. No behavior change beyond the prefix; labels/selectors are unchanged.
