### PR TITLE
[ci] Run PR checks on release branches (main)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "release-*"
 
 env:
   GOPRIVATE: "flant.internal"


### PR DESCRIPTION
## Problem

PRs into release branches get no CI: the `pull_request` trigger in `.github/workflows/release.yaml` matches only base `main`. Backports land by hand, which is the kind of change that most needs checks, and today a broken backport shows up only when the release tag is built (see #460 breaking the `v0.30.22` build, fixed by #461).

## Fix

Add `release-*` to the trigger filter.

For `pull_request` events GitHub reads the workflow from the merge ref of the PR, i.e. from the base branch. So this change on `main` does not affect the existing release branches - it makes sure every future release branch cut from `main` starts with the correct filter, so the problem does not come back.

The existing branches are covered separately with the same one-liner: #441 for `release-0.32`, #467 for `release-0.30`.
