### PR TITLE
[plugins] Advise the cli-download role on a 403 from registry-packages-proxy

### DIFF
--- a/internal/dist/cmd/errdetect/diagnose.go
+++ b/internal/dist/cmd/errdetect/diagnose.go
@@ -42,7 +42,7 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 		return help(err, "registry-packages-proxy: forbidden (403)",
 			"the identity may not download the CLI",
 			"bind the ClusterRole 'd8:registry-packages-proxy:cli-download' to the user/group",
-			"authorization is cached ~5 min - after binding, retry with a fresh token")
+			"a denied check is cached ~30s - after binding the role, wait half a minute and retry with the same token")
 	case errors.Is(err, rpp.ErrNotFound):
 		return help(err, "registry-packages-proxy: version not found (404)",
 			"this deckhouse-cli version is not published",

--- a/internal/plugins/cmd/errdetect/diagnose.go
+++ b/internal/plugins/cmd/errdetect/diagnose.go
@@ -38,11 +38,14 @@ func Diagnose(err error) *diagnostic.HelpfulError {
 		return help(err, "registry-packages-proxy: unauthorized (401)",
 			"no accepted Bearer token (a client-certificate kubeconfig is not enough)",
 			"use a kubeconfig with an OIDC token (Kubeconfig Generator or 'd8 login')")
+	// Plugins are downloaded over /v1/images/, which kube-rbac-proxy authorizes
+	// through the deployments/cli-binary subresource: that is the cli-download
+	// role, not packages-download (it covers /v1/packages/).
 	case errors.Is(err, rpp.ErrForbidden):
 		return help(err, "registry-packages-proxy: forbidden (403)",
 			"the identity may not download plugins",
-			"bind the ClusterRole 'd8:registry-packages-proxy:packages-download' to the user/group",
-			"authorization is cached ~5 min - after binding, retry with a fresh token")
+			"bind the ClusterRole 'd8:registry-packages-proxy:cli-download' to the user/group",
+			"a denied check is cached ~30s - after binding the role, wait half a minute and retry with the same token")
 	case errors.Is(err, rpp.ErrNotFound):
 		return help(err, "registry-packages-proxy: plugin or version not found (404)",
 			"this plugin or version is not published",

--- a/internal/plugins/cmd/errdetect/diagnose_test.go
+++ b/internal/plugins/cmd/errdetect/diagnose_test.go
@@ -37,7 +37,7 @@ func TestDiagnose(t *testing.T) {
 		wantSol  string
 	}{
 		{"401", rpp.ErrUnauthorized, "unauthorized (401)", "OIDC"},
-		{"403", rpp.ErrForbidden, "forbidden (403)", "packages-download"},
+		{"403", rpp.ErrForbidden, "forbidden (403)", "cli-download"},
 		{"404", rpp.ErrNotFound, "plugin or version not found (404)", "deckhouse-cli/plugins"},
 		{"5xx", rpp.ErrUpstream, "upstream error (5xx)", "registry-packages-proxy pods"},
 		{"discovery", rpp.ErrEndpointDiscovery, "endpoint discovery via the Kubernetes API failed", "--rpp-endpoint"},


### PR DESCRIPTION
## Summary

The 403 diagnostic for `d8 dist plugins` told users to bind the wrong ClusterRole. They bound it and still got 403.

## Problem

- Plugins are downloaded over `/v1/images/`
- kube-rbac-proxy authorizes that whole prefix through the `deployments/cli-binary` subresource
- That subresource is granted by `d8:registry-packages-proxy:cli-download`
- The diagnostic named `d8:registry-packages-proxy:packages-download`, which covers `/v1/packages/` and is never called by the CLI
- So the advice led nowhere: bind the role, wait, get 403 again
- The same block also said "authorization is cached ~5 min - after binding, retry with a fresh token". A denial is cached for about 30 seconds, and the old token keeps working, so both halves were wrong
- The `d8 dist` copy of the diagnostic named the right role but carried the same wrong hint about the cache

## Fix

- Advise `cli-download` for plugins
- Say that a denial is cached for about 30 seconds and the same token still works, in both copies of the diagnostic
- Add a short comment next to the case so the role is not "corrected" back later

## Before / After

**Before:** a 403 on `d8 dist plugins install <name>` sent the user to `packages-download`, which does not open the route.

**After:** the same 403 sends the user to `cli-download`, the role that actually grants `/v1/images/`.

## Tests

- `TestDiagnose` in `internal/plugins/cmd/errdetect` now pins `cli-download` in the 403 advice

## Notes

- Source of truth: `modules/039-registry-packages-proxy/templates/deployment.yaml` in deckhouse maps `/v1/images/` to subresource `cli-binary` and `/v1/packages/` to `packages`
- Repo docs were already right (`internal/plugins/README.md`, `internal/selfupdate/README.md`); only the code lagged behind
