### PR TITLE
[snapshot] fix deprecated VS-connector subresources group

### DIFF
--- a/internal/snapshot/aggapi/client.go
+++ b/internal/snapshot/aggapi/client.go
@@ -23,7 +23,9 @@ limitations under the License.
 //     namespace made relative). Served by the node's OWN subresource group (core
 //     group for the core Snapshot, the domain-prefixed group for domain snapshot CRs
 //     — the domain apiserver proxies to the core content layer); CSI VolumeSnapshot
-//     leaves use the dedicated VS-connector group instead.
+//     leaves use the dedicated storage-foundation VS-connector group instead (distinct
+//     from the CSI VolumeSnapshot CRD's own group, which neither storage-foundation nor
+//     state-snapshotter owns).
 //   - manifests-with-data-restoration: a ready-to-apply manifest array for the
 //     node's whole subtree (the server delegates domain subtrees internally).
 //     Served by the node's OWN subresource group (core group for the core
@@ -33,8 +35,9 @@ limitations under the License.
 //     the core Snapshot, the domain-prefixed group for domain snapshot CRs — the
 //     domain apiserver's upload facade records the node's own childrenSnapshotRefs and
 //     forwards the manifests to the core content layer); CSI VolumeSnapshot leaves use
-//     the dedicated VS-connector group instead. The upload is bind-first: it returns
-//     409 ImportContentNotBound until the node's SnapshotContent is bound.
+//     the dedicated storage-foundation VS-connector group instead. The upload is
+//     bind-first: it returns 409 ImportContentNotBound until the node's SnapshotContent
+//     is bound.
 //
 // All three subresources now route the same way — by the node's own group — so there is
 // no longer any download/upload group asymmetry. Every subresource is addressed by the
