### PR TITLE
[deckhouse-cli] Update built-in package command to v0.0.27

### DIFF
--- a/internal/packagecmd/internal/packages/definition.go
+++ b/internal/packagecmd/internal/packages/definition.go
@@ -37,6 +37,48 @@ type Definition struct {
 	Name       string `yaml:"name" json:"name"`
 
 	Descriptions Descriptions `yaml:"descriptions,omitempty" json:"descriptions,omitempty"`
+	Requirements Requirements `yaml:"requirements,omitempty" json:"requirements,omitempty"`
+}
+
+// Requirements are the platform and module dependencies the package declares.
+// It mirrors the contract deckhouse-controller enforces when the package is
+// installed; the plugin only checks that it is well-formed, since no cluster
+// exists at build time.
+type Requirements struct {
+	Kubernetes VersionConstraint   `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty"`
+	Deckhouse  VersionConstraint   `yaml:"deckhouse,omitempty" json:"deckhouse,omitempty"`
+	Modules    ModulesRequirements `yaml:"modules,omitempty" json:"modules,omitempty"`
+}
+
+// VersionConstraint wraps a semver constraint expression. Empty means "no constraint".
+type VersionConstraint struct {
+	Constraint string `yaml:"constraint,omitempty" json:"constraint,omitempty"`
+}
+
+// ModulesRequirements groups module dependencies by how they gate the package:
+//   - Mandatory: the module must be enabled;
+//   - Conditional: enforced only when the module is enabled;
+//   - AnyOf: at least one member of each group must be enabled;
+//   - NoneOf: no member of any group may be enabled.
+type ModulesRequirements struct {
+	Mandatory   []ModuleDependency `yaml:"mandatory,omitempty" json:"mandatory,omitempty"`
+	Conditional []ModuleDependency `yaml:"conditional,omitempty" json:"conditional,omitempty"`
+	AnyOf       []ModuleGroup      `yaml:"anyOf,omitempty" json:"anyOf,omitempty"`
+	NoneOf      []ModuleGroup      `yaml:"noneOf,omitempty" json:"noneOf,omitempty"`
+}
+
+// ModuleDependency is a named module dependency with an optional semver constraint.
+type ModuleDependency struct {
+	Name       string `yaml:"name" json:"name"`
+	Constraint string `yaml:"constraint,omitempty" json:"constraint,omitempty"`
+}
+
+// ModuleGroup is a named group of module dependencies, shared by the AnyOf and
+// NoneOf buckets. Name is required and identifies the group in diagnostics.
+type ModuleGroup struct {
+	Name        string             `yaml:"name" json:"name"`
+	Description string             `yaml:"description,omitempty" json:"description,omitempty"`
+	Modules     []ModuleDependency `yaml:"modules" json:"modules"`
 }
 
 // Descriptions holds localized description text for the package.

--- a/internal/packagecmd/internal/verify/lint/linters/requirements/linter.go
+++ b/internal/packagecmd/internal/verify/lint/linters/requirements/linter.go
@@ -1,0 +1,62 @@
+package requirements
+
+import (
+	"context"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/requirements/rules"
+)
+
+// LinterID is the stable identifier used to reference this linter in configuration and diagnostics.
+const LinterID = "requirements"
+
+// Config holds the package definition and settings required to construct a Linter.
+type Config struct {
+	Definition packages.Definition
+	Settings   LinterSettings
+}
+
+// LinterSettings combines the shared linter-level severity with the per-rule settings for this linter.
+type LinterSettings struct {
+	lint.LinterSettings
+	RulesSettings
+}
+
+// RulesSettings holds the severity configuration for each rule in the requirements linter.
+type RulesSettings struct {
+	ModuleGroups lint.RuleSettings
+	Constraints  lint.RuleSettings
+}
+
+// NewLinter constructs a Linter from cfg, scoping its diagnostics to this linter and capping severity at the configured level.
+func NewLinter(cfg Config, res *diag.Collector) *Linter {
+	return &Linter{
+		settings: cfg.Settings.RulesSettings,
+		config:   cfg,
+		collector: res.With(
+			diag.LinterID(LinterID),
+			diag.MaxLevel(cfg.Settings.LinterSettings.Impact)),
+	}
+}
+
+// Linter checks that the requirements declared in package.yaml are well-formed.
+// Only the shape is checked: whether the cluster actually satisfies them is
+// decided by deckhouse-controller at install time, and no cluster exists here.
+type Linter struct {
+	config   Config
+	settings RulesSettings
+
+	collector *diag.Collector
+}
+
+// Lint executes all requirements rules against the configured package definition.
+func (l *Linter) Lint(ctx context.Context) {
+	reqs := l.config.Definition.Requirements
+
+	rules.NewModuleGroupsRule(reqs.Modules,
+		l.collector.With(diag.MaxLevel(l.settings.ModuleGroups.Impact))).Check(ctx)
+	rules.NewConstraintsRule(reqs,
+		l.collector.With(diag.MaxLevel(l.settings.Constraints.Impact))).Check(ctx)
+}

