### PR TITLE
[deckhouse-cli] fix macOS SIGKILL by installing the binary atomically

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -383,14 +383,21 @@ install_binary() {
     esac
   fi
   
+  # Install via temp file + rename: the binary must land under the final name
+  # with a fresh inode, or macOS SIGKILLs it on exec (stale kernel
+  # code-signing cache after an in-place overwrite). rm guards against a
+  # leftover temp file: cp over it would keep its inode.
+  tmp_path="${target_path}.tmp.$$"
+
   # Check if we need sudo to install
   if [ ! -w "$INSTALL_DIR" ]; then
     if user_can_sudo; then
       fmt_info "Installing ${BINARY_NAME} to ${target_path} (requires sudo)..."
       sudo mkdir -p "$INSTALL_DIR"
-      sudo cp "$binary_path" "${target_path}.tmp.$$"
-      sudo chmod +x "${target_path}.tmp.$$"
-      sudo mv -f "${target_path}.tmp.$$" "$target_path"
+      sudo rm -f "$tmp_path"
+      sudo cp "$binary_path" "$tmp_path"
+      sudo chmod +x "$tmp_path"
+      sudo mv -f "$tmp_path" "$target_path"
     else
       fmt_error "Cannot write to ${INSTALL_DIR} and sudo is not available"
       fmt_error "Please run with sudo or choose a different installation directory"
@@ -399,9 +406,10 @@ install_binary() {
   else
     fmt_info "Installing ${BINARY_NAME} to ${target_path}..."
     mkdir -p "$INSTALL_DIR"
-    cp "$binary_path" "${target_path}.tmp.$$"
-    chmod +x "${target_path}.tmp.$$"
-    mv -f "${target_path}.tmp.$$" "$target_path"
+    rm -f "$tmp_path"
+    cp "$binary_path" "$tmp_path"
+    chmod +x "$tmp_path"
+    mv -f "$tmp_path" "$target_path"
   fi
   
   fmt_success "${BINARY_NAME} installed successfully!"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -388,8 +388,9 @@ install_binary() {
     if user_can_sudo; then
       fmt_info "Installing ${BINARY_NAME} to ${target_path} (requires sudo)..."
       sudo mkdir -p "$INSTALL_DIR"
-      sudo cp "$binary_path" "$target_path"
-      sudo chmod +x "$target_path"
+      sudo cp "$binary_path" "${target_path}.tmp.$$"
+      sudo chmod +x "${target_path}.tmp.$$"
+      sudo mv -f "${target_path}.tmp.$$" "$target_path"
     else
       fmt_error "Cannot write to ${INSTALL_DIR} and sudo is not available"
       fmt_error "Please run with sudo or choose a different installation directory"
@@ -398,8 +399,9 @@ install_binary() {
   else
     fmt_info "Installing ${BINARY_NAME} to ${target_path}..."
     mkdir -p "$INSTALL_DIR"
-    cp "$binary_path" "$target_path"
-    chmod +x "$target_path"
+    cp "$binary_path" "${target_path}.tmp.$$"
+    chmod +x "${target_path}.tmp.$$"
+    mv -f "${target_path}.tmp.$$" "$target_path"
   fi
   
   fmt_success "${BINARY_NAME} installed successfully!"


### PR DESCRIPTION
## Problem

On macOS (Apple Silicon), after the installer reinstalls/updates `d8`, the binary is killed with `SIGKILL` on every invocation, before any output:

```
$ d8 --version
fish: Job 1, 'd8 --version' terminated by signal SIGKILL (Forced quit)
$ d8            # from bash
Killed: 9       d8
```

`codesign --verify --deep --strict` on the installed binary **passes**, and a byte-for-byte copy of the same file at a different path runs fine — so the binary and its ad-hoc signature are intact. The kill comes from the kernel code-signing subsystem (AMFI), not Gatekeeper (no dialog) or an EDR (none present).

## Root cause

`install_binary` places the binary with `cp "$binary_path" "$target_path"` over an **existing** target. `cp` onto an existing path is `open(O_TRUNC)+write` — it **keeps the same inode**. When updating in place, the kernel still holds the code-signing validation cached for the *previous* contents of that vnode; the new pages no longer match → `cs_invalid` → AMFI sends `SIGKILL` on exec. `codesign --verify` still passes because it checks the on-disk seal, not the kernel's cached state.

A fresh inode (via `rename()`) has no stale cache, which is why copying the file elsewhere makes it run.

## Fix

Copy to a temporary file next to the target and `mv -f` it into place — an atomic `rename()`, so the new binary always gets a fresh inode. Applied to both the sudo and non-sudo paths.

## Testing

- `sh -n tools/install.sh` — syntax OK.
- Reproduced the SIGKILL with an in-place `cp` overwrite; confirmed the installed binary runs after the atomic-replace path.