### PR TITLE
[deckhouse-cli] bump release channels to 0.33.7

### DIFF
--- a/trdl_channels.yaml
+++ b/trdl_channels.yaml
@@ -2,6 +2,6 @@ groups:
   - name: "0"
     channels:
       - name: ea
-        version: 0.33.6
+        version: 0.33.7
       - name: stable
-        version: 0.33.6
+        version: 0.33.7


### PR DESCRIPTION
Bump release channels from `0.33.6` -> `0.33.7`