--- a/internal/packagecmd/internal/verify/lint/linters/requirements/rules/constraints.go
+++ b/internal/packagecmd/internal/verify/lint/linters/requirements/rules/constraints.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
+)
+
+// Rule purpose: reject unparseable version constraints before the package is shipped.
+// Constraints inside anyOf/noneOf groups are covered by the module-groups rule.
+
+// ConstraintsRuleID is the stable identifier used to reference this rule in configuration.
+const ConstraintsRuleID = "constraints"
+
+// constraintsRule checks that the platform and flat module constraints are valid semver.
+type constraintsRule struct {
+	collector    *diag.Collector
+	requirements packages.Requirements
+}
+
+// NewConstraintsRule constructs a rule that validates the declared version constraints.
+func NewConstraintsRule(requirements packages.Requirements, collector *diag.Collector) *constraintsRule {
+	return &constraintsRule{
+		requirements: requirements,
+		collector:    collector.With(diag.RuleID(ConstraintsRuleID), diag.Path(packages.DefinitionFile)),
+	}
+}
+
+// Check validates the kubernetes, deckhouse, mandatory and conditional constraints.
+func (r *constraintsRule) Check(_ context.Context) {
+	r.checkConstraint("requirements.kubernetes.constraint", r.requirements.Kubernetes.Constraint)
+	r.checkConstraint("requirements.deckhouse.constraint", r.requirements.Deckhouse.Constraint)
+
+	for _, dep := range r.requirements.Modules.Mandatory {
+		r.checkConstraint(fmt.Sprintf("mandatory module %q", dep.Name), dep.Constraint)
+	}
+
+	for _, dep := range r.requirements.Modules.Conditional {
+		r.checkConstraint(fmt.Sprintf("conditional module %q", dep.Name), dep.Constraint)
+	}
+}
+
+// checkConstraint reports a finding when constraint is set but is not valid semver.
+// An empty constraint is allowed and means "any version".
+func (r *constraintsRule) checkConstraint(subject, constraint string) {
+	if constraint == "" {
+		return
+	}
+
+	if _, err := semver.NewConstraint(constraint); err != nil {
+		r.collector.With(diag.Value(constraint)).Error("%s: invalid version constraint", subject)
+	}
+}

