### PR TITLE
[deckhouse-cli] Bump golang.org/x/image to close reachable WEBP CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	go.cypherpunks.ru/gogost/v5 v5.13.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
-	golang.org/x/image v0.39.0
+	golang.org/x/image v0.45.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.8
@@ -619,7 +619,7 @@ require (
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/api v0.230.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2053,6 +2053,8 @@ golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMx
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
 golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -2323,6 +2325,8 @@ golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
## Problem

`golang.org/x/image` v0.39.0 on the 0.30 line carries two WEBP decoder flaws that are reachable from d8 code, with no architecture or configuration guard:

- CVE-2026-46601 — panic on a VP8 chunk whose dimensions do not match the canvas size
- CVE-2026-46603 — excessive memory allocation decoding a crafted VP8L image

`internal/packagecmd/internal/utils/iconutil.Find` globs `icon.*` at the package root and hands the file to `webp.DecodeConfig`, so the input is whatever the package author ships. `govulncheck` confirms the call chain `iconutil.Find -> webp.DecodeConfig -> webp.decode -> vp8l.Decode`.

The other five x/image findings in the same scan are decoders the binary never imports (`bmp`, `tiff`) or, for CVE-2026-33813, a panic that only occurs on 32-bit platforms while every d8 build is 64-bit. This bump closes them too.

## Fix

- golang.org/x/image v0.39.0 -> v0.45.0
- golang.org/x/text v0.40.0 -> v0.41.0 (required by x/image v0.45.0)

Nothing else moves. x/image v0.45.0 declares `go 1.25.0`, below the module's 1.25.6, so the release builder image needs no change.

## Tests

- `go build` and `go vet` pass for `internal/packagecmd/internal/utils/iconutil`
- `go list -m` resolves golang.org/x/image v0.45.0 and golang.org/x/text v0.41.0

A full `go build ./...` and `go mod tidy` could not run locally: `github.com/hashicorp/vault` is replaced by an internal module behind `flant.internal`, which needs the `DECKHOUSE_PRIVATE_REPO` credentials CI has. go.mod was updated with `go mod edit` and the four go.sum lines were taken from a clean module resolved against sum.golang.org, so CI should validate the full graph.

Once released, this version is meant to be pinned as d8CliVersion in deckhouse release-1.73, replacing v0.30.21.
