### PR TITLE
[ci] Run PR checks on release branches (release-0.30)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "release-*"
 
 env:
   GOPRIVATE: "flant.internal"


### PR DESCRIPTION
## Problem

PRs into `release-0.30` get no CI. The only check they receive is DCO. The `pull_request` trigger in `.github/workflows/release.yaml` matches only base `main`, so `test`, `lint` and `pr-build` never start for PRs into this branch.

The recent backports show the cost. #459, #460 and #461 all merged here without checks, and #460 broke the `v0.30.22` build - it was only caught when the tag was built, and #461 exists solely to fix that. The `pr-build` job would have caught it at PR time.

## Fix

Add `release-*` to the trigger filter. Same one-line fix as #441 does for `release-0.32`.

The jobs need no changes: `release`, `test`, `lint` and `pr-build` all exist in this branch and the Taskfile targets they call are present.

## Proof

This PR runs its own checks: for `pull_request` events GitHub reads the workflow from the merge ref of the PR, so the new filter already applies here.

The same change lands on `main` separately, so future release branches are cut with the filter already correct.