--- a/internal/packagecmd/internal/verify/lint/linters/requirements/rules/module_groups.go
+++ b/internal/packagecmd/internal/verify/lint/linters/requirements/rules/module_groups.go
@@ -1,0 +1,160 @@
+package rules
+
+import (
+	"context"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
+)
+
+// Rule purpose: reject ill-formed anyOf/noneOf module groups before the package is
+// shipped, so the author sees the problem here rather than when the controller
+// rejects the package at install time.
+
+// ModuleGroupsRuleID is the stable identifier used to reference this rule in configuration.
+const ModuleGroupsRuleID = "module-groups"
+
+// moduleGroupsRule checks that anyOf/noneOf groups are well-formed and that no module
+// is declared in contradictory buckets.
+type moduleGroupsRule struct {
+	collector *diag.Collector
+	modules   packages.ModulesRequirements
+}
+
+// NewModuleGroupsRule constructs a rule that validates the anyOf/noneOf module groups.
+func NewModuleGroupsRule(modules packages.ModulesRequirements, collector *diag.Collector) *moduleGroupsRule {
+	return &moduleGroupsRule{
+		modules:   modules,
+		collector: collector.With(diag.RuleID(ModuleGroupsRuleID), diag.Path(packages.DefinitionFile)),
+	}
+}
+
+// Check validates both group buckets, then the collisions between all buckets.
+func (r *moduleGroupsRule) Check(_ context.Context) {
+	anyOf := r.checkBucket(r.modules.AnyOf, "anyOf")
+	noneOf := r.checkBucket(r.modules.NoneOf, "noneOf")
+
+	r.checkCollisions(anyOf, noneOf)
+}
+
+// checkBucket validates one bucket of groups and returns its members as
+// module name -> declaring group name, for the cross-bucket checks. The same
+// module in two distinct groups of one bucket is allowed.
+func (r *moduleGroupsRule) checkBucket(groups []packages.ModuleGroup, bucket string) map[string]string {
+	members := make(map[string]string)
+	seenGroups := make(map[string]struct{}, len(groups))
+
+	for i, group := range groups {
+		if group.Name == "" {
+			r.collector.Error("%s group [%d]: name is required", bucket, i)
+			continue
+		}
+
+		if _, dup := seenGroups[group.Name]; dup {
+			r.collector.With(diag.Value(group.Name)).
+				Error("%s group %q: duplicate group name", bucket, group.Name)
+
+			continue
+		}
+
+		seenGroups[group.Name] = struct{}{}
+
+		if len(group.Modules) == 0 {
+			r.collector.With(diag.Value(group.Name)).
+				Error("%s group %q: at least one module is required", bucket, group.Name)
+
+			continue
+		}
+
+		r.checkGroupModules(group, bucket, members)
+	}
+
+	return members
+}
+
+// checkGroupModules validates the modules of one group and records them in members.
+func (r *moduleGroupsRule) checkGroupModules(group packages.ModuleGroup, bucket string, members map[string]string) {
+	seen := make(map[string]struct{}, len(group.Modules))
+
+	for _, module := range group.Modules {
+		if module.Name == "" {
+			r.collector.With(diag.Value(group.Name)).
+				Error("%s group %q: module name is required", bucket, group.Name)
+
+			continue
+		}
+
+		if _, dup := seen[module.Name]; dup {
+			r.collector.With(diag.Value(module.Name)).
+				Error("%s group %q: duplicate module %q", bucket, group.Name, module.Name)
+
+			continue
+		}
+
+		seen[module.Name] = struct{}{}
+
+		if module.Constraint != "" {
+			if _, err := semver.NewConstraint(module.Constraint); err != nil {
+				r.collector.With(diag.Value(module.Constraint)).
+					Error("%s group %q module %q: invalid version constraint", bucket, group.Name, module.Name)
+			}
+		}
+
+		members[module.Name] = group.Name
+	}
+}
+
+// checkCollisions reports modules declared in contradictory buckets: a module cannot be
+// both required and forbidden, and a group member that is already an unconditional
+// dependency makes the group dead weight.
+func (r *moduleGroupsRule) checkCollisions(anyOf, noneOf map[string]string) {
+	mandatory := moduleNames(r.modules.Mandatory)
+	conditional := moduleNames(r.modules.Conditional)
+
+	for name := range conditional {
+		if _, dup := mandatory[name]; dup {
+			r.collector.With(diag.Value(name)).Error("module %q is both mandatory and conditional", name)
+		}
+	}
+
+	for name, group := range anyOf {
+		if _, dup := mandatory[name]; dup {
+			r.collector.With(diag.Value(name)).
+				Error("module %q is both mandatory and a member of anyOf group %q", name, group)
+		}
+
+		if _, dup := conditional[name]; dup {
+			r.collector.With(diag.Value(name)).
+				Error("module %q is both conditional and a member of anyOf group %q", name, group)
+		}
+	}
+
+	for name, group := range noneOf {
+		if _, dup := mandatory[name]; dup {
+			r.collector.With(diag.Value(name)).
+				Error("module %q is both mandatory and a member of noneOf group %q", name, group)
+		}
+
+		if _, dup := conditional[name]; dup {
+			r.collector.With(diag.Value(name)).
+				Error("module %q is both conditional and a member of noneOf group %q", name, group)
+		}
+
+		if anyGroup, dup := anyOf[name]; dup {
+			r.collector.With(diag.Value(name)).
+				Error("module %q is a member of both anyOf group %q and noneOf group %q", name, anyGroup, group)
+		}
+	}
+}
+
+// moduleNames collects the declared module names of a flat bucket.
+func moduleNames(deps []packages.ModuleDependency) map[string]struct{} {
+	out := make(map[string]struct{}, len(deps))
+	for _, dep := range deps {
+		out[dep.Name] = struct{}{}
+	}
+
+	return out
+}

