### PR TITLE
[deckhouse-cli] bump release channels to v0.33.6

### DIFF
--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -2,6 +2,6 @@ groups:
   - name: "0"
     channels:
       - name: ea
-        version: 0.32.1
+        version: 0.33.6
       - name: stable
-        version: 0.32.1
+        version: 0.33.6


### PR DESCRIPTION
## Summary

Bumps the ea and stable trdl release channels from v0.32.1 to v0.33.6 so installs via trdl get the new release.