@@ -74,15 +77,26 @@ const (
 	// -> "subresources.sds-unified-snapshots-poc.deckhouse.io").
 	DomainSubresourcesGroupPrefix = "subresources."
 
-	// VSConnectorGroup is the generic-PVC extended VolumeSnapshot connector subresource group.
-	VSConnectorGroup = "subresources.snapshot.storage.k8s.io"
+	// VSConnectorGroup is the generic-PVC extended VolumeSnapshot connector subresource
+	// group, owned and served by storage-foundation. It is intentionally NOT the CSI
+	// external-snapshotter group (VolumeSnapshotGroup below) — storage-foundation only
+	// exposes subresources on the VolumeSnapshot's namespaced identity, it does not own
+	// the VolumeSnapshot CRD itself.
+	VSConnectorGroup = "subresources.storage-foundation.deckhouse.io"
 	// VSConnectorVersion is the version served under VSConnectorGroup.
 	VSConnectorVersion = "v1"
 
 	// StorageGroup is the API group of the core Snapshot / SnapshotContent CRDs.
 	StorageGroup = "state-snapshotter.deckhouse.io"
 	// VolumeSnapshotGroup is the CSI external-snapshotter API group of VolumeSnapshot leaves.
+	// This is the real CSI CRD group — neither storage-foundation nor state-snapshotter owns
+	// it — and is a distinct group from VSConnectorGroup above; do not conflate the two.
 	VolumeSnapshotGroup = "snapshot.storage.k8s.io"
+	// VolumeSnapshotVersion is the API version of the CSI external-snapshotter
+	// VolumeSnapshot CRD group (VolumeSnapshotGroup). It is independent of
+	// VSConnectorVersion (the subresources group's version) even though both currently
+	// equal "v1" — the two happen to match today, but do not reuse one for the other.
+	VolumeSnapshotVersion = "v1"
 	// VolumeSnapshotResource is the resource plural of CSI VolumeSnapshot objects.
 	VolumeSnapshotResource = "volumesnapshots"
 	// VolumeSnapshotKind is the kind of CSI VolumeSnapshot leaf nodes.
@@ -644,7 +658,8 @@ func (c *Client) LeafDataExportTarget(ref NodeRef) (string, string, string, erro
 
 // subresourceGroupVersion returns the aggregated subresource group and version that
 // serves restore/upload for a node of the given GVK:
-//   - CSI VolumeSnapshot leaves -> the VS-connector group.
+//   - CSI VolumeSnapshot leaves -> the storage-foundation VS-connector group (distinct
+//     from VolumeSnapshotGroup, the CSI VolumeSnapshot CRD's own group).
 //   - the core Snapshot (state-snapshotter.deckhouse.io) -> the core subresources group.
 //   - any domain snapshot CR -> "subresources." + its API group, same version.
 func subresourceGroupVersion(ref NodeRef) (string, string, error) {

--- a/internal/snapshot/aggapi/client_test.go
+++ b/internal/snapshot/aggapi/client_test.go
@@ -111,7 +111,7 @@ func TestDownloadPath(t *testing.T) {
 		{
 			name: "csi volume snapshot leaf uses vs-connector group",
 			ref:  NodeRef{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "vs-1", Namespace: "ns"},
-			want: "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-download",
+			want: "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-download",
 		},
 	}
 
@@ -157,7 +157,7 @@ func TestSubresourcePath(t *testing.T) {
 			name: "csi volume snapshot leaf restore uses vs-connector group",
 			ref:  NodeRef{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "vs-1", Namespace: "ns"},
 			sub:  SubManifestsRestore,
-			want: "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-with-data-restoration",
+			want: "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-with-data-restoration",
 		},
 	}
 
@@ -203,7 +203,7 @@ func TestUploadPath(t *testing.T) {
 		{
 			name: "csi volume snapshot leaf upload uses vs-connector group",
 			ref:  NodeRef{APIVersion: "snapshot.storage.k8s.io/v1", Kind: "VolumeSnapshot", Name: "vs-1", Namespace: "ns"},
-			want: "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-and-children-refs-upload",
+			want: "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-and-children-refs-upload",
 		},
 	}
 
@@ -294,16 +294,19 @@ func TestResourceFor_NoMapper(t *testing.T) {
 // (e.g. regressing domain upload back to the core group, or the reverse of the earlier
 // domain-download proxy work) fails fast here.
 //
-// Server contract summary (verified against state-snapshotter source):
+// Server contract summary (verified against state-snapshotter source, VS-connector against
+// storage-foundation):
 //   - manifests-download (GET): core group for Snapshot; domain-prefixed group for domain CRs
-//     (domainapi proxies to the core content layer); VS-connector for VS leaf. Every path is
-//     addressed by the node's own namespaced CR — the CLI never reads cluster-scoped
-//     snapshotcontents; restore_handler.go SetupRoutes + domainapi/handler.go.
+//     (domainapi proxies to the core content layer); VS-connector (storage-foundation) for VS
+//     leaf. Every path is addressed by the node's own namespaced CR — the CLI never reads
+//     cluster-scoped snapshotcontents; restore_handler.go SetupRoutes + domainapi/handler.go.
 //   - manifests-with-data-restoration (GET): core group for Snapshot; domain-prefixed
-//     group for domain CRs (domainapi/handler.go, GET-only); VS-connector for VS leaf.
+//     group for domain CRs (domainapi/handler.go, GET-only); VS-connector (storage-foundation)
+//     for VS leaf.
 //   - manifests-and-children-refs-upload (POST): core group for Snapshot; domain-prefixed group
 //     for domain CRs (domainapi upload facade — bind-first, forwards manifests to the core content
-//     layer); VS-connector for VS leaf. Routed by the node's own group, symmetric to download/restore.
+//     layer); VS-connector (storage-foundation) for VS leaf. Routed by the node's own group,
+//     symmetric to download/restore.
 func TestAggregatedAPIContract(t *testing.T) {
 	c := NewClient(nil, testMapper())
 
@@ -332,11 +335,11 @@ func TestAggregatedAPIContract(t *testing.T) {
 			wantPath:   "/apis/subresources.sds-unified-snapshots-poc.deckhouse.io/v1alpha1/namespaces/ns/demovirtualdisksnapshots/vds-1/manifests-download",
 			wantMethod: http.MethodGet,
 		},
-		// volumesnapshot_connector.go handleVolumeSnapshotNamespaced -> handleVolumeSnapshotManifestsDownload
+		// storage-foundation VS-connector: handleVolumeSnapshotNamespaced -> handleVolumeSnapshotManifestsDownload
 		{
 			name:       "VS leaf: manifests-download -> VS-connector group",
 			pathFn:     func(c *Client) (string, error) { return c.downloadPath(vsRef) },
-			wantPath:   "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-download",
+			wantPath:   "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-download",
 			wantMethod: http.MethodGet,
 		},
 
@@ -356,11 +359,11 @@ func TestAggregatedAPIContract(t *testing.T) {
 			wantPath:   "/apis/subresources.sds-unified-snapshots-poc.deckhouse.io/v1alpha1/namespaces/ns/demovirtualdisksnapshots/vds-1/manifests-with-data-restoration",
 			wantMethod: http.MethodGet,
 		},
-		// volumesnapshot_connector.go handleVolumeSnapshotNamespaced -> handleVolumeSnapshotManifestsWithDataRestoration
+		// storage-foundation VS-connector: handleVolumeSnapshotNamespaced -> handleVolumeSnapshotManifestsWithDataRestoration
 		{
 			name:       "VS leaf: manifests-with-data-restoration -> VS-connector group",
 			pathFn:     func(c *Client) (string, error) { return c.subresourcePath(vsRef, SubManifestsRestore) },
-			wantPath:   "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-with-data-restoration",
+			wantPath:   "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-with-data-restoration",
 			wantMethod: http.MethodGet,
 		},
 
@@ -381,11 +384,11 @@ func TestAggregatedAPIContract(t *testing.T) {
 			wantPath:   "/apis/subresources.sds-unified-snapshots-poc.deckhouse.io/v1alpha1/namespaces/ns/demovirtualdisksnapshots/vds-1/manifests-and-children-refs-upload",
 			wantMethod: http.MethodPost,
 		},
-		// volumesnapshot_connector.go handleVolumeSnapshotNamespaced -> handleManifestsAndChildrenUpload (verb: create/POST)
+		// storage-foundation VS-connector: handleVolumeSnapshotNamespaced -> handleManifestsAndChildrenUpload (verb: create/POST)
 		{
 			name:       "VS leaf: manifests-and-children-refs-upload -> VS-connector group",
 			pathFn:     func(c *Client) (string, error) { return c.uploadPath(vsRef) },
-			wantPath:   "/apis/subresources.snapshot.storage.k8s.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-and-children-refs-upload",
+			wantPath:   "/apis/subresources.storage-foundation.deckhouse.io/v1/namespaces/ns/volumesnapshots/vs-1/manifests-and-children-refs-upload",
 			wantMethod: http.MethodPost,
 		},
 	}

--- a/internal/snapshot/snapimport/import.go
+++ b/internal/snapshot/snapimport/import.go
@@ -1369,7 +1369,7 @@ func (cfg Config) snapshotResource() (schema.GroupVersionResource, error) {
 func (cfg Config) volumeSnapshotResource() (schema.GroupVersionResource, error) {
 	mapping, err := cfg.Mapper.RESTMapping(
 		schema.GroupKind{Group: aggapi.VolumeSnapshotGroup, Kind: volumeSnapshotKind},
-		aggapi.VSConnectorVersion)
+		aggapi.VolumeSnapshotVersion)
 	if err != nil {
 		return schema.GroupVersionResource{}, fmt.Errorf("resolve VolumeSnapshot resource: %w", err)
 	}

--- a/internal/snapshot/snapimport/import_test.go
+++ b/internal/snapshot/snapimport/import_test.go
@@ -3132,3 +3132,97 @@ func TestRun_BlocksOnUnboundNodes(t *testing.T) {
 		t.Errorf("expected the leaf import marker to be created in pass 1 before the bind gate: %v", gErr)
 	}
 }
+
+// versionCapturingRESTMapper wraps a meta.RESTMapper and records every version argument
+// RESTMapping was called with, so a test can assert exactly which version constant a
+// caller used without needing a full hand-rolled Mapper mock.
+type versionCapturingRESTMapper struct {
+	meta.RESTMapper
+	gotVersions []string
+}
+
+func (m *versionCapturingRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m.gotVersions = append(m.gotVersions, versions...)
+
+	return m.RESTMapper.RESTMapping(gk, versions...)
+}
+
+// TestConfig_VolumeSnapshotResource guards against volumeSnapshotResource() ever resolving the
+// CSI VolumeSnapshot RESTMapping through aggapi.VSConnectorVersion (the unrelated
+// storage-foundation subresources group's version) instead of aggapi.VolumeSnapshotVersion (the
+// CSI external-snapshotter CRD group's own version). The two constants happen to both equal "v1"
+// today, so a regression that swapped them back would NOT be caught by any test asserting success
+// alone — every "success" case here also asserts the exact version string passed to RESTMapping.
+func TestConfig_VolumeSnapshotResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		mapperGVKs []schema.GroupVersionKind
+		wantErr    bool
+	}{
+		{
+			name: "success: CSI VolumeSnapshot registered only under its real v1 resolves",
+			mapperGVKs: []schema.GroupVersionKind{
+				{Group: aggapi.VolumeSnapshotGroup, Version: "v1", Kind: aggapi.VolumeSnapshotKind},
+			},
+		},
+		{
+			// A RESTMapper reflecting the real cluster (CSI VolumeSnapshot only ever served at
+			// v1) must still fail to resolve if the caller asked for any other version — this is
+			// what would happen if volumeSnapshotResource() were changed to pass
+			// aggapi.VSConnectorVersion and that constant ever diverged from "v1".
+			name: "error: mapper has no v1 mapping registered",
+			mapperGVKs: []schema.GroupVersionKind{
+				{Group: aggapi.VolumeSnapshotGroup, Version: "v1beta1", Kind: aggapi.VolumeSnapshotKind},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := meta.NewDefaultRESTMapper(nil)
+			for _, gvk := range tt.mapperGVKs {
+				base.Add(gvk, meta.RESTScopeNamespace)
+			}
+
+			mapper := &versionCapturingRESTMapper{RESTMapper: base}
+			cfg := Config{Mapper: mapper}
+
+			gvr, err := cfg.volumeSnapshotResource()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("volumeSnapshotResource(): expected error, got resource %v", gvr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("volumeSnapshotResource(): unexpected error: %v", err)
+			}
+
+			if gvr.Resource != aggapi.VolumeSnapshotResource {
+				t.Errorf("resource: got %q, want %q", gvr.Resource, aggapi.VolumeSnapshotResource)
+			}
+
+			// The regression this test exists to catch: the version requested must be the CSI
+			// external-snapshotter VolumeSnapshot CRD group's real wire version, "v1" — pinned
+			// here as a literal (the actual, stable CSI contract), not as aggapi.VolumeSnapshotVersion,
+			// so the test also catches that constant itself drifting away from the real CSI
+			// version, not just a swap for the unrelated aggapi.VSConnectorVersion (the
+			// storage-foundation subresources group's version, which happens to equal "v1" today
+			// but is independent and could diverge in the future).
+			const realCSIVolumeSnapshotVersion = "v1"
+
+			if len(mapper.gotVersions) != 1 || mapper.gotVersions[0] != realCSIVolumeSnapshotVersion {
+				t.Errorf("RESTMapping version args: got %v, want [%q] (the real CSI VolumeSnapshot version)",
+					mapper.gotVersions, realCSIVolumeSnapshotVersion)
+			}
+		})
+	}
+}

--- a/internal/snapshot/source/node.go
+++ b/internal/snapshot/source/node.go
@@ -165,7 +165,7 @@ func (n *Node) Ref() aggapi.NodeRef {
 //
 // For orphan leaf volume nodes this is also the node's own ref:
 // APIVersion=snapshot.storage.k8s.io/v1, Kind=VolumeSnapshot, Name=VS CR name. The
-// VolumeSnapshot connector (subresources.snapshot.storage.k8s.io) resolves this ref via
+// VolumeSnapshot connector (subresources.storage-foundation.deckhouse.io) resolves this ref via
 // VolumeSnapshot.status.boundSnapshotContentName to the leaf's own child SnapshotContent
 // ManifestCheckpoint (which holds the captured PVC manifest).
 func (n *Node) ManifestScopeRef() aggapi.NodeRef {


### PR DESCRIPTION
## Summary

VolumeSnapshot node subresources (manifests-download, manifests-with-data-restoration, manifests-and-children-refs-upload) are now served by storage-foundation, not state-snapshotter. d8 was still addressing the old group, which now works only as a server-side deprecated alias.

## Problem

- The three subresources moved from state-snapshotter's `subresources.snapshot.storage.k8s.io` to storage-foundation's `subresources.storage-foundation.deckhouse.io` (version unchanged, still `v1`)
- The old group is kept only as a server-side alias (same handlers, byte-identical body, differs only in discovery name and a `Warning: 299` header) — clients are not meant to rely on it
- d8's `aggapi` client was still hardcoded to the old group, with no fallback intended on either side

## Fix

- `VSConnectorGroup` now points at `subresources.storage-foundation.deckhouse.io`; no dual-group or fallback logic added
- Split `VolumeSnapshotVersion` out of `VSConnectorVersion`: `snapimport`'s CSI VolumeSnapshot RESTMapping call was borrowing the subresources group's version constant, which only worked because both happened to equal `"v1"`
- Updated the six expected paths and producer-reference comments in `client_test.go`, and the group name in the `node.go` comment

## Before / After

Before: `d8 snapshot download/upload/restore` against a CSI `VolumeSnapshot` leaf addresses `subresources.snapshot.storage.k8s.io`.
After: the same commands address `subresources.storage-foundation.deckhouse.io` — same path shape, same body, only the group name changes.

## Tests

- `TestDownloadPath` / `TestSubresourcePath` / `TestUploadPath` / `TestAggregatedAPIContract` — VS-leaf expectations updated to the new group
- `TestConfig_VolumeSnapshotResource` — new regression test pinning the literal CSI wire version, guards against reintroducing the `VSConnectorVersion`/`VolumeSnapshotVersion` mix-up

## Notes

Manually verified against a live cluster: discovery serves the new group, and `download`/`upload` against a real CSI `VolumeSnapshot` leaf both succeed end-to-end.