--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
@@ -8,14 +8,17 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
 )
 
-// Rule purpose: require every rendered object's name to start with the application instance prefix so cluster resources are scoped to the instance.
+// Rule purpose: require every rendered object's name to start with the d8a- application
+// marker followed by the instance name, so cluster resources are recognizable as
+// Deckhouse-application-owned and scoped to the instance.
 
 // InstancePrefixRuleID is the stable identifier used to reference this rule in configuration.
 const InstancePrefixRuleID = "instance-prefix"
 
-// instancePrefix is the prefix every rendered object's name must start with.
-// It tracks the hardcoded verify-time instance name from internal/packages.Render.
-const instancePrefix = "test-"
+// instancePrefix is the prefix every rendered object's name must start with: the fixed
+// d8a- application marker plus the hardcoded verify-time instance name from
+// internal/packages.Render.
+const instancePrefix = "d8a-test-"
 
 // InstancePrefixRule asserts every rendered object's name starts with the instance prefix.
 type InstancePrefixRule struct {
@@ -42,6 +45,6 @@ func (r *InstancePrefixRule) Check(_ context.Context) {
 		r.collector.With(
 			diag.ObjectID(obj.ObjectID()),
 			diag.Path(obj.FilePath),
-		).Error("object name does not start with the instance prefix")
+		).Error("object name does not start with the required d8a- instance prefix")
 	}
 }

--- a/internal/packagecmd/internal/verify/lint/settings/load.go
+++ b/internal/packagecmd/internal/verify/lint/settings/load.go
@@ -15,6 +15,7 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/images"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/layout"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/oss"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/requirements"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/templates"
 )
 
@@ -35,6 +36,8 @@ type Root struct {
 	Icon icon.LinterSettings
 	// OSS contains runtime settings for the oss metadata linter.
 	OSS oss.LinterSettings
+	// Requirements contains runtime settings for the package requirements linter.
+	Requirements requirements.LinterSettings
 }
 
 // LoadRoot loads lint settings and returns runtime-ready linter settings.
@@ -91,6 +94,10 @@ func defaultLintersSettings() *Root {
 	r.OSS.RulesSettings.Fields.SetLevel("error", nil)
 	r.OSS.RulesSettings.Version.SetLevel("error", nil)
 
+	r.Requirements.Impact = lint.Error.Ptr()
+	r.Requirements.RulesSettings.ModuleGroups.SetLevel("error", nil)
+	r.Requirements.RulesSettings.Constraints.SetLevel("error", nil)
+
 	return r
 }
 
@@ -130,6 +137,10 @@ func remapLintersSettings(cfg Config) *Root {
 	r.OSS.RulesSettings.Parse.SetLevel(cfg.Linters.OSS.Rules.Parse.Impact, lint.Error.Ptr())
 	r.OSS.RulesSettings.Fields.SetLevel(cfg.Linters.OSS.Rules.Fields.Impact, lint.Error.Ptr())
 	r.OSS.RulesSettings.Version.SetLevel(cfg.Linters.OSS.Rules.Version.Impact, lint.Error.Ptr())
+
+	r.Requirements.SetLevel(cfg.Linters.Requirements.Impact)
+	r.Requirements.RulesSettings.ModuleGroups.SetLevel(cfg.Linters.Requirements.Rules.ModuleGroups.Impact, lint.Error.Ptr())
+	r.Requirements.RulesSettings.Constraints.SetLevel(cfg.Linters.Requirements.Rules.Constraints.Impact, lint.Error.Ptr())
 
 	return r
 }

