### PR TITLE
[chore] bump package plugin to v0.0.33

### DIFF
--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/instance_prefix.go
@@ -15,10 +15,14 @@ import (
 // InstancePrefixRuleID is the stable identifier used to reference this rule in configuration.
 const InstancePrefixRuleID = "instance-prefix"
 
-// instancePrefix is the prefix every rendered object's name must start with: the fixed
-// d8a- application marker plus the hardcoded verify-time instance name from
-// internal/packages.Render.
-const instancePrefix = "d8a-test-"
+// d8aPrefix is the fixed application marker every rendered object's name must start with.
+const d8aPrefix = "d8a-"
+
+// instancePrefix is the hardcoded verify-time instance name from internal/packages.Render.
+const instancePrefix = "test-"
+
+// objectNameTemplatePrefix is the required template prefix shown in diagnostics.
+const objectNameTemplatePrefix = "d8a-{{ .Application.Instance.Name }}-"
 
 // InstancePrefixRule asserts every rendered object's name starts with the instance prefix.
 type InstancePrefixRule struct {
@@ -37,15 +41,20 @@ func NewInstancePrefixRule(objects []render.Object, collector *diag.Collector) *
 // Check verifies every rendered object's name starts with the instance prefix.
 func (r *InstancePrefixRule) Check(_ context.Context) {
 	for _, obj := range r.objects {
-		name := obj.GetName()
-		if strings.HasPrefix(name, instancePrefix) {
-			continue
-		}
+		name, ok := strings.CutPrefix(obj.GetName(), d8aPrefix)
+		expectedName := objectNameTemplatePrefix + strings.TrimPrefix(name, instancePrefix)
 
-		r.collector.With(
-			diag.ObjectID(obj.ObjectID()),
-			diag.Path(obj.FilePath),
-		).Error("object name does not start with the required d8a- instance prefix")
+		if !ok {
+			r.collector.With(
+				diag.ObjectID(obj.ObjectID()),
+				diag.Path(obj.FilePath),
+			).Error("object name does not start with the required d8a- prefix; it should be %q", expectedName)
+		} else if !strings.HasPrefix(name, instancePrefix) {
+			r.collector.With(
+				diag.ObjectID(obj.ObjectID()),
+				diag.Path(obj.FilePath),
+			).Error("object name does not start with the required instance prefix; it should be %q", expectedName)
+		}
 	}
 
 	r.collector.Commit()


### PR DESCRIPTION
It brings a new version of package plugin. This version separates error in instance prefix rule into two explicit.

<img width="1126" height="361" alt="Screenshot 2026-08-25 at 4 50 29 PM" src="https://github.com/user-attachments/assets/c3e2c863-d182-47bb-b449-c2e0d0e6c82d" />