### PR TITLE
[deckhouse-cli] Fix RPP access docs and the TLS flag that could not help

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -141,7 +141,7 @@ The persistent flags above are shared by every `d8 plugins` subcommand; the
 | Symptom | Cause | Fix |
 |---|---|---|
 | `image or tag not found` (404) | that plugin - or that specific version - is not published in this cluster's registry | check with `d8 plugins versions <name>`; publishing is the plugin CI's job |
-| `... unauthorized (401)` | no accepted Bearer token (a client-certificate kubeconfig is not enough) | use an OIDC-token kubeconfig (Kubeconfig Generator or `d8 login`) |
+| `... unauthorized (401)` | no accepted Bearer token (a client-certificate kubeconfig is not enough) | use an OIDC-token kubeconfig (Deckhouse console or `d8 login`) |
 | `... forbidden (403)` | your identity may not download plugins | ask an admin to bind the ClusterRole `d8:registry-packages-proxy:cli-download`; a denial is cached for 30 seconds, so retry in half a minute |
 | `... requirements not satisfied` | mandatory **plugin** dependencies are missing or version-incompatible | run `d8 plugins contract <name>`; on `install` deps auto-install, but at plugin *run* time install them manually as the hint says (`d8 plugins install <dep>`) |
 | `... requires Kubernetes/Deckhouse/module ...` | a **cluster-side** requirement is unmet (a different message from the row above) | upgrade the cluster/module, or pass `--skip-cluster-checks` to bypass verification |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -128,7 +128,7 @@ modules) are only *verified* - d8 never changes the cluster for you.
 | `--skip-cluster-checks` | `D8_PLUGINS_SKIP_CLUSTER_CHECKS=1` | skip cluster-side requirement checks |
 | `--rpp-endpoint` | `D8_RPP_ENDPOINT` | proxy base URL; discovered from the cluster when empty |
 | `--rpp-ca-file` | `D8_RPP_CA_FILE` | PEM CA bundle to verify the proxy TLS certificate |
-| `--rpp-insecure-skip-tls-verify` | - | skip proxy TLS verification (debugging only) |
+| `--insecure-skip-tls-verify` | - | skip TLS verification of both the API server and the proxy (debugging only) |
 | `--version X` *(install only)* | - | install an exact version; may be a pre-release |
 | `--use-major N` *(install, update)* | - | cross to major `N`; by default operations stay within the installed major |
 | `--force` *(install only)* | - | reinstall even if already current (re-pull and re-verify) |
@@ -146,7 +146,7 @@ The persistent flags above are shared by every `d8 plugins` subcommand; the
 | `... requirements not satisfied` | mandatory **plugin** dependencies are missing or version-incompatible | run `d8 plugins contract <name>`; on `install` deps auto-install, but at plugin *run* time install them manually as the hint says (`d8 plugins install <dep>`) |
 | `... requires Kubernetes/Deckhouse/module ...` | a **cluster-side** requirement is unmet (a different message from the row above) | upgrade the cluster/module, or pass `--skip-cluster-checks` to bypass verification |
 | `... upstream error (5xx)` | the proxy could not reach the backing registry | retry shortly, or check the `registry-packages-proxy` pods in `d8-cloud-instance-manager` |
-| `endpoint discovery ... failed`, `x509:` to the API server | endpoint discovery goes through your kubeconfig's **API server** (not the proxy), which was unreachable or had an invalid certificate | confirm the API server is reachable with a valid cert, or skip discovery with `--rpp-endpoint https://registry-packages-proxy.<domain>` (`D8_RPP_ENDPOINT`) |
+| `endpoint discovery ... failed`, `x509:` to the API server | endpoint discovery goes through your kubeconfig's **API server** (not the proxy), which was unreachable or had an invalid certificate | confirm the API server is reachable with a valid cert. To get through meanwhile: `--insecure-skip-tls-verify` for a bad certificate, or `--rpp-endpoint https://registry-packages-proxy.<domain>` (`D8_RPP_ENDPOINT`) to skip discovery altogether |
 | `cannot reach the cluster to ...` | the cluster is needed to verify requirements or select a version, but is unreachable | pass `--skip-cluster-checks` (`D8_PLUGINS_SKIP_CLUSTER_CHECKS=1`) |
 
 The access model is shared with d8 self-update; see
@@ -165,5 +165,3 @@ prefer the proxy flow above.
   (a shortcut for `--source-login=license-token`), or your
   `~/.docker/config.json` - in that order. `--tls-skip-verify` and `--insecure`
   relax TLS / allow HTTP for that registry.