--- a/internal/packagecmd/internal/verify/lint/settings/settings.go
+++ b/internal/packagecmd/internal/verify/lint/settings/settings.go
@@ -28,6 +28,9 @@ type LintersSettings struct {
 
 	// OSS contains settings for optional oss.yaml metadata checks.
 	OSS OSSSettings `mapstructure:"oss"`
+
+	// Requirements contains settings for package.yaml requirements checks.
+	Requirements RequirementsSettings `mapstructure:"requirements"`
 }
 
 // LayoutSettings configures the layout linter and its rules.
@@ -144,6 +147,23 @@ type OSSRulesSettings struct {
 	Fields RuleSettings `mapstructure:"fields"`
 	// Version configures checks for version and versions field usage.
 	Version RuleSettings `mapstructure:"version"`
+}
+
+// RequirementsSettings configures the requirements linter and its rules.
+type RequirementsSettings struct {
+	// Impact sets the maximum severity emitted by the requirements linter.
+	Impact string `mapstructure:"impact"`
+	// Rules contains per-rule requirements linter settings.
+	Rules RequirementsRulesSettings `mapstructure:"rules"`
+}
+
+// RequirementsRulesSettings configures individual requirements linter rules.
+type RequirementsRulesSettings struct {
+	// ModuleGroups configures checks that anyOf/noneOf module groups are well-formed
+	// and that no module lands in contradictory buckets.
+	ModuleGroups RuleSettings `mapstructure:"module-groups"`
+	// Constraints configures checks that declared version constraints are valid semver.
+	Constraints RuleSettings `mapstructure:"constraints"`
 }
 
 // RuleSettings configures a single rule.

--- a/internal/packagecmd/internal/verify/verify.go
+++ b/internal/packagecmd/internal/verify/verify.go
@@ -15,6 +15,7 @@ import (
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/images"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/layout"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/oss"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/requirements"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/linters/templates"
 	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/settings"
 )
@@ -135,6 +136,11 @@ func buildLinters(ctx context.Context, root *settings.Root, path string, collect
 		Path:     path,
 	}, collector)
 
+	requirementsLinter := requirements.NewLinter(requirements.Config{
+		Settings:   root.Requirements,
+		Definition: def,
+	}, collector)
+
 	return []linter{
 		layoutLinter,
 		templatesLinter,
@@ -142,5 +148,6 @@ func buildLinters(ctx context.Context, root *settings.Root, path string, collect
 		imagesLinter,
 		iconLinter,
 		ossLinter,
+		requirementsLinter,
 	}, nil
 }

