### PR TITLE
[chore] bump package plugin to v0.0.34

### DIFF
--- a/internal/packagecmd/internal/packages/render.go
+++ b/internal/packagecmd/internal/packages/render.go
@@ -140,6 +140,11 @@ func buildPlatformValues() any {
 			"ingressClass":         "nginx",
 			"publicDomainTemplate": "%s.%s.domain.io",
 		},
+		"discovery": map[string]any{
+			"apiVersions": []string{"autoscaling.k8s.io/v1/VerticalPodAutoscaler", "cert-manager.io/v1"},
+		},
+		"capabilities":   []string{"autoscaling.k8s.io/v1/VerticalPodAutoscaler", "cert-manager.io/v1"},
+		"enabledModules": []string{"verticalPodAutoscaler", "certManager"},
 	}
 }
 

--- a/internal/packagecmd/internal/verify/lint/doc/templates.go
+++ b/internal/packagecmd/internal/verify/lint/doc/templates.go
@@ -60,6 +60,30 @@ var templatesDoc = Linter{
 			Tunable: false,
 		},
 		{
+			ID:      rules.JobNameRuleID,
+			Summary: "Restricts Job names to 52 characters",
+			Description: []string{
+				"Job names are limited to 52 characters by the package naming convention. The rendered name is checked after all template values and prefixes have been applied.",
+			},
+			Reports: []string{
+				"a rendered Job has a metadata.name longer than 52 characters",
+			},
+			Example: Example{
+				Reported: []string{
+					"kind: Job",
+					"metadata:",
+					"  name: {{ .Application.Instance.Name }}-a-very-long-maintenance-job-name",
+				},
+				Accepted: []string{
+					"kind: Job",
+					"metadata:",
+					"  name: {{ .Application.Instance.Name }}-maintenance",
+				},
+			},
+			Fix:     "Shorten metadata.name to 52 characters or fewer, including values added during template rendering.",
+			Tunable: false,
+		},
+		{
 			ID:      rules.PDBRuleID,
 			Summary: "Requires a PodDisruptionBudget for every pod controller",
 			Description: []string{
@@ -175,7 +199,7 @@ var templatesDoc = Linter{
 		},
 	},
 	Notes: []string{
-		"The instance-prefix and instance-namespace rules encode hard multi-instance contracts: they have no per-rule severity and always run at the linter severity.",
-		"Both are checked for application packages only, which deploy once per instance. A module deploys once per cluster and is not subject to them.",
+		"The instance-prefix, instance-namespace and job-name rules encode hard contracts: they have no per-rule severity and always run at the linter severity.",
+		"All three are checked for application packages only, which deploy once per instance. A module deploys once per cluster and is not subject to them.",
 	},
 }

--- a/internal/packagecmd/internal/verify/lint/linters/templates/linter.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/linter.go
@@ -27,6 +27,9 @@ var ruleScopes = lint.RuleScopes{
 	rules.InstanceNamespaceRuleID: {
 		lint.TypeApplication: {lint.ScopeStatic, lint.ScopeBundle},
 	},
+	rules.JobNameRuleID: {
+		lint.TypeApplication: {lint.ScopeStatic, lint.ScopeBundle},
+	},
 }
 
 // RuleScopes returns the rules narrowed to fewer targets than the linter itself runs in.
@@ -49,8 +52,8 @@ type LinterSettings struct {
 }
 
 // RulesSettings holds the severity configuration for each tunable rule in the templates linter.
-// The instance-prefix and instance-namespace rules are intentionally absent: they encode hard
-// multi-instance contracts and run at the linter-level severity without per-rule overrides.
+// The instance-prefix, instance-namespace and job-name rules are intentionally absent: they
+// encode hard contracts and run at the linter-level severity without per-rule overrides.
 type RulesSettings struct {
 	PDB         lint.RuleSettings
 	ServicePort lint.RuleSettings
@@ -68,7 +71,7 @@ func NewLinter(cfg Config, res *diag.Collector) *Linter {
 	}
 }
 