-- `--rpp-insecure-skip-tls-verify` skips registry-packages-proxy TLS
-  verification (debugging only).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -33,6 +33,10 @@ cluster and is not the intended flow.) The access model:
   with `--rpp-endpoint` / `D8_RPP_ENDPOINT`, pass a private CA with
   `--rpp-ca-file`.
 
+Starting from scratch? Follow
+[self-update.md - Getting started](self-update.md#getting-started): the same
+kubeconfig and the same grant work for plugins.
+
 The access model is the same as for d8 self-update (see
 [self-update.md - How access works](self-update.md#how-access-works) for the
 OIDC-kubeconfig and endpoint-discovery details), down to the ClusterRole:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,17 +25,21 @@ cluster and is not the intended flow.) The access model:
 - Authentication: the **Bearer token** from your kubeconfig (client
   certificates do not work).
 - Authorization: the ClusterRole
-  `d8:registry-packages-proxy:packages-download`, bound by the cluster
-  administrator. Authorization is cached for about 5 minutes, so after the
-  binding is created, retry with a fresh token.
-- Endpoint: discovered automatically through your kubeconfig's API server;
-  override with `--rpp-endpoint` / `D8_RPP_ENDPOINT`, pass a private CA with
+  `d8:registry-packages-proxy:cli-download`, bound by the cluster
+  administrator. A denial is cached for 30 seconds, so a `403` caught before
+  the binding existed clears in half a minute.
+- Endpoint: discovered automatically through your kubeconfig's API server,
+  which also needs `get` on the `registry-packages-proxy` Ingress; override
+  with `--rpp-endpoint` / `D8_RPP_ENDPOINT`, pass a private CA with
   `--rpp-ca-file`.
 
-The access model is shared with d8 self-update (see
+The access model is the same as for d8 self-update (see
 [self-update.md - How access works](self-update.md#how-access-works) for the
-OIDC-kubeconfig and endpoint-discovery details), but the ClusterRole differs:
-plugins need `packages-download`, CLI self-update needs `cli-download`.
+OIDC-kubeconfig and endpoint-discovery details), down to the ClusterRole:
+plugins are published under `deckhouse-cli/plugins/<name>` and travel the same
+`/v1/images/` route, so `cli-download` covers both. The administrator grants it
+as described in
+[Granting access to CLI downloads](/products/kubernetes-platform/documentation/v1/modules/registry-packages-proxy/#granting-access-to-cli-downloads).
 
 ## Commands
 
@@ -134,7 +138,7 @@ The persistent flags above are shared by every `d8 plugins` subcommand; the
 |---|---|---|
 | `image or tag not found` (404) | that plugin - or that specific version - is not published in this cluster's registry | check with `d8 plugins versions <name>`; publishing is the plugin CI's job |
 | `... unauthorized (401)` | no accepted Bearer token (a client-certificate kubeconfig is not enough) | use an OIDC-token kubeconfig (Kubeconfig Generator or `d8 login`) |
-| `... forbidden (403)` | your identity may not download plugins | ask an admin to bind the ClusterRole `d8:registry-packages-proxy:packages-download`; authorization is cached ~5 min, so retry with a fresh token |
+| `... forbidden (403)` | your identity may not download plugins | ask an admin to bind the ClusterRole `d8:registry-packages-proxy:cli-download`; a denial is cached for 30 seconds, so retry in half a minute |
 | `... requirements not satisfied` | mandatory **plugin** dependencies are missing or version-incompatible | run `d8 plugins contract <name>`; on `install` deps auto-install, but at plugin *run* time install them manually as the hint says (`d8 plugins install <dep>`) |
 | `... requires Kubernetes/Deckhouse/module ...` | a **cluster-side** requirement is unmet (a different message from the row above) | upgrade the cluster/module, or pass `--skip-cluster-checks` to bypass verification |
 | `... upstream error (5xx)` | the proxy could not reach the backing registry | retry shortly, or check the `registry-packages-proxy` pods in `d8-cloud-instance-manager` |

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -41,15 +41,18 @@ cluster registry (credentials live only inside the cluster)
 
 ### Authorization
 
-Download permission is the ClusterRole
-`d8:registry-packages-proxy:cli-download`. By default it is bound to
-**nobody** - the administrator decides who may download:
+You need two permissions, and by default neither is bound to anyone - the
+administrator grants them:
 
-```bash
-kubectl create clusterrolebinding d8-cli-download \
-  --clusterrole=d8:registry-packages-proxy:cli-download \
-  --group=<your-operators-group>   # or --user=... / --serviceaccount=...
-```
+- Downloading: the ClusterRole `d8:registry-packages-proxy:cli-download`. The
+  same role covers `d8 plugins`.
+- Endpoint discovery: `get` on the `registry-packages-proxy` Ingress in
+  `d8-cloud-instance-manager`. Without it, pass `--rpp-endpoint` by hand.
+
+The proxy caches a denial for 30 seconds, so a `403` caught before the binding
+existed clears in half a minute. See
+[Granting access to CLI downloads](/products/kubernetes-platform/documentation/v1/modules/registry-packages-proxy/#granting-access-to-cli-downloads)
+for the commands.
 
 ### Endpoint
 
@@ -136,7 +139,7 @@ $ d8 cli use v0.13.0            # repeated: "deckhouse-cli is already at v0.13.0
 |---|---|---|
 | `... unauthorized` (401) | no token in kubeconfig, or a client-certificate identity | use an OIDC kubeconfig from the Kubeconfig Generator |
 | `... forbidden` (403) | the `cli-download` role is not bound to you | ask the administrator for the ClusterRoleBinding |
-| 403 right after the role was bound | the proxy caches authorization for ~5 min per token | retry with a fresh token or wait 5 minutes |
+| 403 right after the role was bound | the proxy caches a denial for 30 seconds | retry in half a minute |
 | `x509: certificate signed by unknown authority` | the proxy endpoint uses a CA your system does not trust | pass `--rpp-ca-file <ca.pem>` |
 | `x509: ... doesn't contain any IP SANs` | you are connecting to a pod IP instead of the Ingress host | set `--rpp-endpoint https://registry-packages-proxy.<publicDomain>` |
 | `deckhouse-cli is already up to date` | you run the latest version | use `--version X` to install an exact (older) one |

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -168,7 +168,11 @@ $ d8 cli use v0.13.0            # repeated: "deckhouse-cli is already at v0.13.0
 | `--kubeconfig`, `-k` / `--context` | `KUBECONFIG` | cluster identity (the Bearer token source) |
 | `--rpp-endpoint` | `D8_RPP_ENDPOINT` | proxy base URL; discovered from the cluster when empty |
 | `--rpp-ca-file` | `D8_RPP_CA_FILE` | PEM CA bundle to verify the proxy TLS certificate |
-| `--rpp-insecure-skip-tls-verify` | - | skip proxy TLS verification (debugging only) |
+| `--insecure-skip-tls-verify` | - | skip TLS verification of both the API server and the proxy (debugging only) |
+
+`d8 cli` opens two TLS connections, each verified on its own: one to the
+Kubernetes API server to find the proxy, one to the proxy to download.
+`--insecure-skip-tls-verify` covers both.
 
 ## Troubleshooting
 
@@ -178,6 +182,7 @@ $ d8 cli use v0.13.0            # repeated: "deckhouse-cli is already at v0.13.0
 | `... forbidden` (403) | the `cli-download` role is not bound to you | ask the administrator for the ClusterRoleBinding |
 | 403 right after the role was bound | the proxy caches a denial for 30 seconds | retry in half a minute |
 | `x509: certificate signed by unknown authority` | the proxy endpoint uses a CA your system does not trust | pass `--rpp-ca-file <ca.pem>` |
+| `endpoint discovery ... x509:` naming the API server host | the API server certificate is untrusted, expired or replaced by the ingress fallback | fix the cluster certificate, or pass `--insecure-skip-tls-verify` to get through meanwhile |
 | `x509: ... doesn't contain any IP SANs` | you are connecting to a pod IP instead of the Ingress host | set `--rpp-endpoint https://registry-packages-proxy.<publicDomain>` |
 | `deckhouse-cli is already up to date` | you run the latest version | use `--version X` to install an exact (older) one |
 | `d8 cli use X` downloads although X was installed before | the local store was cleaned, or X was installed on another machine/user | it will download once and stay installed |

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -8,7 +8,8 @@
 - The cluster administrator grants (and revokes) download permission with a
   regular RBAC binding.
 
-**Contents:** [Access](#how-access-works) · [Commands](#commands) ·
+**Contents:** [Getting started](#getting-started) ·
+[Access](#how-access-works) · [Commands](#commands) ·
 [Version store](#how-versions-are-stored) ·
 [Switching & rollback](#switching-and-rollback) ·
 [Flags & env](#flags-and-environment-variables) ·
@@ -16,6 +17,42 @@
 
 > Plugin management (`d8 plugins`) uses the same access model and is covered
 > in [plugins.md](plugins.md).
+
+## Getting started
+
+You need a kubeconfig with a Bearer token and two permissions on the cluster.
+You do not need access to master nodes.
+
+1. Ask an administrator for access. They bind one ClusterRole and one read
+   permission, both described in
+   [Granting access to CLI downloads](/products/kubernetes-platform/documentation/v1/modules/registry-packages-proxy/#granting-access-to-cli-downloads).
+   The same grant also covers `d8 plugins`.
+
+1. Get a personal kubeconfig from the Kubeconfig Generator at
+   `https://kubeconfig.<publicDomain>`. Log in, copy the raw config and save it:
+
+   ```bash
+   KCFG=/tmp/d8-kubeconfig
+   cat > "$KCFG" <<'EOF'
+   <paste the kubeconfig here>
+   EOF
+   ```
+
+1. Check that it works:
+
+   ```bash
+   d8 cli check --kubeconfig "$KCFG"
+   ```
+
+   `up to date` or a newer version means access is fine. On `403`, the role is
+   not bound yet - retry in half a minute, then ask the administrator.
+
+1. Use it. Set `KUBECONFIG` once and drop the flag:
+
+   ```bash
+   export KUBECONFIG="$KCFG"
+   d8 cli update
+   ```
 
 ## How access works
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -20,39 +20,32 @@
 
 ## Getting started
 
-You need a kubeconfig with a Bearer token and two permissions on the cluster.
-You do not need access to master nodes.
+You need a kubeconfig that authenticates with a **Bearer token**, and an identity
+that holds two permissions on the cluster. Access to master nodes is not needed.
 
-1. Ask an administrator for access. They bind one ClusterRole and one read
-   permission, both described in
+1. Ask an administrator to grant your user or group access. They bind one
+   ClusterRole and one read permission, both described in
    [Granting access to CLI downloads](/products/kubernetes-platform/documentation/v1/modules/registry-packages-proxy/#granting-access-to-cli-downloads).
    The same grant also covers `d8 plugins`.
 
-1. Get a personal kubeconfig from the Kubeconfig Generator at
-   `https://kubeconfig.<publicDomain>`. Log in, copy the raw config and save it:
-
-   ```bash
-   KCFG=/tmp/d8-kubeconfig
-   cat > "$KCFG" <<'EOF'
-   <paste the kubeconfig here>
-   EOF
-   ```
+1. Use the kubeconfig you already use for `kubectl`, as long as it carries a
+   token. A client-certificate config - the `kubernetes-admin` one on a master
+   node, for example - is rejected by the proxy. Without a token, get a personal
+   kubeconfig from the Kubeconfig Generator at `https://kubeconfig.<publicDomain>`.
 
 1. Check that it works:
 
    ```bash
-   d8 cli check --kubeconfig "$KCFG"
+   d8 cli check
    ```
 
-   `up to date` or a newer version means access is fine. On `403`, the role is
-   not bound yet - retry in half a minute, then ask the administrator.
+   `up to date`, or a newer version being offered, means access is fine. On
+   `403` the role is not bound yet - retry in half a minute, then ask the
+   administrator.
 
-1. Use it. Set `KUBECONFIG` once and drop the flag:
-
-   ```bash
-   export KUBECONFIG="$KCFG"
-   d8 cli update
-   ```
+`d8` picks up `KUBECONFIG` (or the default `~/.kube/config`) the same way
+`kubectl` does. Point it at another file with `--kubeconfig`, or select a
+context with `--context`.
 
 ## How access works
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -31,7 +31,7 @@ that holds two permissions on the cluster. Access to master nodes is not needed.
 1. Use the kubeconfig you already use for `kubectl`, as long as it carries a
    token. A client-certificate config - the `kubernetes-admin` one on a master
    node, for example - is rejected by the proxy. Without a token, get a personal
-   kubeconfig from the Kubeconfig Generator at `https://kubeconfig.<publicDomain>`.
+   kubeconfig from the Deckhouse console at `https://console.<publicDomain>`.
 
 1. Check that it works:
 
@@ -66,8 +66,9 @@ cluster registry (credentials live only inside the cluster)
   `kubernetes-admin` config on master nodes).
 
 > [!TIP]
-> Get a personal OIDC kubeconfig from your cluster's Kubeconfig Generator:
-> `https://kubeconfig.<publicDomain>`.
+> Get a personal OIDC kubeconfig from the Deckhouse console:
+> `https://console.<publicDomain>`. Clusters without the console module serve
+> the standalone generator at `https://kubeconfig.<publicDomain>` instead.
 
 ### Authorization
 
@@ -171,7 +172,7 @@ Kubernetes API server to find the proxy, one to the proxy to download.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `... unauthorized` (401) | no token in kubeconfig, or a client-certificate identity | use an OIDC kubeconfig from the Kubeconfig Generator |
+| `... unauthorized` (401) | no token in kubeconfig, or a client-certificate identity | use an OIDC kubeconfig from the Deckhouse console |
 | `... forbidden` (403) | the `cli-download` role is not bound to you | ask the administrator for the ClusterRoleBinding |
 | 403 right after the role was bound | the proxy caches a denial for 30 seconds | retry in half a minute |
 | `x509: certificate signed by unknown authority` | the proxy endpoint uses a CA your system does not trust | pass `--rpp-ca-file <ca.pem>` |

--- a/internal/plugins/README.md
+++ b/internal/plugins/README.md
@@ -153,7 +153,8 @@ A failure at any step leaves the previous version installed and working.
 |---|---|
 | install root | `--plugins-dir` / `DECKHOUSE_CLI_PATH` |
 | identity (rpp + cluster checks) | `-k/--kubeconfig`, `--context` |
-| RPP endpoint / TLS | `--rpp-endpoint`, `--rpp-ca-file`, `--rpp-insecure-skip-tls-verify` |
+| RPP endpoint / TLS | `--rpp-endpoint`, `--rpp-ca-file` |
+| skip TLS verification on both legs (API server and proxy) | `--insecure-skip-tls-verify` |
 | skip cluster-side requirement checks | `--skip-cluster-checks` / `D8_PLUGINS_SKIP_CLUSTER_CHECKS=1` |
 
 ## Boundaries and deliberate decisions

--- a/internal/plugins/README.md
+++ b/internal/plugins/README.md
@@ -39,8 +39,9 @@ The `pluginSource` interface (`source.go`) has two implementations, chosen in
   side (ADR #386: deckhouse-cli reaches the registry exclusively through the
   proxy, so every command needs a reachable cluster). See
   `internal/selfupdate/README.md` for what RPP is and how authorization works -
-  plugin download is gated by the `d8:registry-packages-proxy:packages-download`
-  ClusterRole, distinct from self-update's `cli-download`. The plugin routes are
+  plugin download is gated by the same `d8:registry-packages-proxy:cli-download`
+  ClusterRole as self-update, because both travel the `/v1/images/` route. The
+  plugin routes are
   `/v1/images/deckhouse-cli/plugins/<name>/{tags,manifests/<ref>,images/<version>}`.
 - **`registryPluginSource` (`source_legacy.go`) - a temporary, hidden `--source`
   bypass.** It pulls straight from a registry repo with go-containerregistry,

--- a/internal/plugins/cmd/errdetect/diagnose.go
+++ b/internal/plugins/cmd/errdetect/diagnose.go
@@ -56,6 +56,7 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 		return help(err, "registry-packages-proxy: endpoint discovery via the Kubernetes API failed",
 			"discovery reaches the proxy through your kubeconfig's API server, which was unreachable or presented an invalid certificate",
 			"this is the Kubernetes API endpoint (kubeconfig 'server:'), not the proxy - confirm it is reachable and its TLS certificate is valid for that host",
+			"accept the certificate anyway: pass --insecure-skip-tls-verify",
 			"skip discovery: pass --rpp-endpoint https://registry-packages-proxy.<publicDomain> (or set D8_RPP_ENDPOINT)",
 			"on a master node, point the kubeconfig at the local API (https://127.0.0.1:6445, CA /etc/kubernetes/pki/ca.crt) with an OIDC token")
 	default:

--- a/internal/plugins/init.go
+++ b/internal/plugins/init.go
@@ -37,7 +37,8 @@ func (m *Manager) InitPluginServices(ctx context.Context) error {
 		return m.initLegacyRegistrySource()
 	}
 
-	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(d8flags.Kubeconfig, d8flags.KubeContext)
+	restConfig, kubeCl, err := utilk8s.SetupK8sClientSet(d8flags.Kubeconfig, d8flags.KubeContext,
+		utilk8s.WithInsecureSkipTLSVerify(rppflags.InsecureSkipTLSVerify))
 	if err != nil {
 		return fmt.Errorf("set up kubernetes client: %w", err)
 	}

--- a/internal/plugins/validators.go
+++ b/internal/plugins/validators.go
@@ -35,6 +35,7 @@ import (
 	d8flags "github.com/deckhouse/deckhouse-cli/internal/plugins/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/plugins/layout"
 	"github.com/deckhouse/deckhouse-cli/internal/plugins/requirements"
+	rppflags "github.com/deckhouse/deckhouse-cli/internal/rpp/flags"
 	"github.com/deckhouse/deckhouse-cli/internal/utilk8s"
 	"github.com/deckhouse/deckhouse-cli/pkg/diagnostic"
 	"github.com/deckhouse/deckhouse-cli/pkg/registry/service"
@@ -345,7 +346,8 @@ func (m *Manager) clusterState(ctx context.Context) (*requirements.ClusterState,
 		return m.clusterStateCache, nil
 	}
 
-	restConfig, _, err := utilk8s.SetupK8sClientSet(d8flags.Kubeconfig, d8flags.KubeContext)
+	restConfig, _, err := utilk8s.SetupK8sClientSet(d8flags.Kubeconfig, d8flags.KubeContext,
+		utilk8s.WithInsecureSkipTLSVerify(rppflags.InsecureSkipTLSVerify))
 	if err != nil {
 		return nil, fmt.Errorf("set up kubernetes client: %w", err)
 	}

--- a/internal/rpp/connect.go
+++ b/internal/rpp/connect.go
@@ -53,7 +53,7 @@ func NewClusterClient(
 			// cluster network, and its certificate carries no IP SANs - say so
 			// before the connection fails with an opaque TLS/timeout error.
 			logger.Debug("no registry-packages-proxy Ingress found; the pod endpoint is reachable " +
-				"only from the cluster network and needs --rpp-insecure-skip-tls-verify (or pass --rpp-endpoint)")
+				"only from the cluster network and needs --insecure-skip-tls-verify (or pass --rpp-endpoint)")
 		}
 
 		endpoint = discovered

--- a/internal/rpp/endpoint.go
+++ b/internal/rpp/endpoint.go
@@ -57,7 +57,7 @@ var errIngressUnusable = errors.New("registry-packages-proxy ingress unusable")
 // chooseDiscoveredEndpoint resolves the proxy endpoint when none was given
 // explicitly. It PREFERS the public Ingress (a valid TLS certificate, reachable
 // from a workstation) and falls back to in-cluster pod IPs (which need
-// --rpp-insecure-skip-tls-verify and cluster-network reachability). The second
+// --insecure-skip-tls-verify and cluster-network reachability). The second
 // return value names the source ("ingress" / "pod") for logging.
 //
 // Only an unusable Ingress (see errIngressUnusable) triggers the pod fallback.

--- a/internal/rpp/flags/flags.go
+++ b/internal/rpp/flags/flags.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 // Package flags declares the CLI flags and environment defaults for reaching the
 // registry-packages-proxy.
+//
+// Reaching the proxy means two separate TLS connections, each with its own trust
+// decision, so each has its own switch:
+//   - the Kubernetes API server, asked where the proxy lives (endpoint discovery);
+//   - the proxy itself, which serves the artifacts.
 package flags
 
 import (
@@ -39,7 +44,8 @@ var (
 	// in addition to the system roots.
 	CAFile = os.Getenv(EnvCAFile)
 
-	// InsecureSkipTLSVerify disables proxy TLS verification (debugging only).
+	// InsecureSkipTLSVerify disables TLS verification on both connections d8 makes:
+	// to the API server and to the proxy (debugging only).
 	InsecureSkipTLSVerify bool
 )
 
@@ -59,8 +65,8 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	)
 	flagSet.BoolVar(
 		&InsecureSkipTLSVerify,
-		"rpp-insecure-skip-tls-verify",
+		"insecure-skip-tls-verify",
 		false,
-		"Skip registry-packages-proxy TLS verification. For debugging only.",
+		"Skip TLS verification of both the Kubernetes API server and registry-packages-proxy certificates. For debugging only.",
 	)
 }

--- a/internal/selfupdate/README.md
+++ b/internal/selfupdate/README.md
@@ -77,8 +77,8 @@ platform's container registry (module `registry-packages-proxy`, ns
   to anyone by default - the cluster administrator decides who may download the CLI.
 - **API used by this package** (the HTTP client lives in `internal/rpp`):
   - `GET /v1/images/deckhouse-cli/tags` -> `{"name": ..., "tags": [...]}` - the version list;
-  - `GET /v1/images/deckhouse-cli/tags/<tag>` -> gzip-tar of the image contents
-    (containing the `d8` file).
+  - `GET /v1/images/deckhouse-cli/images/<version>?platform=<os>-<arch>` -> gzip-tar
+    of the image contents (containing the `d8` file).
 - **Endpoint** is discovered automatically (Ingress -> pod-IP fallback) or set
   explicitly (`--rpp-endpoint` / `D8_RPP_ENDPOINT`).
 

--- a/internal/selfupdate/README.md
+++ b/internal/selfupdate/README.md
@@ -122,7 +122,8 @@ Platforms (`rpp_source.go`):
 | Need | How |
 |---|---|
 | explicit RPP endpoint | `--rpp-endpoint` / `D8_RPP_ENDPOINT` |
-| custom CA / skip TLS verification | `--rpp-ca-file` / `--rpp-insecure-skip-tls-verify` |
+| custom CA for the proxy | `--rpp-ca-file` / `D8_RPP_CA_FILE` |
+| skip TLS verification on both legs (API server and proxy) | `--insecure-skip-tls-verify` |
 | identity | `-k/--kubeconfig`, `--context` |
 
 ## Boundaries and deliberate decisions

--- a/internal/selfupdate/cmd/command.go
+++ b/internal/selfupdate/cmd/command.go
@@ -177,7 +177,8 @@ func newUpdater(ctx context.Context, cmd *cobra.Command, logger *dkplog.Logger) 
 	kubeconfig, _ := cmd.Flags().GetString("kubeconfig")
 	kubeContext, _ := cmd.Flags().GetString("context")
 
-	restConfig, kube, err := utilk8s.SetupK8sClientSet(kubeconfig, kubeContext)
+	restConfig, kube, err := utilk8s.SetupK8sClientSet(kubeconfig, kubeContext,
+		utilk8s.WithInsecureSkipTLSVerify(rppflags.InsecureSkipTLSVerify))
 	if err != nil {
 		return nil, fmt.Errorf("set up kubernetes client: %w", err)
 	}

--- a/internal/selfupdate/cmd/errdetect/diagnose.go
+++ b/internal/selfupdate/cmd/errdetect/diagnose.go
@@ -55,6 +55,7 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 		return help(err, "registry-packages-proxy: endpoint discovery via the Kubernetes API failed",
 			"discovery reaches the proxy through your kubeconfig's API server; that server was unreachable or presented an invalid certificate",
 			"this is the Kubernetes API endpoint (kubeconfig 'server:'), not the proxy; confirm it is reachable with a valid TLS certificate for that host",
+			"accept the certificate anyway: pass --insecure-skip-tls-verify",
 			"skip discovery: pass --rpp-endpoint https://registry-packages-proxy.<publicDomain> (or set D8_RPP_ENDPOINT)",
 			"on a master node, point the kubeconfig at the local API (https://127.0.0.1:6445, CA /etc/kubernetes/pki/ca.crt) with an OIDC token")
 	default:

--- a/internal/utilk8s/clientset.go
+++ b/internal/utilk8s/clientset.go
@@ -24,14 +24,29 @@ func DefaultKubeconfigPath() string {
 	return clientcmd.RecommendedHomeFile
 }
 
+// ClientOption overrides a kubeconfig setting from the command line, the way
+// kubectl's global flags do.
+type ClientOption func(*clientcmd.ConfigOverrides)
+
+// WithInsecureSkipTLSVerify turns off verification of the API server certificate.
+// The kubeconfig CA is dropped along with it: a CA and skipped verification cannot
+// both apply.
+func WithInsecureSkipTLSVerify(insecure bool) ClientOption {
+	return func(overrides *clientcmd.ConfigOverrides) {
+		overrides.ClusterInfo.InsecureSkipTLSVerify = insecure
+	}
+}
+
 // SetupK8sClientSet reads kubeconfig file at kubeconfigPath and constructs a kubernetes clientset from it.
 // If contextName is not empty, context under that name is used instead of default.
-func SetupK8sClientSet(kubeconfigPath, contextName string) (*rest.Config, *kubernetes.Clientset, error) {
-	var configOverrides *clientcmd.ConfigOverrides
+func SetupK8sClientSet(kubeconfigPath, contextName string, opts ...ClientOption) (*rest.Config, *kubernetes.Clientset, error) {
+	configOverrides := &clientcmd.ConfigOverrides{}
 	if contextName != DefaultKubeContext {
-		configOverrides = &clientcmd.ConfigOverrides{
-			CurrentContext: contextName,
-		}
+		configOverrides.CurrentContext = contextName
+	}
+
+	for _, opt := range opts {
+		opt(configOverrides)
 	}
 
 	// use splitlist func to use separator from OS specific

--- a/internal/utilk8s/clientset_test.go
+++ b/internal/utilk8s/clientset_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utilk8s
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// selfSignedCAPEM builds a CA that client-go can actually parse: an unparsable
+// blob fails at clientset construction and never reaches the trust settings.
+func selfSignedCAPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// writeKubeconfig writes a kubeconfig that pins a CA, so a plain read must
+// produce a verifying config.
+func writeKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	body := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: https://api.example.test
+    certificate-authority-data: %s
+contexts:
+- name: c
+  context: {cluster: c, user: u}
+current-context: c
+users:
+- name: u
+  user: {token: t}
+`, base64.StdEncoding.EncodeToString(selfSignedCAPEM(t)))
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	return path
+}
+
+func TestSetupK8sClientSetVerifiesByDefault(t *testing.T) {
+	restConfig, _, err := SetupK8sClientSet(writeKubeconfig(t), DefaultKubeContext)
+	require.NoError(t, err)
+
+	require.False(t, restConfig.Insecure)
+	require.NotEmpty(t, restConfig.CAData)
+	require.Equal(t, "t", restConfig.BearerToken)
+}
+
+func TestSetupK8sClientSetInsecureDropsCA(t *testing.T) {
+	restConfig, _, err := SetupK8sClientSet(writeKubeconfig(t), DefaultKubeContext,
+		WithInsecureSkipTLSVerify(true))
+	require.NoError(t, err)
+
+	// A CA and skipped verification cannot both apply: client-go rejects the
+	// combination, so the option has to clear the kubeconfig CA.
+	require.True(t, restConfig.Insecure)
+	require.Empty(t, restConfig.CAData)
+	require.Empty(t, restConfig.CAFile)
+
+	// The identity survives: only server trust changes.
+	require.Equal(t, "t", restConfig.BearerToken)
+}
+
+func TestSetupK8sClientSetInsecureFalseKeepsCA(t *testing.T) {
+	restConfig, _, err := SetupK8sClientSet(writeKubeconfig(t), DefaultKubeContext,
+		WithInsecureSkipTLSVerify(false))
+	require.NoError(t, err)
+
+	require.False(t, restConfig.Insecure)
+	require.NotEmpty(t, restConfig.CAData)
+}


### PR DESCRIPTION
## Summary

Two things blocked downloads through registry-packages-proxy: the docs named a ClusterRole that grants nothing, and the only TLS escape hatch covered the wrong connection. Both are fixed, and every claim is checked against the code.

## Problem

The docs sent admins to the wrong role:

- `plugins.md` said plugins need `d8:registry-packages-proxy:packages-download`, and that it differs from self-update's `cli-download`. Both wrong.
- Plugins live under `deckhouse-cli/plugins/<name>` and travel the same `/v1/images/` route, guarded by the `cli-binary` subresource. `cli-download` covers them.
- An admin following these docs bound a role that grants nothing, and downloads kept returning `403`.
- Both pages said authorization is cached for about 5 minutes and told the user to fetch a fresh token. A denial clears in 30 seconds; a new token changes nothing.
- Neither page mentioned that endpoint discovery reads the `registry-packages-proxy` Ingress. Without that permission the command dies before it reaches the proxy.
- `internal/selfupdate/README.md` listed the download route as `/v1/images/deckhouse-cli/tags/<tag>`, which the proxy does not serve.

The insecure flag covered the wrong connection:

- `d8 cli` and `d8 plugins` open two TLS connections: one to the Kubernetes API server for endpoint discovery, one to the proxy for downloads.
- `--rpp-insecure-skip-tls-verify` relaxed only the second one.
- So an API server certificate the client cannot verify killed every command, with no flag to get past it. The only way out was editing the kubeconfig by hand.
- Hit on a dev cluster: the API server ingress lost its TLS secret and served the ingress-nginx fallback certificate. Every command died on `x509: certificate is valid for ingress.local`, and the old flag changed nothing.

## Fix

Docs:

- One role for everything: `cli-download` covers `d8 cli` and `d8 plugins`.
- Real cache numbers, with the practical advice ("retry in half a minute").
- Both pages name the Ingress read permission.
- The download route is `/v1/images/deckhouse-cli/images/<version>?platform=<os>-<arch>`.
- Both pages link to the module docs for the grant commands, so the recipe lives in one place.

Flag:

- `--insecure-skip-tls-verify` relaxes both connections.
- It works through a `clientcmd` override, the same way kubectl does it, so the kubeconfig CA is dropped instead of colliding with the insecure setting.
- The kubeconfig identity (token, client certificate, exec plugin) is untouched. Only server trust changes.
- `--rpp-insecure-skip-tls-verify` is removed. It could not solve the failure people actually hit, and two flags for one idea invited picking the wrong one.
- Endpoint-discovery diagnostics name the flag, so the error itself points at the fix.

## Tests

New unit tests in `internal/utilk8s/clientset_test.go`:

- `TestSetupK8sClientSetVerifiesByDefault` - a kubeconfig with a CA still verifies.
- `TestSetupK8sClientSetInsecureDropsCA` - the option turns verification off, clears the CA, keeps the bearer token.
- `TestSetupK8sClientSetInsecureFalseKeepsCA` - passing `false` changes nothing.

Run against a dev cluster whose API server ingress served the fallback certificate:

| Run | Result |
|---|---|
| no flags | `x509: certificate is valid for ingress.local` |
| `--rpp-insecure-skip-tls-verify` (old flag) | same failure |
| `--insecure-skip-tls-verify` | `A newer deckhouse-cli is available` |
| `d8 plugins versions <name> --insecure-skip-tls-verify` | version list returned |
| kubeconfig with a valid CA, no flag | reaches the proxy, `401` as expected - verification not weakened |