--- a/internal/packagecmd/packagecmd.go
+++ b/internal/packagecmd/packagecmd.go
@@ -15,7 +15,7 @@ import (
 // entry point (cmd/package/main.go) and the "version" subcommand, whose value is
 // injected by the plugin's own ldflags. d8 reports its version itself.
 //
-// Vendored from d8-package-plugin v0.0.25 (4458426). Keep this in sync when
+// Vendored from d8-package-plugin v0.0.27 (97da2a0). Keep this in sync when
 // re-syncing internal/, pkg/ and templates/ from upstream.
 func NewCommand() *cobra.Command {
 	return pkgcmd.NewCmdRoot()

--- a/internal/packagecmd/templates/APPLICATION.md
+++ b/internal/packagecmd/templates/APPLICATION.md
@@ -37,7 +37,9 @@ templates/
 └── _helpers/              # хелперы — вызываются через include, сами ресурсов не создают
     ├── quantity_bytes.tpl
     ├── bytes_quantity.tpl
-    └── public_domain.tpl
+    ├── public_domain.tpl
+    ├── ingress_class.tpl
+    └── https.tpl
 ```
 
 Каждый `*.yaml` рендерится в Kubernetes-манифест. Файлы в `_helpers/` (по соглашению с префиксом `_`)
@@ -60,6 +62,8 @@ templates/
 | `.Application.Package.Images` | map «имя образа → ссылка»; доступ через `index … "<name>"` |
 | `.Application.Package.Registry.dockercfg` | dockerconfig для секрета доступа к реестру |
 | `.Platform.applications.publicDomainTemplate` | шаблон публичного FQDN (для хелпера `public_domain`) |
+| `.Platform.applications.ingressClass` | IngressClass для приложений (для хелпера `ingress_class`) |
+| `.Platform.applications.https` | политика HTTPS/TLS: `.mode`, `.certManager.clusterIssuerName` (для хелперов `https_*`) |
 | `.Capabilities.APIVersions.Has "<gvk>"` | есть ли данный API/CRD в кластере |
 
 > Поля `.Application.Settings.*` берутся из схемы `openapi/settings.yaml`: что объявлено там —
@@ -178,7 +182,7 @@ spec:
 
 Хелперы — именованные шаблоны (`{{ define "name" }}…{{ end }}`), вызываемые через
 `{{ include "name" аргумент }}`. Аргумент передаётся один; чтобы отдать несколько значений,
-собирают `list` или `dict`. В приложении доступны три хелпера.
+собирают `list` или `dict`. В приложении доступны следующие хелперы.
 
 ### `quantity_bytes` — quantity → байты
 
@@ -230,6 +234,41 @@ Kubernetes-quantity (строку) в целое число байт.
 - Если в шаблоне платформы не ровно три `%s` — прерывает рендер понятной ошибкой (`fail`).
 - **Для чего:** единообразно строить внешний адрес приложения (Ingress/ссылки), не хардкодя
   доменную схему в каждом манифесте.
+
+### `ingress_class` — IngressClass приложения
+
+[ingress_class.tpl](application/templates/_helpers/ingress_class.tpl) возвращает имя IngressClass,
+которое платформа задала для приложений экосистемы Deckhouse.
+
+```yaml
+ingressClassName: {{ include "ingress_class" . | quote }}
+```
+
+- Аргумент — контекст (`.`); берёт `.Platform.applications.ingressClass` (по умолчанию `nginx`).
+- **Для чего:** не хардкодить класс Ingress-контроллера в манифесте — берётся тот, что настроен в кластере.
+
+### `https_*` — TLS/HTTPS для Ingress
+
+[https.tpl](application/templates/_helpers/https.tpl) — семейство хелперов, читающих политику HTTPS
+платформы из `.Platform.applications.https`. Режимы: `Disabled`, `CertManager`, `CustomCertificate`,
+`OnlyInURI`.
+
+```yaml
+{{- if (include "https_ingress_tls_enabled" .) }}
+  tls:
+    - hosts: [ {{ .Application.Settings.ingress.host }} ]
+      secretName: {{ .Application.Instance.Name }}-ingress-tls
+{{- end }}
+```
+
+- `https_mode` — текущий режим (`.Platform.applications.https.mode`).
+- `https_ingress_tls_enabled` — непустая строка (истинна в `if`), когда для Ingress нужен TLS —
+  то есть в режимах `CertManager` и `CustomCertificate`.
+- `https_cert_manager_cluster_issuer_name` — имя ClusterIssuer cert-manager
+  (`.Platform.applications.https.certManager.clusterIssuerName`, по умолчанию `letsencrypt`) — для
+  аннотации `cert-manager.io/cluster-issuer` или ресурса `Certificate`.
+- **Для чего:** не хардкодить включение TLS и имя issuer в каждом манифесте — берётся политика HTTPS,
+  настроенная в кластере.
 
 
 ---

--- a/internal/packagecmd/templates/application/templates/_helpers/https.tpl
+++ b/internal/packagecmd/templates/application/templates/_helpers/https.tpl
@@ -1,0 +1,24 @@
+{{- /* Usage: {{ include "https_mode" . }} */ -}}
+{{- /* returns the HTTPS mode configured for Deckhouse ecosystem applications: */ -}}
+{{- /* Disabled | CertManager | CustomCertificate | OnlyInURI */ -}}
+{{- define "https_mode" -}}
+  {{- $context := . -}} {{- /* Template context with .Application, .Platform, etc */ -}}
+  {{- $context.Platform.applications.https.mode -}}
+{{- end -}}
+
+{{- /* Usage: {{ if (include "https_ingress_tls_enabled" .) }} */ -}}
+{{- /* returns a non-empty string when TLS should be enabled on the application Ingress */ -}}
+{{- define "https_ingress_tls_enabled" -}}
+  {{- $context := . -}} {{- /* Template context with .Application, .Platform, etc */ -}}
+  {{- $mode := include "https_mode" $context -}}
+  {{- if or (eq "CertManager" $mode) (eq "CustomCertificate" $mode) -}}
+    not empty string
+  {{- end -}}
+{{- end -}}
+
+{{- /* Usage: {{ include "https_cert_manager_cluster_issuer_name" . }} */ -}}
+{{- /* returns the cert-manager ClusterIssuer name for Deckhouse ecosystem applications */ -}}
+{{- define "https_cert_manager_cluster_issuer_name" -}}
+  {{- $context := . -}} {{- /* Template context with .Application, .Platform, etc */ -}}
+  {{- $context.Platform.applications.https.certManager.clusterIssuerName -}}
+{{- end -}}

--- a/internal/packagecmd/templates/application/templates/_helpers/ingress_class.tpl
+++ b/internal/packagecmd/templates/application/templates/_helpers/ingress_class.tpl
@@ -1,0 +1,6 @@
+{{- /* Usage: {{ include "ingress_class" . }} */ -}}
+{{- /* returns the IngressClass name configured for Deckhouse ecosystem applications */ -}}
+{{- define "ingress_class" -}}
+  {{- $context := . -}} {{- /* Template context with .Application, .Platform, etc */ -}}
+  {{- $context.Platform.applications.ingressClass -}}
+{{- end -}}

--- a/internal/packagecmd/templates/application/templates/deployment.yaml
+++ b/internal/packagecmd/templates/application/templates/deployment.yaml
@@ -6,7 +6,7 @@ memory: 70Mi
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   revisionHistoryLimit: 2
   replicas: {{ .Application.Settings.replicas | default 1 }}
@@ -26,7 +26,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       imagePullSecrets:
-        - name: {{ .Application.Instance.Name }}-registrysecret
+        - name: d8a-{{ .Application.Instance.Name }}-registrysecret
       containers:
         - name: server
           image: {{ index .Application.Package.Images "echo" }}

--- a/internal/packagecmd/templates/application/templates/pdb.yaml
+++ b/internal/packagecmd/templates/application/templates/pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   minAvailable: 1
   selector:

--- a/internal/packagecmd/templates/application/templates/registry-secret.yaml
+++ b/internal/packagecmd/templates/application/templates/registry-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Application.Instance.Name }}-registrysecret
+  name: d8a-{{ .Application.Instance.Name }}-registrysecret
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Application.Package.Registry.dockercfg }}

--- a/internal/packagecmd/templates/application/templates/service.yaml
+++ b/internal/packagecmd/templates/application/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   type: ClusterIP
   selector:

--- a/internal/packagecmd/templates/application/templates/vpa.yaml
+++ b/internal/packagecmd/templates/application/templates/vpa.yaml
@@ -2,12 +2,12 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ .Application.Instance.Name }}-server
+  name: d8a-{{ .Application.Instance.Name }}-server
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Application.Instance.Name }}-server
+    name: d8a-{{ .Application.Instance.Name }}-server
   updatePolicy:
     updateMode: Initial
   resourcePolicy:


### PR DESCRIPTION
# Summary

This syncs the vendored copy from upstream v0.0.25 to v0.0.27: 
- TLS and IngressClass template helpers
- a new `requirements` linter in `verify`
- the `d8a-` prefix for application resource names. 


The mirrored tree now matches upstream byte for byte, except `pkg/cmd/cmd.go`, which drops the plugin-only `version` subcommand.

# Breaking

⚠️ **Breaking:** _names of rendered objects must now start with_ `d8a-`, so an existing application package that names resources `{{ .Application.Instance.Name }}-server` starts failing `d8 package verify`.