-// Linter runs templates rules against an application package directory.
+// Linter runs template rules against a package directory.
 type Linter struct {
 	config   Config
 	settings RulesSettings
@@ -85,6 +88,10 @@ func (l *Linter) Lint(ctx context.Context) {
 
 	if l.runs(rules.InstanceNamespaceRuleID) {
 		rules.NewInstanceNamespaceRule(l.config.Rendered, l.collector).Check(ctx)
+	}
+
+	if l.runs(rules.JobNameRuleID) {
+		rules.NewJobNameRule(l.config.Rendered, l.collector).Check(ctx)
 	}
 
 	if l.runs(rules.PDBRuleID) {

--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+	"context"
+	"strings"
+
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/packages/render"
+	"github.com/deckhouse/deckhouse-cli/internal/packagecmd/internal/verify/lint/diag"
+)
+
+// Rule purpose: enforce the package convention that Job names do not exceed 52 characters.
+
+const (
+	// JobNameRuleID is the stable identifier used to reference this rule in diagnostics.
+	JobNameRuleID = "job-name"
+	// maxJobNameLength is the maximum allowed length of a Job name.
+	maxJobNameLength = 15
+
+	cronJobKind = "CronJob"
+	jobKind     = "Job"
+)
+
+// JobNameRule asserts every Job name is at most 52 characters long.
+type JobNameRule struct {
+	collector *diag.Collector
+	objects   []render.Object
+}
+
+// NewJobNameRule constructs a JobNameRule scoped to its rule identifier.
+func NewJobNameRule(objects []render.Object, collector *diag.Collector) *JobNameRule {
+	return &JobNameRule{
+		collector: collector.With(diag.RuleID(JobNameRuleID)),
+		objects:   objects,
+	}
+}
+
+// Check verifies every Job name is at most 52 characters long.
+func (r *JobNameRule) Check(_ context.Context) {
+	for _, obj := range r.objects {
+		if obj.GetKind() != cronJobKind && obj.GetKind() != jobKind {
+			continue
+		}
+
+		name, ok := strings.CutPrefix(obj.GetName(), d8aPrefix)
+		if !ok {
+			continue
+		}
+
+		name, ok = strings.CutPrefix(name, instancePrefix)
+		if !ok {
+			continue
+		}
+
+		if len(name) <= maxJobNameLength {
+			continue
+		}
+
+		r.collector.With(
+			diag.ObjectID(obj.ObjectID()),
+			diag.Path(obj.FilePath),
+			diag.Value(name),
+		).Error("job name must not exceed %d characters; got %d", maxJobNameLength, len(name))
+	}
+
+	r.collector.Commit()
+}

--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
@@ -14,7 +14,7 @@ const (
 	// JobNameRuleID is the stable identifier used to reference this rule in diagnostics.
 	JobNameRuleID = "job-name"
 	// maxJobNameLength is the maximum allowed length of a Job name.
-	maxJobNameLength = 24
+	maxJobNameLength = 23
 
 	cronJobKind = "CronJob"
 	jobKind     = "Job"

--- a/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
+++ b/internal/packagecmd/internal/verify/lint/linters/templates/rules/job_name.go
@@ -14,7 +14,7 @@ const (
 	// JobNameRuleID is the stable identifier used to reference this rule in diagnostics.
 	JobNameRuleID = "job-name"
 	// maxJobNameLength is the maximum allowed length of a Job name.
-	maxJobNameLength = 15
+	maxJobNameLength = 24
 
 	cronJobKind = "CronJob"
 	jobKind     = "Job"

--- a/internal/packagecmd/internal/verify/lint/settings/settings.go
+++ b/internal/packagecmd/internal/verify/lint/settings/settings.go
@@ -67,8 +67,8 @@ type TemplatesSettings struct {
 }
 
 // TemplatesRulesSettings configures individual templates linter rules.
-// The instance-prefix and instance-namespace rules are intentionally not exposed here;
-// they encode hard multi-instance contracts and are not user-tunable.
+// The instance-prefix, instance-namespace and job-name rules are intentionally not exposed
+// here; they encode hard contracts and are not user-tunable.
 type TemplatesRulesSettings struct {
 	// PDB configures checks that every pod controller is covered by a PodDisruptionBudget.
 	PDB RuleSettings `mapstructure:"pdb"`


### PR DESCRIPTION
It brings the new "job_name" rule to template. 
<img width="619" height="249" alt="Screenshot 2026-08-26 at 11 36 35 AM" src="https://github.com/user-attachments/assets/24e3ed6e-1975-4fc2-a7dc-dc4c224a32b9" />

Signed-off-by: Stepan Paksashvili <stepan.paksashvili@flant.com>